### PR TITLE
Revert "Support cxMinNonNullValuesPercentage annotation from PrometheusRule"

### DIFF
--- a/internal/controller/prometheusrule_controller.go
+++ b/internal/controller/prometheusrule_controller.go
@@ -332,7 +332,7 @@ func prometheusRuleToCoralogixAlertSpec(rule prometheus.Rule) coralogixv1alpha1.
 						AlertWhen:                  coralogixv1alpha1.PromqlAlertWhenMoreThan,
 						Threshold:                  resource.MustParse("0"),
 						SampleThresholdPercentage:  100,
-						MinNonNullValuesPercentage: getMinNonNullValuesPercentage(rule),
+						MinNonNullValuesPercentage: ptr.To(0),
 					},
 				},
 			},
@@ -384,16 +384,6 @@ func getNotificationIntegrationName(rule prometheus.Rule) *string {
 	}
 
 	return nil
-}
-
-func getMinNonNullValuesPercentage(rule prometheus.Rule) *int {
-	if minNonNullValuesPercentage, ok := rule.Annotations["cxMinNonNullValuesPercentage"]; ok {
-		if minNonNullValuesPercentageInt, err := strconv.Atoi(minNonNullValuesPercentage); err == nil {
-			return ptr.To(minNonNullValuesPercentageInt)
-		}
-	}
-
-	return ptr.To(0)
 }
 
 var prometheusAlertForToCoralogixPromqlAlertTimeWindow = map[prometheus.Duration]coralogixv1alpha1.MetricTimeWindow{

--- a/tests/integration/alertmangerconfigs/alertmangerconfig-basic/03-assert.yaml
+++ b/tests/integration/alertmangerconfigs/alertmangerconfig-basic/03-assert.yaml
@@ -19,7 +19,7 @@ spec:
       promql:
         conditions:
           alertWhen: More
-          minNonNullValuesPercentage: 20
+          minNonNullValuesPercentage: 0
           sampleThresholdPercentage: 100
           threshold: "0"
           timeWindow: FiveMinutes
@@ -65,7 +65,7 @@ spec:
       promql:
         conditions:
           alertWhen: More
-          minNonNullValuesPercentage: 20
+          minNonNullValuesPercentage: 0
           sampleThresholdPercentage: 100
           threshold: "0"
           timeWindow: FiveMinutes
@@ -117,7 +117,7 @@ spec:
       promql:
         conditions:
           alertWhen: More
-          minNonNullValuesPercentage: 20
+          minNonNullValuesPercentage: 0
           sampleThresholdPercentage: 100
           threshold: "0"
           timeWindow: FiveMinutes

--- a/tests/integration/alertmangerconfigs/alertmangerconfig-basic/05-assert.yaml
+++ b/tests/integration/alertmangerconfigs/alertmangerconfig-basic/05-assert.yaml
@@ -19,7 +19,7 @@ spec:
       promql:
         conditions:
           alertWhen: More
-          minNonNullValuesPercentage: 20
+          minNonNullValuesPercentage: 0
           sampleThresholdPercentage: 100
           threshold: "0"
           timeWindow: FiveMinutes
@@ -65,7 +65,7 @@ spec:
       promql:
         conditions:
           alertWhen: More
-          minNonNullValuesPercentage: 20
+          minNonNullValuesPercentage: 0
           sampleThresholdPercentage: 100
           threshold: "0"
           timeWindow: FiveMinutes
@@ -112,7 +112,7 @@ spec:
       promql:
         conditions:
           alertWhen: More
-          minNonNullValuesPercentage: 20
+          minNonNullValuesPercentage: 0
           sampleThresholdPercentage: 100
           threshold: "0"
           timeWindow: FiveMinutes

--- a/tests/integration/prometheusrules/prometheusrules-basic/03-install.yaml
+++ b/tests/integration/prometheusrules/prometheusrules-basic/03-install.yaml
@@ -18,7 +18,7 @@ spec:
           expr: histogram_quantile(0.99, sum(irate(istio_request_duration_seconds_bucket{reporter="source",destination_service=~"ingress-annotation-test-svc.example-app.svc.cluster.local"}[1m])) by (le, destination_workload)) > 0.2
           for: 15m
           annotations:
-            cxMinNonNullValuesPercentage: "20"
+            cxMinNonNullValuesPercentage: "25"
           labels:
             severity: info
     - name: example.rules
@@ -31,6 +31,6 @@ spec:
           expr: histogram_quantile(0.99, sum(irate(istio_request_duration_seconds_bucket{reporter="source",destination_service=~"ingress-annotation-test-svc.example-app.svc.cluster.local"}[1m])) by (le, destination_workload)) > 0.2
           for: 5m
           annotations:
-            cxMinNonNullValuesPercentage: "20"
+            cxMinNonNullValuesPercentage: "25"
           labels:
             severity: critical


### PR DESCRIPTION
We decided not to support configuring Coralogix Alert CRD special properties through Prometheus alerts annotations and labels. Instead we will support updating those extra properties in the alert CRD itself, without being overwritten.

Reverts coralogix/coralogix-operator#212