### PR TITLE
fix presets/status role location

### DIFF
--- a/charts/coralogix-operator/templates/cluster_role.yaml
+++ b/charts/coralogix-operator/templates/cluster_role.yaml
@@ -173,6 +173,14 @@ rules:
 - apiGroups:
   - coralogix.com
   resources:
+  - presets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - coralogix.com
+  resources:
   - globalrouters
   verbs:
   - create
@@ -197,14 +205,6 @@ rules:
   - patch
   - update
 {{- end }}
-- apiGroups:
-  - coralogix.com
-  resources:
-  - presets/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - coralogix.com
   resources:


### PR DESCRIPTION
`presets/status` role was accidentally left outside of the
```yaml
{{- if .Values.coralogixOperator.notificationCenter.enabled }}`
...
{{- end }}
```
which left it there even when the user doesn't enable NC (and there is no such thing as Preset on the cluster).
It had no functional impact because k8s doesn't validate that, but it can be confusing for users.
