### PR TITLE
Add notification center feature flag

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,6 +21,7 @@ jobs:
       CORALOGIX_REGION: ${{ secrets.CORALOGIX_REGION }}
       CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
       ENABLE_WEBHOOKS: true
+      ENABLE_NOTIFICATION_CENTER: true
       SCOPE_RECONCILE_INTERVAL_SECONDS: 30
     steps:
       - name: Checkout

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -49,6 +49,7 @@ jobs:
             --set coralogixOperator.image.tag="${{ env.IMG_TAG }}" \
             --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}" \
             --set coralogixOperator.webhooks.enabled=true \
+            --set coralogixOperator.notificationCenter.enabled=true \
             --set coralogixOperator.reconcileIntervalSeconds.scope=30
       - name: Run e2e Tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ e2e-tests:
 
 .PHONY: helm-sync-check
 helm-sync-check:
-	sh scripts/helm-sync-check.sh
+	bash scripts/helm-sync-check.sh
 
 .PHONY: helm-update-crds
 helm-update-crds:

--- a/api/coralogix/v1beta1/alert_types.go
+++ b/api/coralogix/v1beta1/alert_types.go
@@ -1164,9 +1164,16 @@ func expandNotificationGroup(notificationGroup *NotificationGroup, listingAlerts
 		return nil, fmt.Errorf("failed to expand webhooks settings: %w", err)
 	}
 
