### PR TITLE
Improve metrics

### DIFF
--- a/api/coralogix/v1alpha1/groupversion_info.go
+++ b/api/coralogix/v1alpha1/groupversion_info.go
@@ -20,11 +20,13 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/coralogix/coralogix-operator/internal/utils"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "coralogix.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: utils.CoralogixAPIGroup, Version: utils.V1alpha1APIVersion}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/coralogix/v1beta1/alert_types.go
+++ b/api/coralogix/v1beta1/alert_types.go
@@ -2357,9 +2357,9 @@ func convertCRNameToIntegrationID(name string, properties *GetResourceRefPropert
 
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "coralogix.com",
+		Group:   utils.CoralogixAPIGroup,
 		Kind:    "OutboundWebhook",
-		Version: "v1alpha1",
+		Version: utils.V1alpha1APIVersion,
 	})
 
 	if err := coralogixreconciler.GetClient().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, u); err != nil {
@@ -2391,9 +2391,9 @@ func convertCRNameToConnectorID(name string, properties *GetResourceRefPropertie
 
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "coralogix.com",
+		Group:   utils.CoralogixAPIGroup,
 		Kind:    "Connector",
-		Version: "v1alpha1",
+		Version: utils.V1alpha1APIVersion,
 	})
 
 	if err := coralogixreconciler.GetClient().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, u); err != nil {
@@ -2420,9 +2420,9 @@ func convertCRNameToPresetID(name string, properties *GetResourceRefProperties) 
 
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "coralogix.com",
+		Group:   utils.CoralogixAPIGroup,
 		Kind:    "Preset",
-		Version: "v1alpha1",
+		Version: utils.V1alpha1APIVersion,
 	})
 
 	if err := coralogixreconciler.GetClient().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, u); err != nil {

--- a/api/coralogix/v1beta1/groupversion_info.go
+++ b/api/coralogix/v1beta1/groupversion_info.go
@@ -20,11 +20,13 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	"github.com/coralogix/coralogix-operator/internal/utils"
 )
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "coralogix.com", Version: "v1beta1"}
+	GroupVersion = schema.GroupVersion{Group: utils.CoralogixAPIGroup, Version: utils.V1beta1APIVersion}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
-	
+
 	"github.com/coralogix/coralogix-operator/internal/utils"
 )
 
@@ -48,6 +48,10 @@ func GetClient() client.Client {
 
 func InitScheme(s *runtime.Scheme) {
 	scheme = s
+}
+
+func GetScheme() *runtime.Scheme {
+	return scheme
 }
 
 // CoralogixReconciler defines the required methods for all Coralogix controllers.

--- a/internal/controller/coralogix/v1alpha1/apikey_controller.go
+++ b/internal/controller/coralogix/v1alpha1/apikey_controller.go
@@ -35,7 +35,6 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/internal/controller/clientset"
 	coralogixreconciler "github.com/coralogix/coralogix-operator/internal/controller/coralogix/coralogix-reconciler"
-	"github.com/coralogix/coralogix-operator/internal/monitoring"
 	"github.com/coralogix/coralogix-operator/internal/utils"
 )
 
@@ -77,7 +76,6 @@ func (r *ApiKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Error(err, "Error on creating ApiKey")
 			return ctrl.Result{RequeueAfter: utils.DefaultErrRequeuePeriod}, err
 		}
-		monitoring.ApiKeyInfoMetric.WithLabelValues(apiKey.Name, apiKey.Namespace).Set(1)
 		return ctrl.Result{}, nil
 	}
 
@@ -87,7 +85,6 @@ func (r *ApiKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Error(err, "Error on deleting ApiKey")
 			return ctrl.Result{RequeueAfter: utils.DefaultErrRequeuePeriod}, err
 		}
-		monitoring.ApiKeyInfoMetric.DeleteLabelValues(apiKey.Name, apiKey.Namespace)
 		return ctrl.Result{}, nil
 	}
 
