### PR TITLE
fix: helm charts improve installation validation

### DIFF
--- a/charts/coralogix-operator/Chart.yaml
+++ b/charts/coralogix-operator/Chart.yaml
@@ -9,7 +9,7 @@ name: coralogix-operator
 sources:
   - https://github.com/coralogix/coralogix-operator
 version: 0.1.5
-appVersion: 0.1.17
+appVersion: 0.1.18
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/coralogix/coralogix-operator
 keywords:

--- a/charts/coralogix-operator/templates/NOTES.txt
+++ b/charts/coralogix-operator/templates/NOTES.txt
@@ -5,3 +5,7 @@
 {{- if and (eq .Values.secret.create false) (eq .Values.secret.secretKeyReference.name nil) }}
 {{ fail "[ERROR] 'secret.secretKeyReference' is required when 'secret.create' is false." }}
 {{ end }}
+
+{{- if (eq .Values.coralogixOperator.region "") }}
+{{ fail "[ERROR] 'coralogixOperator.region' must be set. Please select one of APAC1,APAC2,EUROPE1,EUROPE2,USA1,USA2 regions. See https://coralogix.com/docs/coralogix-domain/ for more information." }}
+{{ end }}


### PR DESCRIPTION
FIX ES-79

region and secret data are mandatory, so adding more validation during helm install

Tested manually using helm:

```
helm upgrade --install test . --set secret.data.apiKey=...
```

```
Release "test" does not exist. Installing it now.

Error: execution error at (coralogix-operator/templates/NOTES.txt:10:3): [ERROR] 'coralogixOperator.region' must be set. Please select one of APAC1,APAC2,EUROPE1,EUROPE2,USA1,USA2 regions. See https://coralogix.com/docs/coralogix-domain/ for more information.
```