### PR TITLE
Fixing notification groups deep equal bug

### DIFF
--- a/apis/coralogix/v1alpha1/alert_types.go
+++ b/apis/coralogix/v1alpha1/alert_types.go
@@ -1197,20 +1197,59 @@ func DeepEqualNotificationGroups(notificationGroups []NotificationGroup, actualN
 		}
 	}
 
-	for i := range notificationGroups {
-		notificationGroup, actualNotificationGroup := notificationGroups[i], actualNotificationGroups[i]
-		{
-			if equal, diff := notificationGroup.DeepEqual(actualNotificationGroup); !equal {
-				return false, utils.Diff{
-					Name:    fmt.Sprintf("Notifications.%d.%s", i, diff.Name),
-					Desired: diff.Desired,
-					Actual:  diff.Actual,
+	desiredGroupByFieldsToNotification := getGroupByFieldsToNotificationMap(notificationGroups)
+	actualGroupByFieldsToNotification := getGroupByFieldsToNotificationMap(actualNotificationGroups)
+	for groupByFields, notifications := range desiredGroupByFieldsToNotification {
+		if actualNotifications, ok := actualGroupByFieldsToNotification[groupByFields]; !ok {
+			return false, utils.Diff{
+				Name:    fmt.Sprintf("Notifications.gropup-by:%s", groupByFields),
+				Desired: notifications,
+				Actual:  nil,
+			}
+		} else {
+			desiredNotificationsByIntegrationName := getNotificationsByIntegrationNameMap(notifications)
+			actualNotificationsByIntegrationName := getNotificationsByIntegrationNameMap(actualNotifications)
+
+			for integrationName, notification := range desiredNotificationsByIntegrationName {
+				if actualNotification, ok := actualNotificationsByIntegrationName[integrationName]; !ok {
+					return false, utils.Diff{
+						Name:    fmt.Sprintf("Notifications.gropup-by:%s.%s", groupByFields, integrationName),
+						Desired: notification,
+						Actual:  nil,
+					}
+				} else if equal, diff := notification.DeepEqual(actualNotification); !equal {
+					return false, utils.Diff{
+						Name:    fmt.Sprintf("Notifications.gropup-by:%s.%s.%s", groupByFields, integrationName, diff.Name),
+						Desired: diff.Desired,
+						Actual:  diff.Actual,
+					}
 				}
 			}
 		}
 	}
 
 	return true, utils.Diff{}
+}
+
+func getGroupByFieldsToNotificationMap(notificationGroups []NotificationGroup) map[string][]Notification {
+	groupByFieldsToNotification := make(map[string][]Notification)
+	for _, notificationGroup := range notificationGroups {
+		groupByFields := fmt.Sprintf("%+q", notificationGroup.GroupByFields)
+		groupByFieldsToNotification[groupByFields] = notificationGroup.Notifications
+	}
+	return groupByFieldsToNotification
+}
+
+func getNotificationsByIntegrationNameMap(notifications []Notification) map[string]Notification {
+	notificationsByIntegrationName := make(map[string]Notification)
+	for _, notification := range notifications {
+		if notification.IntegrationName != nil {
+			notificationsByIntegrationName[*notification.IntegrationName] = notification
+		} else {
+			notificationsByIntegrationName["emailRecipients"] = notification
+		}
+	}
+	return notificationsByIntegrationName
 }
 
 func (in *AlertSpec) ExtractUpdateAlertRequest(ctx context.Context, id string) (*alerts.UpdateAlertByUniqueIdRequest, error) {
@@ -1338,8 +1377,8 @@ func (in *Notification) DeepEqual(actualNotification Notification) (bool, utils.
 	if in.RetriggeringPeriodMinutes != actualNotification.RetriggeringPeriodMinutes {
 		return false, utils.Diff{
 			Name:    "RetriggeringPeriodMinutes",
-			Desired: in.RetriggeringPeriodMinutes,
-			Actual:  actualNotification.RetriggeringPeriodMinutes,
+			Desired: fmt.Sprintf("%d", in.RetriggeringPeriodMinutes),
+			Actual:  fmt.Sprintf("%d", actualNotification.RetriggeringPeriodMinutes),
 		}
 	}
 

--- a/apis/coralogix/v1alpha1/alert_types.go
+++ b/apis/coralogix/v1alpha1/alert_types.go
@@ -1324,43 +1324,6 @@ type NotificationGroup struct {
 	Notifications []Notification `json:"notifications,omitempty"`
 }
 
-func (in *NotificationGroup) DeepEqual(actualNotificationGroup NotificationGroup) (bool, utils.Diff) {
-	if groupByFields, actualGroupByFields := in.GroupByFields, actualNotificationGroup.GroupByFields; !utils.SlicesWithUniqueValuesEqual(groupByFields, actualGroupByFields) {
-		return false, utils.Diff{
-			Name:    "GroupByFields",
-			Desired: groupByFields,
-			Actual:  actualGroupByFields,
-		}
-	}
-
-	notifications, actualNotifications := in.Notifications, actualNotificationGroup.Notifications
-	{
-		if length, actualLength := len(notifications), len(actualNotifications); length != actualLength {
-			return false, utils.Diff{
-				Name:    "Notifications.Length",
-				Desired: length,
-				Actual:  actualLength,
-			}
-		}
-
-		for i := range notifications {
-			notification, actualNotification := notifications[i], actualNotifications[i]
-			{
-				if equal, diff := notification.DeepEqual(actualNotification); !equal {
-					return false, utils.Diff{
-						Name:    fmt.Sprintf("Notifications[%d].%s", i, diff.Name),
-						Desired: diff.Desired,
-						Actual:  diff.Actual,
-					}
-				}
-			}
-
-		}
-	}
-
-	return true, utils.Diff{}
-}
-
 type Notification struct {
 	RetriggeringPeriodMinutes int32 `json:"retriggeringPeriodMinutes,omitempty"`
 

--- a/apis/coralogix/v1alpha1/alert_types.go
+++ b/apis/coralogix/v1alpha1/alert_types.go
@@ -1210,7 +1210,7 @@ func DeepEqualNotificationGroups(notificationGroups []NotificationGroup, actualN
 		}
 	}
 
-	return false, utils.Diff{}
+	return true, utils.Diff{}
 }
 
 func (in *AlertSpec) ExtractUpdateAlertRequest(ctx context.Context, id string) (*alerts.UpdateAlertByUniqueIdRequest, error) {

--- a/apis/coralogix/v1alpha1/alert_types_test.go
+++ b/apis/coralogix/v1alpha1/alert_types_test.go
@@ -1,0 +1,188 @@
+package v1alpha1
+
+import "testing"
+
+func TestDeepEqualNotificationGroupsEquals(t *testing.T) {
+	integrationName := "WebhookAlerts"
+	notificationGroups := []NotificationGroup{
+		{
+			GroupByFields: []string{"field1", "field2"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+			},
+		},
+		{
+			GroupByFields: []string{"field3"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+			},
+		},
+	}
+
+	//Changing the order of the notification groups should not affect the result
+	actualNotificationGroups := []NotificationGroup{
+		{
+			GroupByFields: []string{"field3"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+			},
+		},
+		{
+			GroupByFields: []string{"field1", "field2"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+			},
+		},
+	}
+	if equal, dif := DeepEqualNotificationGroups(notificationGroups, actualNotificationGroups); !equal {
+		t.Error("Expected to be equal but got: ", dif)
+	}
+}
+
+func TestDeepEqualNotificationGroupsNotEquals(t *testing.T) {
+	integrationName := "WebhookAlerts"
+	notificationGroups := []NotificationGroup{
+		{
+			GroupByFields: []string{"field1", "field2"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+			},
+		},
+		{
+			GroupByFields: []string{"field3"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+			},
+		},
+	}
+
+	actualNotificationGroups := []NotificationGroup{
+		{
+			GroupByFields: []string{"field3"},
+			Notifications: []Notification{
+				{
+					//Changing the RetriggeringPeriodMinutes should affect the result
+					RetriggeringPeriodMinutes: 10,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+			},
+		},
+		{
+			GroupByFields: []string{"field1", "field2"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+			},
+		},
+	}
+
+	if equal, _ := DeepEqualNotificationGroups(notificationGroups, actualNotificationGroups); equal {
+		t.Error("Expected to be not equal but got")
+	}
+
+	actualNotificationGroups = []NotificationGroup{
+		{
+			//Changing the GroupByFields should affect the result
+			GroupByFields: []string{"field3", "field4"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+			},
+		},
+		{
+			GroupByFields: []string{"field1", "field2"},
+			Notifications: []Notification{
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					EmailRecipients:           []string{"example@coralogix.com"},
+				},
+				{
+					RetriggeringPeriodMinutes: 5,
+					NotifyOn:                  NotifyOnTriggeredOnly,
+					IntegrationName:           &integrationName,
+				},
+			},
+		},
+	}
+
+	if equal, _ := DeepEqualNotificationGroups(notificationGroups, actualNotificationGroups); equal {
+		t.Error("Expected to be not equal but got")
+	}
+}


### PR DESCRIPTION
It turns out that NotificationGroups and Notifications within each NotificationGroup do not maintain the creation order, therefore a different type of comparison between spec and status is needed.