### PR TITLE
fix: PrometheusRule controller to not overwrite advanced Alert fields

### DIFF
--- a/internal/controller/prometheusrule_controller.go
+++ b/internal/controller/prometheusrule_controller.go
@@ -261,10 +261,30 @@ func (r *PrometheusRuleReconciler) convertPrometheusRuleAlertToCxAlert(ctx conte
 				updated = true
 			}
 
-			desiredSpec := prometheusAlertingRuleToAlertSpec(&rule)
-			if !reflect.DeepEqual(alert.Spec, desiredSpec) {
-				alert.Spec = desiredSpec
+			desiredDescription := rule.Annotations["description"]
+			if alert.Spec.Description != desiredDescription {
+				alert.Spec.Description = desiredDescription
 				updated = true
+			}
+
+			desiredEntityLabels := rule.Labels
+			if !reflect.DeepEqual(alert.Spec.EntityLabels, desiredEntityLabels) {
+				alert.Spec.EntityLabels = desiredEntityLabels
+				updated = true
+			}
+
+			desiredPriority := getPriority(rule)
+			if alert.Spec.Priority != desiredPriority {
+				alert.Spec.Priority = desiredPriority
+				updated = true
+			}
+
+			desiredTypeDefinition := coralogixv1beta1.AlertTypeDefinition{
+				MetricThreshold: prometheusAlertToMetricThreshold(rule),
+			}
+			desiredTypeDefinition.MetricThreshold.MissingValues.MinNonNullValuesPct = alert.Spec.TypeDefinition.MetricThreshold.MissingValues.MinNonNullValuesPct
+			if !reflect.DeepEqual(alert.Spec.TypeDefinition, desiredTypeDefinition) {
+				alert.Spec.TypeDefinition = desiredTypeDefinition
 			}
 
 			if updated {


### PR DESCRIPTION
In https://github.com/coralogix/coralogix-operator/pull/278, I accidentally changed the PrometheusRule controller to overwrite all the Alert Spec, which deletes its advanced fields that user may already started to use.

In this PR I fix it and add a test for it.