### PR TITLE
remove group-by from promql alert spec

### DIFF
--- a/apis/coralogix/v1alpha1/alert_types.go
+++ b/apis/coralogix/v1alpha1/alert_types.go
@@ -2409,9 +2409,6 @@ type PromqlConditions struct {
 	TimeWindow MetricTimeWindow `json:"timeWindow"`
 
 	// +optional
-	GroupBy []string `json:"groupBy,omitempty"`
-
-	// +optional
 	ReplaceMissingValueWithZero bool `json:"replaceMissingValueWithZero,omitempty"`
 
 	// +kubebuilder:validation:Minimum:=0
@@ -2428,14 +2425,6 @@ func (in *PromqlConditions) DeepEqual(actualCondition PromqlConditions) (bool, u
 			Name:    "Threshold",
 			Desired: in.Threshold,
 			Actual:  actualCondition.Threshold,
-		}
-	}
-
-	if !utils.SlicesWithUniqueValuesEqual(in.GroupBy, actualCondition.GroupBy) {
-		return false, utils.Diff{
-			Name:    "GroupBy",
-			Desired: in.GroupBy,
-			Actual:  actualCondition.GroupBy,
 		}
 	}
 

--- a/apis/coralogix/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/coralogix/v1alpha1/zz_generated.deepcopy.go
@@ -749,11 +749,6 @@ func (in *Promql) DeepCopy() *Promql {
 func (in *PromqlConditions) DeepCopyInto(out *PromqlConditions) {
 	*out = *in
 	out.Threshold = in.Threshold.DeepCopy()
-	if in.GroupBy != nil {
-		in, out := &in.GroupBy, &out.GroupBy
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.MinNonNullValuesPercentage != nil {
 		in, out := &in.MinNonNullValuesPercentage, &out.MinNonNullValuesPercentage
 		*out = new(int)

--- a/config/crd/bases/coralogix.com_alerts.yaml
+++ b/config/crd/bases/coralogix.com_alerts.yaml
@@ -194,10 +194,6 @@ spec:
                                 - More
                                 - Less
                                 type: string
-                              groupBy:
-                                items:
-                                  type: string
-                                type: array
                               manageUndetectedValues:
                                 properties:
                                   autoRetireRatio:
@@ -1091,10 +1087,6 @@ spec:
                                 - More
                                 - Less
                                 type: string
-                              groupBy:
-                                items:
-                                  type: string
-                                type: array
                               manageUndetectedValues:
                                 properties:
                                   autoRetireRatio:

--- a/controllers/alphacontrollers/alert_controller.go
+++ b/controllers/alphacontrollers/alert_controller.go
@@ -622,7 +622,6 @@ func flattenPromqlAlert(conditionParams *alerts.ConditionParameters, promqlParam
 		Threshold:                   utils.FloatToQuantity(conditionParams.GetThreshold().GetValue()),
 		SampleThresholdPercentage:   int(promqlParams.GetSampleThresholdPercentage().GetValue()),
 		TimeWindow:                  coralogixv1alpha1.MetricTimeWindow(alertProtoTimeWindowToSchemaTimeWindow[conditionParams.GetTimeframe()]),
-		GroupBy:                     utils.WrappedStringSliceToStringSlice(conditionParams.GetGroupBy()),
 		ReplaceMissingValueWithZero: promqlParams.GetSwapNullValues().GetValue(),
 	}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -750,13 +750,6 @@ AlertSpec defines the desired state of Alert
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b>groupBy</b></td>
-        <td>[]string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b><a href="#alertspecalerttypemetricpromqlconditionsmanageundetectedvalues">manageUndetectedValues</a></b></td>
         <td>object</td>
         <td>
@@ -3015,13 +3008,6 @@ AlertStatus defines the observed state of Alert
             <i>Enum</i>: Minute, FiveMinutes, TenMinutes, FifteenMinutes, TwentyMinutes, ThirtyMinutes, Hour, TwoHours, FourHours, SixHours, TwelveHours, TwentyFourHours<br/>
         </td>
         <td>true</td>
-      </tr><tr>
-        <td><b>groupBy</b></td>
-        <td>[]string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
       </tr><tr>
         <td><b><a href="#alertstatusalerttypemetricpromqlconditionsmanageundetectedvalues">manageUndetectedValues</a></b></td>
         <td>object</td>


### PR DESCRIPTION
Remove group-by array from promql-alert spec since when filling `group-by` through the query (e.g.
- 
```yaml
searchQuery: |-
     sum(
      max_over_time(aws_autoscaling_group_in_service_instances_average[15m] offset 30m) 
      / 
      aws_autoscaling_group_total_instances_average offset 30m
     ) **by (auto_scaling_group_name, region, cluster, env)**
```
), the alerts-API returns the group-by in the designated field as well (
```yaml
groupBy: [auto_scaling_group_name, region, cluster, env]
```
), which causes a diff between the spec and the status and an attempt to update the CR forever.