### PR TITLE
adding coralogixOperator.secretKey function

### DIFF
--- a/charts/coralogix-operator/templates/_helpers.tpl
+++ b/charts/coralogix-operator/templates/_helpers.tpl
@@ -72,3 +72,14 @@ Create the name of the service account to use
 {{- .Values.secret.secretKeyReference.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the name of the secret key, defaults to CORALOGIX_API_KEY
+*/}}
+{{- define "coralogixOperator.secretKey" -}}
+{{- if and (.Values.secret.create) (not .Values.secret.secretKeyReference) }}
+{{- print "CORALOGIX_API_KEY" }}
+{{- else }}
+{{- .Values.secret.secretKeyReference.key }}
+{{- end }}
+{{- end }}

--- a/charts/coralogix-operator/templates/deployment.yaml
+++ b/charts/coralogix-operator/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: {{ include "coralogixOperator.secretName" . }}
-                key: "CORALOGIX_API_KEY"
+                key: {{ include "coralogixOperator.secretKey" . }}
         image: {{ .Values.coralogixOperator.image.repository }}:v{{ .Values.coralogixOperator.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.coralogixOperator.image.pullPolicy }}
         livenessProbe:


### PR DESCRIPTION
If secretKeyReference is defined then use the secret key name, otherwise default to `CORALOGIX_API_KEY`