-	destinations, err := expandDestinations(notificationGroup.Destinations, listingAlertsAndWebhooksProperties)
-	if err != nil {
-		return nil, fmt.Errorf("failed to expand destinations: %w", err)
+	var destinations []*cxsdk.NotificationDestination
+	if notificationGroup.Destinations != nil {
+		if config.GetConfig().EnableNotificationCenter {
+			destinations, err = expandDestinations(notificationGroup.Destinations, listingAlertsAndWebhooksProperties)
+			if err != nil {
+				return nil, fmt.Errorf("failed to expand destinations: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("destinations cannot be set when notification center is disabled")
+		}
 	}
 
 	return &cxsdk.AlertDefNotificationGroup{

--- a/charts/coralogix-operator/templates/cluster_role.yaml
+++ b/charts/coralogix-operator/templates/cluster_role.yaml
@@ -76,32 +76,6 @@ rules:
 - apiGroups:
   - coralogix.com
   resources:
-  - presets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - coralogix.com
-  resources:
-  - presets/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - coralogix.com
-  resources:
-  - presets/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - coralogix.com
-  resources:
   - recordingrulegroupsets
   verbs:
   - create
@@ -151,6 +125,7 @@ rules:
   - get
   - patch
   - update
+{{- if .Values.coralogixOperator.notificationCenter.enabled }}
 - apiGroups:
   - coralogix.com
   resources:
@@ -180,7 +155,7 @@ rules:
 - apiGroups:
   - coralogix.com
   resources:
-  - customroles
+  - presets
   verbs:
   - create
   - delete
@@ -192,16 +167,8 @@ rules:
 - apiGroups:
   - coralogix.com
   resources:
-  - customroles/finalizers
+  - presets/finalizers
   verbs:
-  - update
-- apiGroups:
-  - coralogix.com
-  resources:
-  - customroles/status
-  verbs:
-  - get
-  - patch
   - update
 - apiGroups:
   - coralogix.com
@@ -225,6 +192,41 @@ rules:
   - coralogix.com
   resources:
   - globalrouters/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}
+- apiGroups:
+  - coralogix.com
+  resources:
+  - presets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coralogix.com
+  resources:
+  - customroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coralogix.com
+  resources:
+  - customroles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - coralogix.com
+  resources:
+  - customroles/status
   verbs:
   - get
   - patch

--- a/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.coralogixOperator.notificationCenter.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -235,3 +236,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/coralogix-operator/templates/crds/coralogix.com_globalrouters.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_globalrouters.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.coralogixOperator.notificationCenter.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -237,3 +238,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.coralogixOperator.notificationCenter.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -220,3 +221,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/coralogix-operator/templates/deployment.yaml
+++ b/charts/coralogix-operator/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
         - -enable-webhooks={{.Values.coralogixOperator.webhooks.enabled }}
         - -label-selector={{ .Values.coralogixOperator.labelSelector }}
         - -namespace-selector={{ .Values.coralogixOperator.namespaceSelector }}
+        - -enable-notification-center={{ .Values.coralogixOperator.notificationCenter.enabled }}
 {{- range $key, $value := .Values.coralogixOperator.reconcileIntervalSeconds }}
         - -{{ lower $key }}-reconcile-interval-seconds={{ $value }}
 {{- end }}

--- a/charts/coralogix-operator/templates/webhook.yaml
+++ b/charts/coralogix-operator/templates/webhook.yaml
@@ -28,6 +28,7 @@ webhooks:
         resources:
           - apikeys
     sideEffects: None
+  {{- if .Values.coralogixOperator.notificationCenter.enabled }}
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -68,6 +69,7 @@ webhooks:
         resources:
           - presets
     sideEffects: None
+  {{- end }}
   - admissionReviewVersions:
       - v1
     clientConfig:

--- a/charts/coralogix-operator/values.yaml
+++ b/charts/coralogix-operator/values.yaml
@@ -88,10 +88,16 @@ coralogixOperator:
   # Set this to false if PrometheusRule CRD is not available in the cluster.
   prometheusRules:
     enabled: true
-  # Set this is to true if you want to enable validation webhooks.
-  # It assumes you have cert-manager installed in your cluster.
+
+  # Set this to false if you want to disable validation and conversion webhooks.
+  # Leaving true assumes you have cert-manager installed in your cluster.
   webhooks:
     enabled: true
+
+  # Set this to true if you want to enable the notification center CRDs and controllers.
+  notificationCenter:
+    enabled: false
+
   # --  Coralogix operator Image
   image:
     repository: coralogixrepo/coralogix-operator

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -113,7 +113,7 @@ func main() {
 	}
 
 	// Check if webhooks are enabled before setting up the webhook server
-	if cfg.EnableWebhooks != "false" {
+	if cfg.EnableWebhooks {
 		mgrOpts.WebhookServer = webhook.NewServer(webhook.Options{
 			TLSOpts: tlsOpts,
 		})
@@ -221,29 +221,32 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Integration")
 		os.Exit(1)
 	}
-	if err = (&v1alpha1controllers.ConnectorReconciler{
-		NotificationsClient: clientSet.Notifications(),
-		Interval:            cfg.ReconcileIntervals[utils.ConnectorKind],
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Connector")
-		os.Exit(1)
-	}
-	if err = (&v1alpha1controllers.PresetReconciler{
-		NotificationsClient: clientSet.Notifications(),
-		Interval:            cfg.ReconcileIntervals[utils.PresetKind],
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Preset")
-		os.Exit(1)
-	}
-	if err = (&v1alpha1controllers.GlobalRouterReconciler{
-		NotificationsClient: clientSet.Notifications(),
-		Interval:            cfg.ReconcileIntervals[utils.GlobalRouterKind],
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "GlobalRouter")
-		os.Exit(1)
+
+	if cfg.EnableNotificationCenter {
+		if err = (&v1alpha1controllers.ConnectorReconciler{
+			NotificationsClient: clientSet.Notifications(),
+			Interval:            cfg.ReconcileIntervals[utils.ConnectorKind],
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Connector")
+			os.Exit(1)
+		}
+		if err = (&v1alpha1controllers.PresetReconciler{
+			NotificationsClient: clientSet.Notifications(),
+			Interval:            cfg.ReconcileIntervals[utils.PresetKind],
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Preset")
+			os.Exit(1)
+		}
+		if err = (&v1alpha1controllers.GlobalRouterReconciler{
+			NotificationsClient: clientSet.Notifications(),
+			Interval:            cfg.ReconcileIntervals[utils.GlobalRouterKind],
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "GlobalRouter")
+			os.Exit(1)
+		}
 	}
 
-	if cfg.EnableWebhooks != "false" {
+	if cfg.EnableWebhooks {
 		if err = webhookcoralogixv1alpha1.SetupOutboundWebhookWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "OutboundWebhook")
 			os.Exit(1)
@@ -263,13 +266,16 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "Alert")
 			os.Exit(1)
 		}
-		if err = webhookcoralogixv1alpha1.SetupConnectorWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Connector")
-			os.Exit(1)
-		}
-		if err = webhookcoralogixv1alpha1.SetupPresetWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "Preset")
-			os.Exit(1)
+
+		if cfg.EnableNotificationCenter {
+			if err = webhookcoralogixv1alpha1.SetupConnectorWebhookWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "Connector")
+				os.Exit(1)
+			}
+			if err = webhookcoralogixv1alpha1.SetupPresetWebhookWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "Preset")
+				os.Exit(1)
+			}
 		}
 	} else {
 		setupLog.Info("Webhooks are disabled")

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,6 +79,7 @@ spec:
         - --label-selector=${LABEL_SELECTOR}
         - --namespace-selector=${NAMESPACE_SELECTOR}
         - --enable-webhooks=${ENABLE_WEBHOOKS}
+        - --enable-notification-center=${ENABLE_NOTIFICATION_CENTER}
         - --scope-reconcile-interval-seconds=${SCOPE_RECONCILE_INTERVAL_SECONDS}
         name: manager
         image: controller

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,7 +73,8 @@ type Config struct {
 	CoralogixUrl                string
 	Selector                    *Selector
 	ReconcileIntervals          map[string]time.Duration
-	EnableWebhooks              string
+	EnableWebhooks              bool
+	EnableNotificationCenter    bool
 	PrometheusRuleController    bool
 	RecordingRuleGroupSetSuffix string
 	MetricsAddr                 string
@@ -115,8 +116,11 @@ func InitConfig(setupLog logr.Logger) *Config {
 		flag.StringVar(&namespaceSelector, "namespace-selector", namespaceSelector, "A list of namespaces to filter custom resources.")
 
 		enableWebhooks := os.Getenv("ENABLE_WEBHOOKS")
-		flag.StringVar(&cfg.EnableWebhooks, "enable-webhooks", enableWebhooks, "Enable webhooks for the operator. Default is true.")
-		enableWebhooks = strings.ToLower(enableWebhooks)
+		flag.StringVar(&enableWebhooks, "enable-webhooks", enableWebhooks, "Enable webhooks for the operator. Default is true.")
+
+		enableNotificationCenter := os.Getenv("ENABLE_NOTIFICATION_CENTER")
+		flag.StringVar(&enableNotificationCenter, "enable-notification-center", enableNotificationCenter,
+			"Enable notification center CRDs and controllers. Default is false.")
 
 		reconcileIntervals := getReconcileIntervals()
 
@@ -144,6 +148,9 @@ func InitConfig(setupLog logr.Logger) *Config {
 			setupLog.Error(err, "invalid arguments for running operator")
 			os.Exit(1)
 		}
+
+		cfg.EnableWebhooks = strings.ToLower(enableWebhooks) != "false"
+		cfg.EnableNotificationCenter = strings.ToLower(enableNotificationCenter) == "true"
 
 		cfg.ReconcileIntervals, err = parseReconcileIntervals(setupLog, reconcileIntervals)
 		if err != nil {

--- a/scripts/helm-sync-check.sh
+++ b/scripts/helm-sync-check.sh
@@ -12,6 +12,12 @@ chart_webhook_file="charts/coralogix-operator/templates/webhook.yaml"
 
 errors_found=0
 
+nc_crds=(
+    "coralogix.com_connectors.yaml"
+    "coralogix.com_presets.yaml"
+    "coralogix.com_globalrouters.yaml"
+)
+
 echo "Validating CRDs..."
 
 # Validate CRDs
@@ -28,9 +34,19 @@ for crd_file in $crds_files; do
     chart_crd_file="$chart_crds_path/$crd_filename"
 
     if [ -f "$chart_crd_file" ]; then
-        if ! cmp -s "$crd_file" "$chart_crd_file"; then
-            echo "CRD file $chart_crd_file is outdated, please run make helm-update-crds"
-            errors_found=$((errors_found + 1))
+        if [[ " ${nc_crds[*]} " =~ " $crd_filename " ]]; then
+            # Ignore first and last lines for NC CRDs in the Helm chart
+            original_content=$(sed '1d;$d' "$chart_crd_file")
+            if ! diff <(echo "$original_content") "$crd_file" >/dev/null; then
+                echo "CRD file $chart_crd_file is outdated, please run make helm-update-crds"
+                errors_found=$((errors_found + 1))
+            fi
+        else
+            # Regular comparison for all other CRDs
+            if ! cmp -s "$crd_file" "$chart_crd_file"; then
+                echo "CRD file $chart_crd_file is outdated, please run make helm-update-crds"
+                errors_found=$((errors_found + 1))
+            fi
         fi
     else
         echo "CRD file $chart_crd_file is missing in the Helm chart. Please run make helm-update-crds"


### PR DESCRIPTION
Due to Notification center (NC) API instability, future breaking changes in the CRDs are expected.
This PR disables NC CRDs, controllers, webhooks and RBAC by default, allowing users to opt-in by setting: `coralogixOperator.notificationCenter.enabled=true`