@@ -97,7 +94,6 @@ func (r *ApiKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Error(err, "Error on deleting ApiKey")
 			return ctrl.Result{RequeueAfter: utils.DefaultErrRequeuePeriod}, err
 		}
-		monitoring.ApiKeyInfoMetric.DeleteLabelValues(apiKey.Name, apiKey.Namespace)
 		return ctrl.Result{}, nil
 	}
 
@@ -106,7 +102,6 @@ func (r *ApiKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		log.Error(err, "Error on updating ApiKey")
 		return ctrl.Result{RequeueAfter: utils.DefaultErrRequeuePeriod}, err
 	}
-	monitoring.ApiKeyInfoMetric.WithLabelValues(apiKey.Name, apiKey.Namespace).Set(1)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/coralogix/v1alpha1/outboundwebhook_controller.go
+++ b/internal/controller/coralogix/v1alpha1/outboundwebhook_controller.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/coralogix/coralogix-operator/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/internal/controller/clientset"
-	"github.com/coralogix/coralogix-operator/internal/monitoring"
 	util "github.com/coralogix/coralogix-operator/internal/utils"
 )
 
@@ -64,7 +63,6 @@ func (r *OutboundWebhookReconciler) HandleCreation(ctx context.Context, log logr
 		return nil, fmt.Errorf("error on creating remote outbound-webhook: %w", err)
 	}
 	log.V(1).Info("Remote outbound-webhook created", "response", protojson.Format(createResponse))
-	monitoring.OutboundWebhookInfoMetric.WithLabelValues(outboundWebhook.Name, outboundWebhook.Namespace, getWebhookType(outboundWebhook)).Set(1)
 
 	log.V(1).Info("Getting outbound-webhook from remote", "id", createResponse.Id.Value)
 	remoteOutboundWebhook, err := r.OutboundWebhooksClient.Get(ctx,
@@ -98,7 +96,6 @@ func (r *OutboundWebhookReconciler) HandleUpdate(ctx context.Context, log logr.L
 		return err
 	}
 	log.V(1).Info("Remote outbound-webhook updated", "outbound-webhook", protojson.Format(updateResponse))
-	monitoring.OutboundWebhookInfoMetric.WithLabelValues(outboundWebhook.Name, outboundWebhook.Namespace, getWebhookType(outboundWebhook)).Set(1)
 	return nil
 }
 
@@ -111,7 +108,6 @@ func (r *OutboundWebhookReconciler) HandleDeletion(ctx context.Context, log logr
 		return fmt.Errorf("error deleting remote outbound-webhook %s: %w", *outboundWebhook.Status.ID, err)
 	}
 	log.V(1).Info("outbound-webhook deleted from remote system", "id", *outboundWebhook.Status.ID)
-	monitoring.OutboundWebhookInfoMetric.WithLabelValues(outboundWebhook.Name, outboundWebhook.Namespace, getWebhookType(outboundWebhook)).Set(0)
 	return nil
 }
 

--- a/internal/controller/coralogix/v1alpha1/recordingrulegroupset_controller.go
+++ b/internal/controller/coralogix/v1alpha1/recordingrulegroupset_controller.go
@@ -29,7 +29,6 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/internal/controller/clientset"
 	"github.com/coralogix/coralogix-operator/internal/controller/coralogix/coralogix-reconciler"
-	"github.com/coralogix/coralogix-operator/internal/monitoring"
 	"github.com/coralogix/coralogix-operator/internal/utils"
 )
 
@@ -63,7 +62,6 @@ func (r *RecordingRuleGroupSetReconciler) HandleCreation(ctx context.Context, lo
 		return nil, fmt.Errorf("error on creating remote recordingRuleGroupSet: %w", err)
 	}
 	log.V(1).Info("Remote recordingRuleGroupSet created", "response", protojson.Format(createResponse))
