### PR TITLE
Avoid duplications in case status update failed

### DIFF
--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
@@ -68,6 +68,11 @@ func ReconcileResource(ctx context.Context, req ctrl.Request, obj client.Object,
 		}
 
 		if err = config.GetClient().Status().Update(ctx, obj); err != nil {
+			log.Error(err, "Error updating status after creation; handling deletion")
+			if err2 := r.HandleDeletion(ctx, log, obj); err2 != nil {
+				log.Error(err2, "Error deleting from remote after status update failure")
+				return ManageErrorWithRequeue(ctx, log, obj, utils.ReasonRemoteDeletionFailed, err2)
+			}
 			return ManageErrorWithRequeue(ctx, log, obj, utils.ReasonInternalK8sError, err)
 		}
 

--- a/internal/utils/conditions.go
+++ b/internal/utils/conditions.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	ReasonRemoteSyncPending         = "RemoteSyncPending"
 	ReasonRemoteCreatedSuccessfully = "RemoteCreatedSuccessfully"
 	ReasonRemoteCreationFailed      = "RemoteCreationFailed"
 	ReasonRemoteUpdatedSuccessfully = "RemoteUpdatedSuccessfully"


### PR DESCRIPTION
Before the common reconciler was introduced, we used to delete the remote resource if we failed to store its ID in the resource status. It was important in order to avoid creating duplicated remote resources in case the status update fails.