### PR TITLE
patch - adding default value for alert timeWindow from PrometheusRule

### DIFF
--- a/controllers/prometheusrule_controller.go
+++ b/controllers/prometheusrule_controller.go
@@ -265,7 +265,7 @@ func prometheusInnerRuleToCoralogixAlert(prometheusRule prometheus.Rule) coralog
 
 	timeWindow, ok := prometheusAlertForToCoralogixPromqlAlertTimeWindow[prometheusRule.For]
 	if !ok {
-		timeWindow = prometheusAlertForToCoralogixPromqlAlertTimeWindow["10m"]
+		timeWindow = prometheusAlertForToCoralogixPromqlAlertTimeWindow["1m"]
 	}
 
 	return coralogixv1alpha1.AlertSpec{

--- a/controllers/prometheusrule_controller.go
+++ b/controllers/prometheusrule_controller.go
@@ -263,7 +263,10 @@ func prometheusInnerRuleToCoralogixAlert(prometheusRule prometheus.Rule) coralog
 		notificationPeriod = defaultCoralogixNotificationPeriod
 	}
 
-	timeWindow := prometheusAlertForToCoralogixPromqlAlertTimeWindow[prometheusRule.For]
+	timeWindow, ok := prometheusAlertForToCoralogixPromqlAlertTimeWindow[prometheusRule.For]
+	if !ok {
+		timeWindow = prometheusAlertForToCoralogixPromqlAlertTimeWindow["10m"]
+	}
 
 	return coralogixv1alpha1.AlertSpec{
 		Severity: coralogixv1alpha1.AlertSeverityInfo,


### PR DESCRIPTION
PrometheusRule `for` field is optional but in Coralogix it's required.
Another deference, is that in Coralogix it can be just one of - [1m, 5m, 10m, 15m, 20m, 30m, 1H, 2H, 4H, 6H, 12H, 24H].
How do we want to handle empty `for`, and how do we want to handle `for` which is not one of the options above? 