### PR TITLE
Change GlobalRouter fallback to optional

### DIFF
--- a/api/coralogix/v1alpha1/connector_types.go
+++ b/api/coralogix/v1alpha1/connector_types.go
@@ -108,6 +108,7 @@ type ConnectorStatus struct {
 // +kubebuilder:subresource:status
 
 // Connector is the Schema for the connectors API.
+// NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
 type Connector struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/coralogix/v1alpha1/globalrouter_types.go
+++ b/api/coralogix/v1alpha1/globalrouter_types.go
@@ -36,7 +36,8 @@ type GlobalRouterSpec struct {
 
 	EntityType string `json:"entityType"`
 
-	Fallback []RoutingTarget `json:"fallback"`
+	// +optional
+	Fallback []RoutingTarget `json:"fallback,omitempty"`
 
 	// +optional
 	Rules []RoutingRule `json:"rules,omitempty"`
@@ -241,6 +242,7 @@ type GlobalRouterStatus struct {
 // +kubebuilder:subresource:status
 
 // GlobalRouter is the Schema for the globalrouters API.
+// NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
 type GlobalRouter struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/coralogix/v1alpha1/preset_types.go
+++ b/api/coralogix/v1alpha1/preset_types.go
@@ -119,6 +119,7 @@ type PresetStatus struct {
 // +kubebuilder:subresource:status
 
 // Preset is the Schema for the presets API.
+// NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
 type Preset struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
@@ -17,7 +17,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Connector is the Schema for the connectors API.
+        description: |-
+          Connector is the Schema for the connectors API.
+          NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
         properties:
           apiVersion:
             description: |-

--- a/charts/coralogix-operator/templates/crds/coralogix.com_globalrouters.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_globalrouters.yaml
@@ -17,7 +17,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GlobalRouter is the Schema for the globalrouters API.
+        description: |-
+          GlobalRouter is the Schema for the globalrouters API.
+          NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
         properties:
           apiVersion:
             description: |-
@@ -153,7 +155,6 @@ spec:
             required:
             - description
             - entityType
-            - fallback
             - name
             type: object
           status:

--- a/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
@@ -17,7 +17,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Preset is the Schema for the presets API.
+        description: |-
+          Preset is the Schema for the presets API.
+          NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/coralogix.com_connectors.yaml
+++ b/config/crd/bases/coralogix.com_connectors.yaml
@@ -17,7 +17,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Connector is the Schema for the connectors API.
+        description: |-
+          Connector is the Schema for the connectors API.
+          NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/coralogix.com_globalrouters.yaml
+++ b/config/crd/bases/coralogix.com_globalrouters.yaml
@@ -17,7 +17,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: GlobalRouter is the Schema for the globalrouters API.
+        description: |-
+          GlobalRouter is the Schema for the globalrouters API.
+          NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
         properties:
           apiVersion:
             description: |-
@@ -153,7 +155,6 @@ spec:
             required:
             - description
             - entityType
-            - fallback
             - name
             type: object
           status:

--- a/config/crd/bases/coralogix.com_presets.yaml
+++ b/config/crd/bases/coralogix.com_presets.yaml
@@ -17,7 +17,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Preset is the Schema for the presets API.
+        description: |-
+          Preset is the Schema for the presets API.
+          NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
         properties:
           apiVersion:
             description: |-

--- a/docs/api.md
+++ b/docs/api.md
@@ -2573,6 +2573,7 @@ ApiKeyStatus defines the observed state of ApiKey.
 
 
 Connector is the Schema for the connectors API.
+NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
 
 <table>
     <thead>
@@ -3286,6 +3287,7 @@ CustomRoleStatus defines the observed state of CustomRole.
 
 
 GlobalRouter is the Schema for the globalrouters API.
+NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
 
 <table>
     <thead>
@@ -3362,19 +3364,19 @@ GlobalRouterSpec defines the desired state of GlobalRouter.
         </td>
         <td>true</td>
       </tr><tr>
-        <td><b><a href="#globalrouterspecfallbackindex">fallback</a></b></td>
-        <td>[]object</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
           <br/>
         </td>
         <td>true</td>
+      </tr><tr>
+        <td><b><a href="#globalrouterspecfallbackindex">fallback</a></b></td>
+        <td>[]object</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
       </tr><tr>
         <td><b><a href="#globalrouterspecrulesindex">rules</a></b></td>
         <td>[]object</td>
@@ -4971,6 +4973,7 @@ OutboundWebhookStatus defines the observed state of OutboundWebhook
 
 
 Preset is the Schema for the presets API.
+NOTE: This CRD exposes a new feature and may have breaking changes in future releases.
 
 <table>
     <thead>


### PR DESCRIPTION
- GlobalRouter fallback should be optional, as the API behaves.
- Add comments about the new NC CRDs to docs, mentioning they can have breaking changes in the near future.