-	monitoring.RecordingRuleGroupSetInfoMetric.WithLabelValues(recordingRuleGroupSet.Name, recordingRuleGroupSet.Namespace).Set(1)
 	recordingRuleGroupSet.Status = coralogixv1alpha1.RecordingRuleGroupSetStatus{
 		ID: &createResponse.Id,
 	}
@@ -83,7 +81,6 @@ func (r *RecordingRuleGroupSetReconciler) HandleUpdate(ctx context.Context, log 
 		return err
 	}
 	log.V(1).Info("Remote recordingRuleGroupSet updated", "recordingRuleGroupSet", protojson.Format(updateResponse))
-	monitoring.RecordingRuleGroupSetInfoMetric.WithLabelValues(recordingRuleGroupSet.Name, recordingRuleGroupSet.Namespace).Set(1)
 	return nil
 }
 
@@ -96,7 +93,6 @@ func (r *RecordingRuleGroupSetReconciler) HandleDeletion(ctx context.Context, lo
 		return fmt.Errorf("error deleting remote recordingRuleGroupSet %s: %w", *recordingRuleGroupSet.Status.ID, err)
 	}
 	log.V(1).Info("RecordingRuleGroupSet deleted from remote system", "id", *recordingRuleGroupSet.Status.ID)
-	monitoring.RecordingRuleGroupSetInfoMetric.DeleteLabelValues(recordingRuleGroupSet.Name, recordingRuleGroupSet.Namespace)
 	return nil
 }
 

--- a/internal/controller/coralogix/v1alpha1/rulegroup_controller.go
+++ b/internal/controller/coralogix/v1alpha1/rulegroup_controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
-	"github.com/coralogix/coralogix-operator/internal/monitoring"
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -58,7 +57,6 @@ func (r *RuleGroupReconciler) HandleCreation(ctx context.Context, log logr.Logge
 		return nil, fmt.Errorf("error on creating remote ruleGroup: %w", err)
 	}
 	log.V(1).Info("Remote ruleGroup created", "response", protojson.Format(createResponse))
-	monitoring.RuleGroupInfoMetric.WithLabelValues(ruleGroup.Name, ruleGroup.Namespace).Set(1)
 	ruleGroup.Status = coralogixv1alpha1.RuleGroupStatus{
 		ID: &createResponse.RuleGroup.Id.Value,
 	}
@@ -75,7 +73,6 @@ func (r *RuleGroupReconciler) HandleUpdate(ctx context.Context, log logr.Logger,
 		return err
 	}
 	log.V(1).Info("Remote ruleGroup updated", "ruleGroup", protojson.Format(updateResponse))
-	monitoring.RuleGroupInfoMetric.WithLabelValues(ruleGroup.Name, ruleGroup.Namespace).Set(1)
 	return nil
 }
 
@@ -89,7 +86,6 @@ func (r *RuleGroupReconciler) HandleDeletion(ctx context.Context, log logr.Logge
 		return fmt.Errorf("error deleting remote ruleGroup %s: %w", id, err)
 	}
 	log.V(1).Info("RuleGroup deleted from remote system", "id", id)
-	monitoring.RuleGroupInfoMetric.WithLabelValues(ruleGroup.Name, ruleGroup.Namespace).Set(0)
 	return nil
 }
 

--- a/internal/controller/coralogix/v1beta1/alert_controller.go
+++ b/internal/controller/coralogix/v1beta1/alert_controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
-	"github.com/coralogix/coralogix-operator/internal/monitoring"
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -70,7 +69,6 @@ func (r *AlertReconciler) HandleCreation(ctx context.Context, log logr.Logger, o
 		return nil, fmt.Errorf("error on creating remote alert: %w", err)
 	}
 	log.V(1).Info("Remote alert created", "response", protojson.Format(createResponse))
-	monitoring.AlertInfoMetric.WithLabelValues(alert.Name, alert.Namespace, getAlertType(alert)).Set(1)
 	alert.Status = coralogixv1beta1.AlertStatus{ID: &createResponse.AlertDef.Id.Value}
 	return alert, nil
 }
