### PR TITLE
[FIX] getting tag name in workflow

### DIFF
--- a/.github/workflows/helm-update.yaml
+++ b/.github/workflows/helm-update.yaml
@@ -19,9 +19,11 @@ jobs:
 
       - name: Update Chart Version
         run: |
-          TAG=$(echo "${{ github.event.ref }}" | sed -n 's/refs\/tags\/v\(.*\)/\1/p')
+          TAG="${{ github.ref_name }}"
           CURRENT_VERSION=$(grep "version:" charts/coralogix-operator/Chart.yaml | awk '{print $2}')
           NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. -v OFS=. '{$3+=1}1')
+
+          echo "${{ github.ref_name }}"
 
           git checkout -b update-chart-version-${TAG}
 


### PR DESCRIPTION
Changing the strategy we're using to get tag name during the workflow time.
https://stackoverflow.com/questions/58177786/get-the-current-pushed-tag-in-github-actions