### PR TITLE
[CHORE] enforcing default value instead of block cr onboarding

### DIFF
--- a/apis/coralogix/v1alpha1/recordingrulegroupset_types.go
+++ b/apis/coralogix/v1alpha1/recordingrulegroupset_types.go
@@ -187,7 +187,6 @@ type RecordingRuleGroup struct {
 	Name string `json:"name,omitempty"`
 
 	//+kubebuilder:default=60
-	// +kubebuilder:validation:Minimum=60
 	IntervalSeconds int32 `json:"intervalSeconds,omitempty"`
 
 	// +optional

--- a/config/crd/bases/coralogix.com_recordingrulegroupsets.yaml
+++ b/config/crd/bases/coralogix.com_recordingrulegroupsets.yaml
@@ -42,7 +42,6 @@ spec:
                     intervalSeconds:
                       default: 60
                       format: int32
-                      minimum: 60
                       type: integer
                     limit:
                       format: int64

--- a/controllers/prometheusrule_controller.go
+++ b/controllers/prometheusrule_controller.go
@@ -246,9 +246,18 @@ func prometheusRuleToRecordingRuleToRuleGroupSet(log logr.Logger, prometheusRule
 		if group.Interval != "" {
 			duration, err := time.ParseDuration(string(group.Interval))
 			if err != nil {
-				log.V(int(zapcore.WarnLevel)).Info("failed to parse interval duration", "interval", group.Interval, "error", err, "using default interval")
+				log.V(int(zapcore.WarnLevel)).Info("Failed to parse interval duration", "interval", group.Interval, "error", err, "using default interval")
 			}
-			interval = int32(duration.Seconds())
+
+			// Convert duration to seconds
+			durationSeconds := int32(duration.Seconds())
+
+			if durationSeconds < interval {
+				log.V(int(zapcore.WarnLevel)).Info("Recording rule interval is lower than the default interval", "interval", durationSeconds, "default interval", interval, "using the greater interval")
+			} else {
+				// Update interval if parsed duration is greater
+				interval = durationSeconds
+			}
 		}
 
 		if rules := prometheusInnerRulesToCoralogixInnerRules(group.Rules); len(rules) > 0 {

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,7 +51,7 @@ Alert is the Schema for the alerts API
       <td>true</td>
       </tr>
       <tr>
-      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta">metadata</a></b></td>
       <td>object</td>
       <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
       <td>true</td>
@@ -4623,7 +4623,7 @@ OutboundWebhook is the Schema for the outboundwebhooks API
       <td>true</td>
       </tr>
       <tr>
-      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta">metadata</a></b></td>
       <td>object</td>
       <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
       <td>true</td>
@@ -5842,7 +5842,7 @@ RecordingRuleGroupSet is the Schema for the recordingrulegroupsets API
       <td>true</td>
       </tr>
       <tr>
-      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta">metadata</a></b></td>
       <td>object</td>
       <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
       <td>true</td>
@@ -5915,7 +5915,6 @@ RecordingRuleGroupSetSpec defines the desired state of RecordingRuleGroupSet
           <br/>
             <i>Format</i>: int32<br/>
             <i>Default</i>: 60<br/>
-            <i>Minimum</i>: 60<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -6146,7 +6145,7 @@ RuleGroup is the Schema for the rulegroups API
       <td>true</td>
       </tr>
       <tr>
-      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta">metadata</a></b></td>
+      <td><b><a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectmeta-v1-meta">metadata</a></b></td>
       <td>object</td>
       <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
       <td>true</td>


### PR DESCRIPTION
Enforcing default interval is a better approach in this case than block on CRD, since some customers might have generate prometheus rules being created by third part service that don't allow rule interval configuration.