@@ -102,7 +100,6 @@ func (r *AlertReconciler) HandleUpdate(ctx context.Context, log logr.Logger, obj
 		return err
 	}
 	log.V(1).Info("Remote alert updated", "alert", protojson.Format(updateResponse))
-	monitoring.AlertInfoMetric.WithLabelValues(alert.Name, alert.Namespace, getAlertType(alert)).Set(1)
 	return nil
 }
 
@@ -115,7 +112,6 @@ func (r *AlertReconciler) HandleDeletion(ctx context.Context, log logr.Logger, o
 		return fmt.Errorf("error deleting remote alert %s: %w", *alert.Status.ID, err)
 	}
 	log.V(1).Info("Alert deleted from remote system", "id", *alert.Status.ID)
-	monitoring.AlertInfoMetric.DeleteLabelValues(alert.Name, alert.Namespace, getAlertType(alert))
 	return nil
 }
 

--- a/internal/controller/prometheusrule_controller_test.go
+++ b/internal/controller/prometheusrule_controller_test.go
@@ -34,6 +34,7 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/api/coralogix/v1alpha1"
 	coralogixv1beta1 "github.com/coralogix/coralogix-operator/api/coralogix/v1beta1"
 	coralogixreconcile "github.com/coralogix/coralogix-operator/internal/controller/coralogix/coralogix-reconciler"
