### PR TITLE
[CHORE] removing reschedule on sucess

### DIFF
--- a/controllers/alphacontrollers/alert_controller.go
+++ b/controllers/alphacontrollers/alert_controller.go
@@ -68,9 +68,7 @@ type AlertReconciler struct {
 
 func (r *AlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var (
-		resultError ctrl.Result = ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}
-		resultOk    ctrl.Result = ctrl.Result{RequeueAfter: defaultRequeuePeriod}
-		err         error
+		err error
 	)
 
 	log := log.FromContext(ctx).WithValues(
@@ -88,34 +86,34 @@ func (r *AlertReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			// Return and don't requeue
 			return ctrl.Result{}, nil
 		}
-		return resultError, err
+		return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
 	}
 
 	if ptr.Deref(alert.Status.ID, "") == "" {
 		err = r.create(ctx, log, alert)
 		if err != nil {
 			log.Error(err, "Error on creating alert")
-			return resultError, err
+			return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
 		}
-		return resultOk, nil
+		return ctrl.Result{}, nil
 	}
 
 	if !alert.ObjectMeta.DeletionTimestamp.IsZero() {
 		err = r.delete(ctx, log, alert)
 		if err != nil {
 			log.Error(err, "Error on deleting alert")
-			return resultError, err
+			return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
 		}
-		return resultOk, nil
+		return ctrl.Result{}, nil
 	}
 
 	err = r.update(ctx, log, alert)
 	if err != nil {
 		log.Error(err, "Error on updating alert")
-		return resultError, err
+		return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
 	}
 
-	return resultOk, nil
+	return ctrl.Result{}, nil
 }
 
 func (r *AlertReconciler) update(ctx context.Context,

--- a/controllers/alphacontrollers/alert_controller_test.go
+++ b/controllers/alphacontrollers/alert_controller_test.go
@@ -234,7 +234,6 @@ func TestAlertCreation(t *testing.T) {
 				assert.Equal(t, defaultErrRequeuePeriod, result.RequeueAfter)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, defaultRequeuePeriod, result.RequeueAfter)
 			}
 		})
 	}
@@ -504,7 +503,6 @@ func TestAlertUpdate(t *testing.T) {
 				assert.Equal(t, defaultErrRequeuePeriod, result.RequeueAfter)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, defaultRequeuePeriod, result.RequeueAfter)
 			}
 		})
 	}
@@ -715,7 +713,6 @@ func TestAlertDelete(t *testing.T) {
 				assert.Equal(t, defaultErrRequeuePeriod, result.RequeueAfter)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, defaultRequeuePeriod, result.RequeueAfter)
 			}
 		})
 	}

--- a/controllers/alphacontrollers/rulegroup_controller.go
+++ b/controllers/alphacontrollers/rulegroup_controller.go
@@ -180,7 +180,7 @@ func (r *RuleGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			if err := r.Status().Update(ctx, ruleGroupCRD); err != nil {
 				log.V(1).Error(err, "updating crd")
 			}
-			return ctrl.Result{RequeueAfter: defaultRequeuePeriod}, nil
+			return ctrl.Result{}, nil
 		} else {
 			log.Error(err, "Received an error while creating a Rule-Group", "ruleGroup", createRuleGroupReq)
 			return ctrl.Result{RequeueAfter: defaultErrRequeuePeriod}, err
@@ -202,7 +202,7 @@ func (r *RuleGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		log.V(1).Info("Rule-Group was updated", "ruleGroup", jstr)
 	}
 
-	return ctrl.Result{RequeueAfter: defaultRequeuePeriod}, nil
+	return ctrl.Result{}, nil
 }
 
 func flattenRuleGroup(ruleGroup *rulesgroups.RuleGroup) (*coralogixv1alpha1.RuleGroupStatus, error) {

--- a/controllers/alphacontrollers/rulegroup_controller_test.go
+++ b/controllers/alphacontrollers/rulegroup_controller_test.go
@@ -202,7 +202,6 @@ func TestRuleGroupReconciler_Reconcile(t *testing.T) {
 
 	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test"}})
 	assert.NoError(t, err)
-	assert.Equal(t, defaultRequeuePeriod, result.RequeueAfter)
 
 	namespacedName := types.NamespacedName{Namespace: "default", Name: "test"}
 	actualRuleGroupCRD := &coralogixv1alpha1.RuleGroup{}
@@ -270,7 +269,6 @@ func TestRuleGroupReconciler_Reconcile_5XX_StatusError(t *testing.T) {
 
 	result, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "default", Name: "test"}})
 	assert.NoError(t, err)
-	assert.Equal(t, defaultRequeuePeriod, result.RequeueAfter)
 
 	namespacedName := types.NamespacedName{Namespace: "default", Name: "test"}
 	actualRuleGroupCRD := &coralogixv1alpha1.RuleGroup{}

--- a/controllers/alphacontrollers/utils.go
+++ b/controllers/alphacontrollers/utils.go
@@ -5,6 +5,5 @@ import (
 )
 
 const (
-	defaultRequeuePeriod    = 30 * time.Second
-	defaultErrRequeuePeriod = 20 * time.Second
+	defaultErrRequeuePeriod = 30 * time.Second
 )


### PR DESCRIPTION
We are removing the default enqueue on success because the controller runtime already synchronizes the watched resources every 10 hours by default. Therefore, forcing a reschedule upon successful reconciliation is unnecessary.

In the future, if needed, we can introduce a flag to adjust the sync period.