### PR TITLE
Fix e2e tests flakiness and upload pod logs after tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -40,3 +40,7 @@ jobs:
       - name: Run e2e Tests
         run: |
           make e2e-tests
+      - name: Collect Operator Logs
+        if: always()
+        run: |
+          scripts/collect-logs.sh

--- a/.github/workflows/generated-files.yml
+++ b/.github/workflows/generated-files.yml
@@ -24,6 +24,7 @@ jobs:
           go-version-file: go.mod
       - name: Generate docs and manifests
         run: |
+          go mod tidy
           make generate
           make manifests
           make generate-api-docs
@@ -31,6 +32,7 @@ jobs:
         run: |
           if ! git diff --exit-code; then
             echo "Some files are out of date. Please run the following commands and commit the changes:"
+            echo "    go mod tidy"
             echo "    make generate-api-docs"
             echo "    make generate"
             echo "    make manifests"

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -52,3 +52,7 @@ jobs:
       - name: Run e2e Tests
         run: |
           make e2e-tests
+      - name: Collect Operator Logs
+        if: always()
+        run: |
+          scripts/collect-logs.sh

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -43,3 +43,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           make integration-tests
+      - name: Collect Operator Logs
+        if: always()
+        run: |
+          scripts/collect-logs.sh

--- a/scripts/collect-logs.sh
+++ b/scripts/collect-logs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+NAMESPACE=${1:-coralogix-operator-system}
+
+echo "Fetching operator logs from namespace: $NAMESPACE"
+
+# Get all pod names in the namespace
+PODS=$(kubectl get pods -n "$NAMESPACE" --no-headers -o custom-columns=":metadata.name")
+
+# If no pods are found, exit
+if [ -z "$PODS" ]; then
+    echo "Error: No pods found in namespace $NAMESPACE"
+    exit 1
+fi
+
+# Count the number of pods
+POD_COUNT=$(echo "$PODS" | wc -l)
+
+# Fail if there is more than one pod
+if [ "$POD_COUNT" -ne 1 ]; then
+    echo "Error: Expected exactly one pod, but found $POD_COUNT in namespace $NAMESPACE!"
+    exit 1
+fi
+
+# Extract the pod name correctly
+POD_NAME=$(echo "$PODS" | head -n 1)
+echo "Found operator pod: $POD_NAME"
+
+echo "=== Operator Logs for $POD_NAME ==="
+kubectl logs "$POD_NAME" -n "$NAMESPACE"
+echo "=== End of Operator Logs ==="

--- a/tests/e2e/custom_role_test.go
+++ b/tests/e2e/custom_role_test.go
@@ -38,7 +38,7 @@ var _ = Describe("CustomRole", Ordered, func() {
 		rolesClient    *cxsdk.RolesClient
 		customRoleID   uint32
 		customRole     *coralogixv1alpha1.CustomRole
-		customRoleName = "custom-role-sample"
+		customRoleName = fmt.Sprintf("custom-role-sample-%d", time.Now().Unix())
 	)
 
 	BeforeEach(func() {

--- a/tests/e2e/group_test.go
+++ b/tests/e2e/group_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Group", Ordered, func() {
 		groupID        uint32
 		groupName      = fmt.Sprintf("group-sample-%d", time.Now().Unix())
 		scopeName      = "scope-for-group"
-		customRoleName = "custom-role-for-group"
+		customRoleName = fmt.Sprintf("custom-role-for-group-%d", time.Now().Unix())
 	)
 
 	BeforeEach(func() {

--- a/tests/e2e/recording_rule_group_test.go
+++ b/tests/e2e/recording_rule_group_test.go
@@ -47,7 +47,7 @@ var _ = Describe("RecordingRuleGroupSet", Ordered, func() {
 
 	It("Should be created successfully", func(ctx context.Context) {
 		By("Creating RecordingRuleGroupSet")
-		recordingRuleGroupSetName := "recording-rule-group-set"
+		recordingRuleGroupSetName := fmt.Sprintf("recording-rule-group-set-%d", time.Now().Unix())
 		recordingRuleGroupSet = &coralogixv1alpha1.RecordingRuleGroupSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      recordingRuleGroupSetName,

--- a/tests/e2e/rule_group_test.go
+++ b/tests/e2e/rule_group_test.go
@@ -37,7 +37,7 @@ var _ = Describe("RuleGroup", Ordered, func() {
 		ruleGroupsClient *cxsdk.RuleGroupsClient
 		ruleGroupID      string
 		ruleGroup        *coralogixv1alpha1.RuleGroup
-		ruleGroupName    = "json-extract-rule"
+		ruleGroupName    = fmt.Sprintf("json-extract-rule-%d", time.Now().Unix())
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
- Use arbitrary names for resources on e2e tests, to avoid flakiness caused by conflicts.
- Remove the update check for TCO policies, as it's another atomic operation that causes flakiness.
- Upload operator pod logs after e2e and integration tests runs, to improve debugging.
- Add `go mod tidy` validation to `generate` workflow.