### PR TITLE
Early error when failing to get alert status from coralogix

### DIFF
--- a/controllers/alphacontrollers/alert_controller.go
+++ b/controllers/alphacontrollers/alert_controller.go
@@ -160,6 +160,10 @@ func (r *AlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		notFount = true
 	} else if err == nil {
 		actualState, flattenErr = flattenAlert(ctx, getAlertResp.GetAlert(), alertCRD.Spec)
+		if flattenErr != nil {
+			log.Error(flattenErr, "Received an error while flattened Alert")
+			return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, flattenErr
+		}
 	}
 
 	if notFount {
@@ -193,6 +197,10 @@ func (r *AlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			}
 
 			actualState, flattenErr = flattenAlert(ctx, createAlertResp.GetAlert(), alertCRD.Spec)
+			if flattenErr != nil {
+				log.Error(flattenErr, "Received an error while flattened Alert")
+				return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, flattenErr
+			}
 			alertCRD.Status = *actualState
 			if err := r.Status().Update(ctx, alertCRD); err != nil {
 				log.Error(err, "Error on updating alert status", "Name", alertCRD.Name, "Namespace", alertCRD.Namespace)
@@ -223,11 +231,6 @@ func (r *AlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 		jstr, _ := jsm.MarshalToString(updateAlertResp)
 		log.V(1).Info("Alert was updated", "alert", jstr)
-	}
-
-	if flattenErr != nil {
-		log.Error(err, "Received an error while flattened Alert")
-		return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
 	}
 
 	return ctrl.Result{RequeueAfter: defaultRequeuePeriod}, nil


### PR DESCRIPTION
After deploying the coralogix-operator to staging and euplatform clusters, we noticed that it wold eventually get nilpointer exceptions on `apis/coralogix/v1alpha1/alert_types.go:1082`:

```
{"level":"info","ts":"2023-08-02T14:58:25Z","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"alert","controllerGroup":"coralogix.com","controllerKind":"Alert","Alert":{"name":"recordtoolarge-alerting-kafka-connect","namespace":"platform"},"namespace":"platform","name":"recordtoolarge-alerting-kafka-connect","reconcileID":"20721bc0-68af-4920-a506-339c860480ce"}panic: runtime error: invalid memory address or nil pointer dereference [recovered]	panic: runtime error: invalid memory address or nil pointer dereference[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xddfa64]goroutine 447 [running]:sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:119 +0x1fapanic({0x1829240, 0x2992280})	/usr/local/go/src/runtime/panic.go:884 +0x213github.com/coralogix/coralogix-operator/apis/coralogix/v1alpha1.(*AlertSpec).DeepEqual(0x1cc4460?, 0xc004f9c868?)	/workspace/apis/coralogix/v1alpha1/alert_types.go:1082 +0x44github.com/coralogix/coralogix-operator/controllers/alphacontrollers.(*AlertReconciler).Reconcile(0xc00043bee0, {0x1cdb2f8, 0xc0051b2e40}, {{{0xc000653d40?, 0x0?}, {0xc0002f38f0?, 0x40de67?}}})	/workspace/controllers/alphacontrollers/alert_controller.go:211 +0x1a25sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1cdb2f8?, {0x1cdb2f8?, 0xc0051b2e40?}, {{{0xc000653d40?, 0x179cf20?}, {0xc0002f38f0?, 0x0?}}})	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:122 +0xc8sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0000a2780, {0x1cdb250, 0xc0002ffef0}, {0x18b4280?, 0xc000143ac0?})	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:323 +0x35fsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0000a2780, {0x1cdb250, 0xc0002ffef0})	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:274 +0x1d9sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:235 +0x85created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:231 +0x587
```

After a few hours trying to reproduce it in a Kind cluster 😅, I noticed that we were calling `DeepEqual`(line 211) with a nil `AlertStatus`. This is happening because we're not handling the error received from `flattenAlert`, or rather handling it too late.