### PR TITLE
Adding the OutboundWebhook CRD and permissions to the helm chart

### DIFF
--- a/charts/coralogix-operator/templates/clusterrole.yaml
+++ b/charts/coralogix-operator/templates/clusterrole.yaml
@@ -100,9 +100,44 @@ rules:
   - patch
   - update
 - apiGroups:
+  - coralogix.com
+  resources:
+  - outboundwebhooks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coralogix.com
+  resources:
+  - outboundwebhooks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - coralogix.com
+  resources:
+  - outboundwebhooks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - prometheusrules
+  - alertmanagerconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
   verbs:
   - get
   - list

--- a/charts/coralogix-operator/templates/crds/coralogix.com_outboundwebhooks.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_outboundwebhooks.yaml
@@ -1,0 +1,359 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: outboundwebhooks.coralogix.com
+spec:
+  group: coralogix.com
+  names:
+    kind: OutboundWebhook
+    listKind: OutboundWebhookList
+    plural: outboundwebhooks
+    singular: outboundwebhook
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OutboundWebhook is the Schema for the outboundwebhooks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OutboundWebhookSpec defines the desired state of OutboundWebhook
+            properties:
+              name:
+                minLength: 0
+                type: string
+              outboundWebhookType:
+                properties:
+                  awsEventBridge:
+                    properties:
+                      detail:
+                        type: string
+                      detailType:
+                        type: string
+                      eventBusArn:
+                        type: string
+                      roleName:
+                        type: string
+                      source:
+                        type: string
+                    required:
+                    - detail
+                    - detailType
+                    - eventBusArn
+                    - roleName
+                    - source
+                    type: object
+                  demisto:
+                    properties:
+                      payload:
+                        type: string
+                      url:
+                        type: string
+                      uuid:
+                        type: string
+                    required:
+                    - payload
+                    - url
+                    - uuid
+                    type: object
+                  emailGroup:
+                    properties:
+                      emailAddresses:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - emailAddresses
+                    type: object
+                  genericWebhook:
+                    properties:
+                      headers:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      method:
+                        enum:
+                        - Unkown
+                        - Get
+                        - Post
+                        - Put
+                        type: string
+                      payload:
+                        type: string
+                      url:
+                        type: string
+                    required:
+                    - method
+                    - url
+                    type: object
+                  jira:
+                    properties:
+                      apiToken:
+                        type: string
+                      email:
+                        type: string
+                      projectKey:
+                        type: string
+                      url:
+                        type: string
+                    required:
+                    - apiToken
+                    - email
+                    - projectKey
+                    - url
+                    type: object
+                  microsoftTeams:
+                    properties:
+                      url:
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  opsgenie:
+                    properties:
+                      url:
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  pagerDuty:
+                    properties:
+                      serviceKey:
+                        type: string
+                    required:
+                    - serviceKey
+                    type: object
+                  sendLog:
+                    properties:
+                      payload:
+                        type: string
+                      url:
+                        type: string
+                    required:
+                    - payload
+                    - url
+                    type: object
+                  slack:
+                    properties:
+                      attachments:
+                        items:
+                          properties:
+                            isActive:
+                              type: boolean
+                            type:
+                              type: string
+                          required:
+                          - isActive
+                          - type
+                          type: object
+                        type: array
+                      digests:
+                        items:
+                          properties:
+                            isActive:
+                              type: boolean
+                            type:
+                              type: string
+                          required:
+                          - isActive
+                          - type
+                          type: object
+                        type: array
+                      url:
+                        type: string
+                    required:
+                    - url
+                    type: object
+                type: object
+            required:
+            - name
+            - outboundWebhookType
+            type: object
+          status:
+            description: OutboundWebhookStatus defines the observed state of OutboundWebhook
+            properties:
+              externalId:
+                type: string
+              id:
+                type: string
+              name:
+                type: string
+              outboundWebhookType:
+                properties:
+                  awsEventBridge:
+                    properties:
+                      detail:
+                        type: string
+                      detailType:
+                        type: string
+                      eventBusArn:
+                        type: string
+                      roleName:
+                        type: string
+                      source:
+                        type: string
+                    required:
+                    - detail
+                    - detailType
+                    - eventBusArn
+                    - roleName
+                    - source
+                    type: object
+                  demisto:
+                    properties:
+                      payload:
+                        type: string
+                      url:
+                        type: string
+                      uuid:
+                        type: string
+                    required:
+                    - payload
+                    - url
+                    - uuid
+                    type: object
+                  emailGroup:
+                    properties:
+                      emailAddresses:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - emailAddresses
+                    type: object
+                  genericWebhook:
+                    properties:
+                      headers:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      method:
+                        enum:
+                        - Unkown
+                        - Get
+                        - Post
+                        - Put
+                        type: string
+                      payload:
+                        type: string
+                      url:
+                        type: string
+                      uuid:
+                        type: string
+                    required:
+                    - method
+                    - url
+                    - uuid
+                    type: object
+                  jira:
+                    properties:
+                      apiToken:
+                        type: string
+                      email:
+                        type: string
+                      projectKey:
+                        type: string
+                      url:
+                        type: string
+                    required:
+                    - apiToken
+                    - email
+                    - projectKey
+                    - url
+                    type: object
+                  microsoftTeams:
+                    properties:
+                      url:
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  opsgenie:
+                    properties:
+                      url:
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  pagerDuty:
+                    properties:
+                      serviceKey:
+                        type: string
+                    required:
+                    - serviceKey
+                    type: object
+                  sendLog:
+                    properties:
+                      payload:
+                        type: string
+                      url:
+                        type: string
+                      uuid:
+                        type: string
+                    required:
+                    - payload
+                    - url
+                    - uuid
+                    type: object
+                  slack:
+                    properties:
+                      attachments:
+                        items:
+                          properties:
+                            isActive:
+                              type: boolean
+                            type:
+                              type: string
+                          required:
+                          - isActive
+                          - type
+                          type: object
+                        type: array
+                      digests:
+                        items:
+                          properties:
+                            isActive:
+                              type: boolean
+                            type:
+                              type: string
+                          required:
+                          - isActive
+                          - type
+                          type: object
+                        type: array
+                      url:
+                        type: string
+                    required:
+                    - url
+                    type: object
+                type: object
+            required:
+            - id
+            - name
+            - outboundWebhookType
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Changes:
- Added the `OutboundWebhook` crd to helm chart
- Updated the k8s clusterole permissions to support the outboundwebooks

Related Issue:

https://github.com/coralogix/coralogix-operator/issues/166