### PR TITLE
Monitoring enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: install-prometheus-crds
 install-prometheus-crds:
 	kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd-full/monitoring.coreos.com_prometheusrules.yaml
+	kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd-full/monitoring.coreos.com_servicemonitors.yaml
 
 .PHONY: install-cert-manager
 install-cert-manager:

--- a/api/coralogix/v1alpha1/alert_conversion.go
+++ b/api/coralogix/v1alpha1/alert_conversion.go
@@ -220,6 +220,7 @@ func (dst *Alert) ConvertFrom(srcRaw conversion.Hub) error {
 
 	dst.Spec.NotificationGroups = convertingNotificationGroupsV1beta1ToV1alpha1(src.Spec.NotificationGroup, src.Spec.NotificationGroupExcess)
 	dst.Status.ID = src.Status.ID
+	dst.Status.Conditions = src.Status.Conditions
 
 	return nil
 }
@@ -246,6 +247,7 @@ func (src *Alert) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.Spec = dstSpec
 	dst.Status.ID = src.Status.ID
+	dst.Status.Conditions = src.Status.Conditions
 
 	return nil
 }

--- a/charts/coralogix-operator/templates/service_monitor.yaml
+++ b/charts/coralogix-operator/templates/service_monitor.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "coralogixOperator.fullname" . }}-service-monitor
+  labels:
+    {{- include "coralogixOperator.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: http
+      scheme: http
+  selector:
+    {{- include "coralogixOperator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/coralogix-operator/values.yaml
+++ b/charts/coralogix-operator/values.yaml
@@ -22,6 +22,11 @@ serviceAccount:
 # -- Annotations to add to the operator pod
 podAnnotations: {}
 
+# -- Service monitor for Prometheus to use.
+serviceMonitor:
+  # -- Specifies whether a service monitor should be created.
+  create: true
+
 # -- SecurityContext holds pod-level security attributes and common container settings.
 # -- This defaults to non root user with uid 2000 and gid 2000. *v1.PodSecurityContext  false
 # -- ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -80,8 +85,7 @@ secret:
 
 # -- Coralogix operator container config
 coralogixOperator:
-  # Set this is to true if Prometheus Operator is installed and
-  # PrometheusRule is available in cluster.
+  # Set this to false if PrometheusRule CRD is not available in the cluster.
   prometheusRules:
     enabled: true
   # Set this is to true if you want to enable validation webhooks.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,9 +18,7 @@ bases:
 - ../manager
 - ../certmanager
 - ../webhook
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
-# [METRICS] Expose the controller manager metrics service.
+- ../prometheus
 - metrics_service.yaml
 
 patchesStrategicMerge:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -6,12 +6,12 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: servicemonitor
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/instance: service-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: coralogix-operator
     app.kubernetes.io/part-of: coralogix-operator
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-monitor
+  name: service-monitor
   namespace: system
 spec:
   endpoints:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,21 @@
+# Coralogix Operator Metrics
+
+| Name                           | Type    | Description                                                             | Labels                                                                          | 
+|--------------------------------------|---------|-------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| cx_operator_info                     | Gauge   | Coralogix Operator information.                                         | go_version, operator_version, coralogix_url, label_selector, namespace_selector |
+| cx_operator_resource_rejections_total | Counter | The total count of rejections by Coralogix Operator validation webhook. | kind, name, namespace                                                           |
+| cx_operator_resource_info            | Gauge   | Coralogix Operator custom resource information.                         | kind, name, namespace, status                                                   |
+
+## Sending Metrics to Coralogix
+The Coralogix Operator's metrics can be sent to Coralogix using Prometheus. 
+This requires configuring Prometheus to both scrape the operator's metrics and send them to Coralogix.
+### Scraping the Metrics
+By default, the Coralogix Operator is deployed with:
+- A [ServiceMonitor](../charts/coralogix-operator/templates/service_monitor.yaml) that instructs Prometheus to scrape the operator’s metrics endpoint.
+- A [ClusterRole](../charts/coralogix-operator/templates/metrics_reader_role.yaml) that grants Prometheus access to the metrics.
+    
+To ensure proper scraping:
+- Verify that Prometheus is configured to select the provided ServiceMonitor.
+- Ensure that the ClusterRole is bound to Prometheus’s ServiceAccount so it has the necessary permissions.
+### Sending the Metrics
+To forward the collected metrics to Coralogix, follow [this guide](https://coralogix.com/docs/integrations/prometheus/prometheus-server/) to configure Prometheus accordingly.


### PR DESCRIPTION
- Expose metrics to Prometheus using a ServiceMonitor.
- Populate `cx_operator_resource_info` metric `status` label based on resources status condition.
- Document metrics and how to send them to Coralogix.
- Add label and namespace selector to PrometheusRule controller.
- Add conditions to alert conversion.