+	"github.com/coralogix/coralogix-operator/internal/utils"
 )
 
 func setupReconciler(t *testing.T, ctx context.Context) (PrometheusRuleReconciler, watch.Interface) {
@@ -84,7 +85,7 @@ func TestPrometheusRulesConversionToCxParsingRules(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app.coralogix.com/track-recording-rules": "true",
+						utils.TrackPrometheusRuleRecordingRulesLabelKey: "true",
 					},
 				},
 				Spec: prometheus.PrometheusRuleSpec{
@@ -101,7 +102,7 @@ func TestPrometheusRulesConversionToCxParsingRules(t *testing.T) {
 					Name:      "new-with-rules",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app.coralogix.com/track-recording-rules": "true",
+						utils.TrackPrometheusRuleRecordingRulesLabelKey: "true",
 					},
 				},
 				Spec: prometheus.PrometheusRuleSpec{
@@ -128,7 +129,7 @@ func TestPrometheusRulesConversionToCxParsingRules(t *testing.T) {
 					Name:      "new-with-rules",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app.coralogix.com/track-recording-rules": "true",
+						utils.TrackPrometheusRuleRecordingRulesLabelKey: "true",
 					},
 				},
 				Spec: prometheus.PrometheusRuleSpec{
@@ -203,7 +204,7 @@ func TestPrometheusRulesConvertionToCxAlert(t *testing.T) {
 					Name:      "test-alert",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app.coralogix.com/track-alerting-rules": "true",
+						utils.TrackPrometheusRuleAlertsLabelKey: "true",
 					},
 				},
 				Spec: prometheus.PrometheusRuleSpec{
@@ -220,7 +221,7 @@ func TestPrometheusRulesConvertionToCxAlert(t *testing.T) {
 					Name:      "new-with-alerting-rules",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app.coralogix.com/track-alerting-rules": "true",
+						utils.TrackPrometheusRuleAlertsLabelKey: "true",
 					},
 				},
 				Spec: prometheus.PrometheusRuleSpec{
@@ -247,7 +248,7 @@ func TestPrometheusRulesConvertionToCxAlert(t *testing.T) {
 					Name:      "new-with-alerting-rules",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app.coralogix.com/track-alerting-rules": "true",
+						utils.TrackPrometheusRuleAlertsLabelKey: "true",
 					},
 				},
 				Spec: prometheus.PrometheusRuleSpec{

--- a/internal/monitoring/collectors.go
+++ b/internal/monitoring/collectors.go
@@ -1,0 +1,148 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	coralogixreconciler "github.com/coralogix/coralogix-operator/internal/controller/coralogix/coralogix-reconciler"
+	"github.com/coralogix/coralogix-operator/internal/utils"
+)
+
+func RegisterCollectors() error {
+	metricsLog.V(1).Info("Registering collectors")
+	resourceInfoCollector := NewResourceInfoCollector()
+	if err := metrics.Registry.Register(resourceInfoCollector); err != nil {
+		metricsLog.Error(err, "Failed to register collector", "collector", resourceInfoCollector)
+		return err
+	}
+	return nil
+}
+
+type ResourceInfoCollector struct {
+	resourceInfoMetric *prometheus.Desc
+	gvks               []schema.GroupVersionKind
+}
+
+func NewResourceInfoCollector() *ResourceInfoCollector {
+	return &ResourceInfoCollector{
+		resourceInfoMetric: prometheus.NewDesc(
+			"cx_operator_resource_info",
+			"Coralogix Operator custom resource information.",
+			[]string{"kind", "name", "namespace", "status"},
+			nil,
+		),
+		gvks: getGVKsToMonitor(),
+	}
+}
+
+func (c *ResourceInfoCollector) Describe(ch chan<- *prometheus.Desc) {
+	log.Log.V(1).Info("Describing metrics for ResourceInfoCollector")
+	ch <- c.resourceInfoMetric
+}
+
+func (c *ResourceInfoCollector) Collect(ch chan<- prometheus.Metric) {
+	log.Log.V(1).Info("Collecting metrics for ResourceInfoCollector")
+	for _, gvk := range c.gvks {
+		resources, err := listResourcesInGVK(gvk)
+		if err != nil {
+			log.Log.Error(err, "Failed to list resources in GVK", "gvk", gvk)
+			continue
+		}
+
+		for _, resource := range resources {
+			metric, err := prometheus.NewConstMetric(
+				c.resourceInfoMetric,
+				prometheus.GaugeValue,
+				1,
+				[]string{
+					gvk.Kind,
+					resource.GetName(),
+					resource.GetNamespace(),
+					"", // status will be extracted from the resource conditions
+				}...,
+			)
+
+			if err != nil {
+				log.Log.Error(err, "Failed to create metric for custom resource",
+					"kind", gvk.Kind,
+					"name", resource.GetName(),
+					"namespace", resource.GetNamespace(),
+				)
+				continue
+			}
+
+			ch <- metric
+		}
+	}
+}
+
+func getGVKsToMonitor() []schema.GroupVersionKind {
+	result := []schema.GroupVersionKind{
+		{Group: utils.MonitoringAPIGroup, Version: utils.V1APIVersion, Kind: utils.PrometheusRuleKind},
+		{Group: utils.MonitoringAPIGroup, Version: utils.V1alpha1APIVersion, Kind: utils.AlertmanagerConfigKind},
+	}
+
+	cxGroupVersion := schema.GroupVersion{Group: utils.CoralogixAPIGroup, Version: utils.V1alpha1APIVersion}
+	knownTypes := coralogixreconciler.GetScheme().KnownTypes(cxGroupVersion)
+	for kind := range knownTypes {
+		// Skip List types. e.g. "AlertList".
+		if strings.HasSuffix(kind, "List") {
+			continue
+		}
+		result = append(result, cxGroupVersion.WithKind(kind))
+	}
+
+	return result
+}
+
+func listResourcesInGVK(gvk schema.GroupVersionKind) ([]unstructured.Unstructured, error) {
+	resourceList := &unstructured.UnstructuredList{}
+	resourceList.SetGroupVersionKind(gvk)
+	labelSelector := utils.GetLabelFilter().Selector
+
+	if gvk.Kind == utils.AlertmanagerConfigKind {
+		req, err := labels.NewRequirement(utils.TrackAlertmanagerConfigLabelKey, selection.Equals, []string{"true"})
+		if err != nil {
+			return nil, err
+		}
+		labelSelector = labelSelector.Add(*req)
+	}
+
+	if gvk.Kind == utils.PrometheusRuleKind {
+		req, err := labels.NewRequirement(utils.TrackPrometheusRuleAlertsLabelKey, selection.Equals, []string{"true"})
+		if err != nil {
+			return nil, err
+		}
+		labelSelector = labelSelector.Add(*req)
+	}
+
+	if err := coralogixreconciler.GetClient().List(context.Background(), resourceList,
+		&client.ListOptions{LabelSelector: labelSelector}); err != nil {
+		return nil, err
+	}
+
+	return resourceList.Items, nil
+}

