### PR TITLE
Delete cr that was deleted externally bug fixing

### DIFF
--- a/apis/coralogix/v1alpha1/alert_types.go
+++ b/apis/coralogix/v1alpha1/alert_types.go
@@ -1392,6 +1392,7 @@ func (in *ShowInInsight) DeepEqual(actualShowInInsight ShowInInsight) (bool, uti
 	return true, utils.Diff{}
 }
 
+// +kubebuilder:validation:Enum=TriggeredOnly;TriggeredAndResolved;
 type NotifyOn string
 
 const (

--- a/config/crd/bases/coralogix.com_alerts.yaml
+++ b/config/crd/bases/coralogix.com_alerts.yaml
@@ -867,6 +867,9 @@ spec:
                           integrationName:
                             type: string
                           notifyOn:
+                            enum:
+                            - TriggeredOnly
+                            - TriggeredAndResolved
                             type: string
                           retriggeringPeriodMinutes:
                             format: int32
@@ -915,6 +918,9 @@ spec:
                 properties:
                   notifyOn:
                     default: TriggeredOnly
+                    enum:
+                    - TriggeredOnly
+                    - TriggeredAndResolved
                     type: string
                   retriggeringPeriodMinutes:
                     format: int32
@@ -1761,6 +1767,9 @@ spec:
                           integrationName:
                             type: string
                           notifyOn:
+                            enum:
+                            - TriggeredOnly
+                            - TriggeredAndResolved
                             type: string
                           retriggeringPeriodMinutes:
                             format: int32
@@ -1809,6 +1818,9 @@ spec:
                 properties:
                   notifyOn:
                     default: TriggeredOnly
+                    enum:
+                    - TriggeredOnly
+                    - TriggeredAndResolved
                     type: string
                   retriggeringPeriodMinutes:
                     format: int32

--- a/docs/api.md
+++ b/docs/api.md
@@ -2218,9 +2218,11 @@ AlertSpec defines the desired state of Alert
         <td>false</td>
       </tr><tr>
         <td><b>notifyOn</b></td>
-        <td>string</td>
+        <td>enum</td>
         <td>
           <br/>
+          <br/>
+            <i>Enum</i>: TriggeredOnly, TriggeredAndResolved<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2304,10 +2306,11 @@ AlertSpec defines the desired state of Alert
     </thead>
     <tbody><tr>
         <td><b>notifyOn</b></td>
-        <td>string</td>
+        <td>enum</td>
         <td>
           <br/>
           <br/>
+            <i>Enum</i>: TriggeredOnly, TriggeredAndResolved<br/>
             <i>Default</i>: TriggeredOnly<br/>
         </td>
         <td>false</td>
@@ -4477,9 +4480,11 @@ AlertStatus defines the observed state of Alert
         <td>false</td>
       </tr><tr>
         <td><b>notifyOn</b></td>
-        <td>string</td>
+        <td>enum</td>
         <td>
           <br/>
+          <br/>
+            <i>Enum</i>: TriggeredOnly, TriggeredAndResolved<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -4563,10 +4568,11 @@ AlertStatus defines the observed state of Alert
     </thead>
     <tbody><tr>
         <td><b>notifyOn</b></td>
-        <td>string</td>
+        <td>enum</td>
         <td>
           <br/>
           <br/>
+            <i>Enum</i>: TriggeredOnly, TriggeredAndResolved<br/>
             <i>Default</i>: TriggeredOnly<br/>
         </td>
         <td>false</td>


### PR DESCRIPTION
If a CR's external resource was deleted externally before the CR was deleted from cluster the operator will try to delete it forever, in hence it required to check if the deletion error that returned from the backend was `NotFoud`.