### PR TITLE
patch - adding label managed-by:coralogix-operator to alerts

### DIFF
--- a/controllers/alphacontrollers/alert_controller.go
+++ b/controllers/alphacontrollers/alert_controller.go
@@ -159,6 +159,15 @@ func (r *AlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	if notFount {
+		if alertCRD.Spec.Labels == nil {
+			alertCRD.Spec.Labels = make(map[string]string)
+		}
+		alertCRD.Spec.Labels["managed-by"] = "coralogix-operator"
+		if err := r.Client.Update(ctx, alertCRD); err != nil {
+			log.Error(err, "Error on updating alert", "Name", alertCRD.Name, "Namespace", alertCRD.Namespace)
+			return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
+		}
+
 		createAlertReq, err := alertCRD.Spec.ExtractCreateAlertRequest()
 		if err != nil {
 			log.Error(err, "Bad request for creating alert", "Name", alertCRD.Name, "Namespace", alertCRD.Namespace)

--- a/tests/e2e/alerts/lucene/00-assert.yaml
+++ b/tests/e2e/alerts/lucene/00-assert.yaml
@@ -30,6 +30,8 @@ status:
         searchQuery: name:\"Frontend transactions\"
   description: alert from k8s operator
   name: lucene alert example
+  labels:
+    managed-by: coralogix-operator
 #  notificationGroups:
 #    - notifications:
 #        - notifyOn: TriggeredOnly

--- a/tests/e2e/alerts/new-value/00-assert.yaml
+++ b/tests/e2e/alerts/new-value/00-assert.yaml
@@ -21,6 +21,8 @@ status:
           - Error
   description: alert from k8s operator
   name: new-value alert example
+  labels:
+    managed-by: coralogix-operator
 #  notificationGroups:
 #    - notifications:
 #        - notifyOn: TriggeredOnly

--- a/tests/e2e/alerts/promql/00-assert.yaml
+++ b/tests/e2e/alerts/promql/00-assert.yaml
@@ -22,6 +22,8 @@ status:
         searchQuery: http_requests_total{status!~\"4..\"}
   description: alert from k8s operator
   name: promql alert example
+  labels:
+    managed-by: coralogix-operator
 #  notificationGroups:
 #    - notifications:
 #        - notifyOn: TriggeredOnly

--- a/tests/e2e/alerts/ratio/00-assert.yaml
+++ b/tests/e2e/alerts/ratio/00-assert.yaml
@@ -43,6 +43,8 @@ status:
           - filter:startsWith:subsystem-name
   description: alert from k8s operator
   name: ratio alert example
+  labels:
+    managed-by: coralogix-operator
 #  notificationGroups:
 #    - notifications:
 #        - notifyOn: TriggeredOnly

--- a/tests/e2e/alerts/standard/00-assert.yaml
+++ b/tests/e2e/alerts/standard/00-assert.yaml
@@ -32,6 +32,7 @@ status:
   labels:
     alert_type: security
     security_severity: high
+    managed-by: coralogix-operator
   name: standard alert example
 #  notificationGroups:
 #    - notifications:

--- a/tests/e2e/alerts/time-relative/00-assert.yaml
+++ b/tests/e2e/alerts/time-relative/00-assert.yaml
@@ -31,6 +31,7 @@ status:
   labels:
     alert_type: security
     security_severity: high
+    managed-by: coralogix-operator
   name: time-relative alert example
 #  notificationGroups:
 #    - notifications:

--- a/tests/e2e/alerts/trace/00-assert.yaml
+++ b/tests/e2e/alerts/trace/00-assert.yaml
@@ -30,6 +30,8 @@ status:
               - filter:contains:400
   description: alert from k8s operator
   name: tracing alert example
+  labels:
+    managed-by: coralogix-operator
   #    notificationGroups:
   #      - notifications:
   #          - notifyOn: TriggeredOnly

--- a/tests/e2e/alerts/unique-count/00-assert.yaml
+++ b/tests/e2e/alerts/unique-count/00-assert.yaml
@@ -24,6 +24,8 @@ status:
           - Error
   description: alert from k8s operator
   name: unique-count alert example
+  labels:
+    managed-by: coralogix-operator
 #  notificationGroups:
 #    - notifications:
 #        - notifyOn: TriggeredOnly


### PR DESCRIPTION
e.g. - 
```
apiVersion: coralogix.com/v1alpha1
kind: Alert
metadata:
  labels:
    app.kubernetes.io/name: alert
    app.kubernetes.io/instance: alert-sample
    app.kubernetes.io/part-of: coralogix-operator
    app.kuberentes.io/managed-by: kustomize
    app.kubernetes.io/created-by: coralogix-operator
  name: standard-alert-example
spec:
  name: standard alert example
  description: alert from k8s operator
  severity: Info
  alertType:
    standard:
      filters:
        searchQuery: remote_addr_enriched:/.*/
      conditions:
        alertWhen: More
        threshold: 5
        timeWindow: FiveMinutes
status:
  active: true
  alertType:
    standard:
      conditions:
        alertWhen: More
        threshold: 5
        timeWindow: FiveMinutes
      filters:
        searchQuery: remote_addr_enriched:/.*/
  description: alert from k8s operator
  **labels:
    managed-by: coralogix-operator**
  name: standard alert example
  severity: Info
```