--- a/internal/utils/consts.go
+++ b/internal/utils/consts.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+const (
+	MonitoringAPIGroup = "monitoring.coreos.com"
+	CoralogixAPIGroup  = "coralogix.com"
+
+	V1alpha1APIVersion = "v1alpha1"
+	V1beta1APIVersion  = "v1beta1"
+	V1APIVersion       = "v1"
+
+	PrometheusRuleKind     = "PrometheusRule"
+	AlertmanagerConfigKind = "AlertmanagerConfig"
+
+	TrackPrometheusRuleAlertsLabelKey         = "app.coralogix.com/track-alerting-rules"
+	TrackPrometheusRuleRecordingRulesLabelKey = "app.coralogix.com/track-recording-rules"
+	TrackAlertmanagerConfigLabelKey           = "app.coralogix.com/track-alertmanager-config"
+	ManagedByAlertmanagerConfigLabelKey       = "app.coralogix.com/managed-by-alertmanager-config"
+)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -52,6 +52,10 @@ func (f *LabelFilter) Matches(resourceLabels map[string]string) bool {
 	return f.Selector.Matches(labels.Set(resourceLabels))
 }
 
+func (f *LabelFilter) String() string {
+	return f.Selector.String()
+}
+
 func InitLabelFilter(selector string) error {
 	parsedSelector, err := labels.Parse(selector)
 	if err != nil {

--- a/internal/webhook/coralogix/v1alpha1/apikey_webhook.go
+++ b/internal/webhook/coralogix/v1alpha1/apikey_webhook.go
@@ -81,7 +81,7 @@ func (v *ApiKeyCustomValidator) ValidateCreate(ctx context.Context, obj runtime.
 	}
 
 	if errs != nil {
-		monitoring.TotalRejectedApiKeysMetric.Inc()
+		monitoring.IncResourceRejectionsTotalMetric(apikey.Kind, apikey.Name, apikey.Namespace)
 		return warnings, errs
 	}
 	return nil, nil
@@ -110,7 +110,7 @@ func (v *ApiKeyCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newO
 	}
 
 	if errs != nil {
-		monitoring.TotalRejectedApiKeysMetric.Inc()
+		monitoring.IncResourceRejectionsTotalMetric(apikey.Kind, apikey.Name, apikey.Namespace)
 		return warnings, errs
 	}
 	return nil, nil

--- a/internal/webhook/coralogix/v1alpha1/rulegroup_webhook.go
+++ b/internal/webhook/coralogix/v1alpha1/rulegroup_webhook.go
@@ -59,7 +59,13 @@ func (v *RuleGroupCustomValidator) ValidateCreate(ctx context.Context, obj runti
 	}
 	rulegrouplog.Info("Validation for RuleGroup upon creation", "name", rulegroup.GetName())
 
-	return validateRulesTypesSet(*rulegroup)
+	warnings, err := validateRulesTypesSet(*rulegroup)
+	if err != nil {
+		monitoring.IncResourceRejectionsTotalMetric(rulegroup.Kind, rulegroup.Name, rulegroup.Namespace)
+		return warnings, fmt.Errorf("validation failed: %v", err)
+	}
+
+	return nil, nil
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type RuleGroup.
@@ -70,7 +76,13 @@ func (v *RuleGroupCustomValidator) ValidateUpdate(ctx context.Context, oldObj, n
 	}
 	rulegrouplog.Info("Validation for RuleGroup upon update", "name", rulegroup.GetName())
 
-	return validateRulesTypesSet(*rulegroup)
+	warnings, err := validateRulesTypesSet(*rulegroup)
+	if err != nil {
+		monitoring.IncResourceRejectionsTotalMetric(rulegroup.Kind, rulegroup.Name, rulegroup.Namespace)
+		return warnings, fmt.Errorf("validation failed: %v", err)
+	}
+
+	return nil, nil
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type RuleGroup.
@@ -100,7 +112,6 @@ func validateRulesTypesSet(ruleGroup coralogixv1alpha1.RuleGroup) (admission.War
 	}
 
 	if errs != nil {
-		monitoring.TotalRejectedRulesGroupsMetric.Inc()
 		return warnings, errs
 	}
 

--- a/internal/webhook/coralogix/v1beta1/alert_webhook.go
+++ b/internal/webhook/coralogix/v1beta1/alert_webhook.go
@@ -89,7 +89,7 @@ func validateAlert(alert *coralogixv1beta1.Alert) (admission.Warnings, error) {
 	}
 
 	if errs != nil {
-		monitoring.TotalRejectedAlertsMetric.Inc()
+		monitoring.IncResourceRejectionsTotalMetric(alert.Kind, alert.Name, alert.Namespace)
 	}
 	return warns, errs
 }


### PR DESCRIPTION
Added/improved metrics:

- `cx_operator_resource_info` - A gauge metric with a record per Coralogix custom resource/`PrometheusRule`/`AlertmanagerConfig` that are tracked by the operator. 
Its implementation is based on a collector that collects all k8s resources in API group `coralogix.com` (and`PrometheusRules`/`AlertmanagerConfigs`), and it is triggered when a request to the `/metrics` endpoint is made. Because it collects all Coralogix's API group resources, NO additional code is required for future Coralogix CRDs.
The status label is empty at the moment, but will be populated based on resource conditions, once they are implemented.
- `cx_operator_resource_rejections_total` - A counter metric with a record per resource, that is incremented on every coralogix-operator's validation webhook rejection.
- `cx_operator_info` a single record metric, exposing basic info about the operator's installation.

To view the metrics without an observability system, run:
`kubectl port-forward deploy/coralogix-operator-controller-manager -n coralogix-operator-system 8080:8080`

and then open `http://localhost:8080/metrics` in your browser.

Snippet example from `/metrics`:

```
# HELP cx_operator_info Coralogix Operator information.
# TYPE cx_operator_info gauge
cx_operator_info{coralogix_url="ng-api-grpc.eu2.coralogix.com:443",go_version="go1.23.6",label_selector="",operator_version="0.3.2"} 1
# HELP cx_operator_resource_info Coralogix Operator custom resource information.
# TYPE cx_operator_resource_info gauge
cx_operator_resource_info{kind="Alert",name="prometheus-example-rules-app-latency-0",namespace="default",status=""} 1
cx_operator_resource_info{kind="Alert",name="prometheus-example-rules-app-latency-1",namespace="default",status=""} 1
cx_operator_resource_info{kind="Alert",name="prometheus-example-rules-app-latency-2",namespace="default",status=""} 1
cx_operator_resource_info{kind="PrometheusRule",name="prometheus-example-rules",namespace="default",status=""} 1
cx_operator_resource_info{kind="RecordingRuleGroupSet",name="prometheus-example-rules",namespace="default",status=""} 1
cx_operator_resource_info{kind="Scope",name="scope-sample",namespace="default",status=""} 1
cx_operator_resource_info{kind="TCOLogsPolicies",name="tco-logs-policies-sample",namespace="default",status=""} 1
# HELP cx_operator_resource_rejections_total The total count of rejections by Coralogix Operator validation webhook.
# TYPE cx_operator_resource_rejections_total counter
cx_operator_resource_rejections_total{kind="OutboundWebhook",name="demisto-webhook",namespace="default"} 2
cx_operator_resource_rejections_total{kind="RuleGroup",name="block-rule",namespace="default"} 3
```