### PR TITLE
[FIX] error checking causing panic

### DIFF
--- a/controllers/alphacontrollers/alert_controller.go
+++ b/controllers/alphacontrollers/alert_controller.go
@@ -988,7 +988,7 @@ func flattenNotificationGroups(ctx context.Context, notificationGroups []*alerts
 	var err error
 	for _, ng := range notificationGroups {
 		notificationGroup, flattenErr := flattenNotificationGroup(ctx, ng)
-		if err != nil {
+		if flattenErr != nil {
 			err = stdErr.Join(err, fmt.Errorf("error on flatten notification-groups - %w", flattenErr))
 			continue
 		}
@@ -1018,6 +1018,7 @@ func flattenNotifications(ctx context.Context, notifications []*alerts.AlertNoti
 		flattenedNotification, flattenErr := flattenNotification(ctx, notification)
 		if flattenErr != nil {
 			err = stdErr.Join(err, fmt.Errorf("error on flatten notifications - %w", flattenErr))
+			continue
 		}
 		result = append(result, flattenedNotification)
 	}


### PR DESCRIPTION
This pull request includes changes to the `alert_controller.go` file, specifically within the `flattenNotificationGroups` and `flattenNotifications` functions. The changes are primarily focused on error handling and flow control.

Here are the most important changes:

* `controllers/alphacontrollers/alert_controller.go`:
  * In the `flattenNotificationGroups` function, the condition for the error check has been modified. Previously, it was checking a variable `err` which wasn't updated inside the loop. Now, it correctly checks `flattenErr`, which is the error returned from the `flattenNotificationGroup` function. This ensures that any errors encountered during the flattening process are properly caught and handled.
  * In the `flattenNotifications` function, a `continue` statement has been added in the error handling block. This means that if an error occurs when flattening a notification, the function will skip the current iteration and move to the next notification, preventing the erroneous notification from being added to the result.

Error sample

```bash
goroutine 153 [running]:sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:115 +0x1e5panic({0x17ad580?, 0x298ecc0?})	/usr/local/go/src/runtime/panic.go:770 +0x132github.com/coralogix/coralogix-operator/controllers/alphacontrollers.flattenNotificationGroups({0x1c89378, 0xc004e11d10}, {0xc0003e8828, 0x1, 0x298efb0?})	/workspace/controllers/alphacontrollers/alert_controller.go:995 +0xe9github.com/coralogix/coralogix-operator/controllers/alphacontrollers.getStatus({_, _}, _, {{0xc0010a0ff0, 0x43}, {0xc000fcbf80, 0x80}, 0x1, {0xc001138900, 0x7}, ...})	/workspace/controllers/alphacontrollers/alert_controller.go:261 +0x43agithub.com/coralogix/coralogix-operator/controllers/alphacontrollers.(*AlertReconciler).update(0xc00059de90, {0x1c89378, 0xc004e11d10}, {{0x1c8c7b8?, 0xc004e11d70?}, 0xc004e11d10?}, 0xc00233cb08)	/workspace/controllers/alphacontrollers/alert_controller.go:132 +0x217github.com/coralogix/coralogix-operator/controllers/alphacontrollers.(*AlertReconciler).Reconcile(0xc00059de90, {0x1c89378, 0xc004e11d10}, {{{0xc001138878?, 0x0?}, {0xc001109620?, 0xc004e11d10?}}})	/workspace/controllers/alphacontrollers/alert_controller.go:111 +0x32asigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1c89378?, {0x1c89378?, 0xc004e11d10?}, {{{0xc001138878?, 0x16ef5e0?}, {0xc001109620?, 0x10?}}})	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:118 +0xb7sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc00026e640, {0x1c893b0, 0xc0006a06e0}, {0x1837fa0, 0xc0055a0440})	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:314 +0x345sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc00026e640, {0x1c893b0, 0xc0006a06e0})	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:265 +0x1c9sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:226 +0x79created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 60	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/controller/controller.go:222 +0x50c
```