### PR TITLE
Add a debugging CLI tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/client-go v0.32.2
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
 	sigs.k8s.io/controller-runtime v0.19.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -99,5 +100,4 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/tools/cxo-observer/README.md
+++ b/tools/cxo-observer/README.md
@@ -1,0 +1,77 @@
+# cxo-observer
+
+## Overview
+`cxo-observer` is a CLI tool that collects Kubernetes resources related to the Coralogix Operator installation, 
+including both core operator components and custom resources (CRs) managed by the operator.
+It is useful for support, debugging, and exporting the current state of your Coralogix Operator installation.  
+The output is compressed into a `.tar.gz` file containing YAML files organized by 
+resource group, version, kind, and namespace, to be easily inspected and shared.
+
+Support requests and issues reports should include the output of this tool, including the affected resources.
+
+### Features
+- Collects Kubernetes resources created by the Coralogix Helm chart (e.g. Deployment, CRDs, ServiceAccount).
+- Collects Coralogix custom resources across the entire cluster by default,
+  with optional filtering by namespace and label selectors.
+
+---
+## Installation
+### Prerequisites
+- [Go](https://golang.org/doc/install) 1.16 or later
+
+```bash
+go install github.com/coralogix/coralogix-operator/tools/cxo-observer@<your-operator-version>
+```
+
+## Usage
+
+```bash
+cxo-observer [flags]
+```
+
+Example:
+```bash
+cxo-observer --chart-namespace=observability --namespace-selector=production,staging --label-selector=team=backend,app=api
+```
+If no `--namespace-selector` nor `--label-selector` is provided, all custom resources across the entire cluster will be collected.
+
+### Flags
+```bash
+$ cxo-observer -h
+Usage of cxo-observer:
+  -chart-name string
+        The name of Coralogix Operator Helm chart release. (default "coralogix-operator")
+  -chart-namespace string
+        The namespace of Coralogix Operator Helm chart release.
+  -kubeconfig string
+        Paths to a kubeconfig. Only required if out-of-cluster.
+  -label-selector string
+        A comma-separated list of key=value labels to filter custom resources.
+  -namespace-selector string
+        A comma-separated list of namespaces to filter custom resources.
+  -zap-devel
+        Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
+  -zap-encoder value
+        Zap log encoding (one of 'json' or 'console')
+  -zap-log-level value
+        Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+  -zap-stacktrace-level value
+        Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
+  -zap-time-encoding value
+        Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
+```
+
+### Output Structure
+```text
+output/
+├── operator-resources/
+│   ├── crds/
+│   │   ├── <crd-name>.yaml
+│   │   └── ...
+│   ├── deployment.yaml
+│   ├── service.yaml   
+│   └── ...
+└── custom-resources/
+    ├── <namespace>/
+    │   └── <group>/<version>/<kind>/<name>.yaml
+```

--- a/tools/cxo-observer/collector.go
+++ b/tools/cxo-observer/collector.go
@@ -1,0 +1,127 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	"github.com/coralogix/coralogix-operator/internal/utils"
+)
+
+func collectOperatorResource(ctx context.Context, log logr.Logger, gvk schema.GroupVersionKind, name string) error {
+	log.V(1).Info("Collecting resource", "kind", gvk.Kind, "name", name)
+
+	resource := &unstructured.Unstructured{}
+	resource.SetGroupVersionKind(gvk)
+	if err := cfg.Client.Get(ctx, client.ObjectKey{Name: name, Namespace: cfg.ChartNamespace}, resource); err != nil {
+		return fmt.Errorf("failed to get resource: %w", err)
+	}
+
+	dir := filepath.Join("temp", "cxo-observer", "operator-resources")
+	fileName := strings.ToLower(resource.GetKind())
+	if gvk.Kind == crdKind {
+		dir = filepath.Join("temp", "cxo-observer", "operator-resources", "crds")
+		fileName = strings.ToLower(resource.GetName())
+	}
+
+	if err := dumpResource(resource, dir, fileName); err != nil {
+		return fmt.Errorf("failed to dump resource: %w", err)
+	}
+
+	return nil
+}
+
+func collectCRsInNamespace(ctx context.Context, log logr.Logger, ns string) error {
+	if ns == "" {
+		log.Info("Collecting custom resources in all namespaces")
+	} else {
+		log.Info("Collecting custom resources in namespace", "namespace", ns)
+	}
+	gvks := utils.GetGVKs(scheme)
+	for _, gvk := range gvks {
+		if err := collectGvkCRs(ctx, log, ns, gvk); err != nil {
+			return fmt.Errorf("failed to collect %s CRs in namespace %s: %w", gvk.Kind, ns, err)
+		}
+	}
+	return nil
+}
+
+func collectGvkCRs(ctx context.Context, log logr.Logger, ns string, gvk schema.GroupVersionKind) error {
+	log.V(1).Info("Collecting CRs", "kind", gvk.Kind, "namespace", ns)
+
+	resources := &unstructured.UnstructuredList{}
+	resources.SetGroupVersionKind(gvk)
+	labelSelector := cfg.Selector.LabelSelector
+	if gvk.Kind == utils.PrometheusRuleKind {
+		req, err := labels.NewRequirement(utils.TrackPrometheusRuleAlertsLabelKey, selection.Equals, []string{"true"})
+		if err != nil {
+			return fmt.Errorf("failed to create label requirement: %w", err)
+		}
+		labelSelector = labelSelector.Add(*req)
+	}
+
+	listOpts := &client.ListOptions{LabelSelector: labelSelector}
+	if ns != "" {
+		listOpts.Namespace = ns
+	}
+
+	if err := cfg.Client.List(ctx, resources, listOpts); err != nil {
+		return fmt.Errorf("failed to list resources: %w", err)
+	}
+
+	for _, resource := range resources.Items {
+		path := filepath.Join(
+			"temp", "cxo-observer", "custom-resources",
+			resource.GetNamespace(),
+			strings.ToLower(gvk.Group),
+			strings.ToLower(gvk.Version),
+			strings.ToLower(gvk.Kind))
+		if err := dumpResource(&resource, path, resource.GetName()); err != nil {
+			return fmt.Errorf("failed to dump resource: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func dumpResource(resource *unstructured.Unstructured, dir, fileName string) error {
+	data, err := yaml.Marshal(resource)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resource: %w", err)
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	filePath := filepath.Join(dir, fileName+".yaml")
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write file %s: %w", filePath, err)
+	}
+
+	return nil
+}

--- a/tools/cxo-observer/config.go
+++ b/tools/cxo-observer/config.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/coralogix/coralogix-operator/internal/utils"
+)
+
+var (
+	cfg = &Config{
+		Selector: &Selector{
+			LabelSelector: labels.Everything(),
+		},
+	}
+	once sync.Once
+)
+
+type Config struct {
+	ChartName      string
+	ChartNamespace string
+	GVKs           []schema.GroupVersionKind
+	Selector       *Selector
+	Client         client.Client
+}
+
+func initConfig(log logr.Logger) {
+	once.Do(func() {
+		var err error
+		var namespaceSelector string
+		var labelSelector string
+		flag.StringVar(&cfg.ChartName, "chart-name", "coralogix-operator",
+			"The name of Coralogix Operator Helm chart release.")
+		flag.StringVar(&cfg.ChartNamespace, "chart-namespace", "",
+			"The namespace of Coralogix Operator Helm chart release.")
+		flag.StringVar(&namespaceSelector, "namespace-selector", "",
+			"A comma-separated list of namespaces to filter custom resources.")
+		flag.StringVar(&labelSelector, "label-selector", labelSelector,
+			"A comma-separated list of key=value labels to filter custom resources.")
+		flag.Usage = func() {
+			fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+			flag.PrintDefaults()
+		}
+
+		opts := zap.Options{}
+		opts.BindFlags(flag.CommandLine)
+		flag.Parse()
+
+		ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+		if cfg.ChartNamespace == "" {
+			log.Error(errors.New("chart-namespace is required"), "Failed to initialize config")
+			os.Exit(1)
+		}
+
+		cfg.Client, err = getClient()
+		if err != nil {
+			log.Error(err, "Failed to initialize client")
+			os.Exit(1)
+		}
+
+		cfg.GVKs = utils.GetGVKs(scheme)
+
+		cfg.Selector, err = parseSelector(labelSelector, namespaceSelector)
+		if err != nil {
+			log.Error(err, "Failed to parse selector")
+			os.Exit(1)
+		}
+	})
+}
+
+func getClient() (client.Client, error) {
+	var err error
+	c, err := client.New(config.GetConfigOrDie(), client.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/tools/cxo-observer/consts.go
+++ b/tools/cxo-observer/consts.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+const (
+	coreAPIGroup          = ""
+	appsAPIGroup          = "apps"
+	rbacAPIGroup          = "rbac.authorization.k8s.io"
+	apiExtensionsAPIGroup = "apiextensions.k8s.io"
+	certManagerAPIGroup   = "cert-manager.io"
+	admissionAPIGroup     = "admissionregistration.k8s.io"
+
+	deploymentKind         = "Deployment"
+	serviceKind            = "Service"
+	serviceAccountKind     = "ServiceAccount"
+	clusterRoleKind        = "ClusterRole"
+	clusterRoleBindingKind = "ClusterRoleBinding"
+	validatingWebhookKind  = "ValidatingWebhookConfiguration"
+	certificateKind        = "Certificate"
+	issuerKind             = "Issuer"
+	crdKind                = "CustomResourceDefinition"
+)

--- a/tools/cxo-observer/main.go
+++ b/tools/cxo-observer/main.go
@@ -1,0 +1,185 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/coralogix/coralogix-operator/api/coralogix/v1alpha1"
+	"github.com/coralogix/coralogix-operator/api/coralogix/v1beta1"
+	"github.com/coralogix/coralogix-operator/internal/utils"
+)
+
+var (
+	scheme = k8sruntime.NewScheme()
+	log    = ctrl.Log.WithName("cxo-observer")
+)
+
+func init() {
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+}
+
+func main() {
+	ctx := context.Background()
+	initConfig(log)
+
+	log.Info("Collecting resources that are part of the operator installation")
+	log.V(1).Info("Collecting Deployment")
+	depGvk := schema.GroupVersionKind{
+		Group:   appsAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    deploymentKind,
+	}
+	if err := collectOperatorResource(ctx, log, depGvk, cfg.ChartName); err != nil {
+		log.Error(err, "Failed to collect Deployment")
+	}
+
+	log.V(1).Info("Collecting Service")
+	svcGvk := schema.GroupVersionKind{
+		Group:   coreAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    serviceKind,
+	}
+	if err := collectOperatorResource(ctx, log, svcGvk, cfg.ChartName); err != nil {
+		log.Error(err, "Failed to collect Service")
+	}
+
+	log.V(1).Info("Collecting ServiceAccount")
+	saGvk := schema.GroupVersionKind{
+		Group:   coreAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    serviceAccountKind,
+	}
+	if err := collectOperatorResource(ctx, log, saGvk, cfg.ChartName); err != nil {
+		log.Error(err, "Failed to collect ServiceAccount")
+	}
+
+	log.V(1).Info("Collecting ClusterRole")
+	crGvk := schema.GroupVersionKind{
+		Group:   rbacAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    clusterRoleKind,
+	}
+	if err := collectOperatorResource(ctx, log, crGvk, cfg.ChartName); err != nil {
+		log.Error(err, "Failed to collect ClusterRole")
+	}
+
+	log.V(1).Info("Collecting ClusterRoleBinding")
+	crbGvk := schema.GroupVersionKind{
+		Group:   rbacAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    clusterRoleBindingKind,
+	}
+	if err := collectOperatorResource(ctx, log, crbGvk, cfg.ChartName); err != nil {
+		log.Error(err, "Failed to collect ClusterRoleBinding")
+	}
+
+	log.V(1).Info("Collecting ValidatingWebhookConfiguration")
+	webhookGvk := schema.GroupVersionKind{
+		Group:   admissionAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    validatingWebhookKind,
+	}
+	if err := collectOperatorResource(ctx, log, webhookGvk, cfg.ChartName+"-webhook"); err != nil {
+		log.Error(err, "Failed to collect ValidatingWebhookConfiguration")
+	}
+
+	log.V(1).Info("Collecting Certificate")
+	certGvk := schema.GroupVersionKind{
+		Group:   certManagerAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    certificateKind,
+	}
+	if err := collectOperatorResource(ctx, log, certGvk, cfg.ChartName+"-serving-cert"); err != nil {
+		log.Error(err, "Failed to collect Certificate")
+	}
+
+	log.V(1).Info("Collecting Issuer")
+	issuerGvk := schema.GroupVersionKind{
+		Group:   certManagerAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    issuerKind,
+	}
+	if err := collectOperatorResource(ctx, log, issuerGvk, "selfsigned-issuer"); err != nil {
+		log.Error(err, "Failed to collect Issuer")
+	}
+
+	log.V(1).Info("Collecting CRDs")
+	crdGVK := schema.GroupVersionKind{
+		Group:   apiExtensionsAPIGroup,
+		Version: utils.V1APIVersion,
+		Kind:    crdKind,
+	}
+	for _, gvk := range cfg.GVKs {
+		crdName := strings.ToLower(gvk.Kind) + "s.coralogix.com"
+		if gvk.Kind == utils.TCOLogsPoliciesKind || gvk.Kind == utils.TCOTracesPoliciesKind {
+			crdName = strings.ToLower(gvk.Kind) + ".coralogix.com"
+		}
+		if gvk.Kind == utils.PrometheusRuleKind {
+			crdName = strings.ToLower(gvk.Kind) + "s.monitoring.coreos.com"
+		}
+
+		if err := collectOperatorResource(ctx, log, crdGVK, crdName); err != nil {
+			log.Error(err, "Failed to collect CRD", "crd", crdName)
+		}
+	}
+
+	log.Info("Collecting custom resources")
+	for _, ns := range cfg.Selector.NamespaceSelector {
+		if err := collectCRsInNamespace(ctx, log, ns); err != nil {
+			log.Error(err, "Failed to collect custom resources in namespace", "namespace", ns)
+		}
+	}
+
+	if err := compress(); err != nil {
+		log.Error(err, "Failed to compress output dir")
+	}
+}
+
+func compress() error {
+	absPath, err := filepath.Abs(filepath.Join("temp", "cxo-observer"))
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %w", err)
+	}
+
+	parentDir := filepath.Dir(absPath)
+	baseName := filepath.Base(absPath)
+	archivePath := filepath.Join(".", "cxo-observer.tar.gz")
+
+	cmd := exec.Command("tar", "-czf", archivePath, "-C", parentDir, baseName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create archive: %w", err)
+	}
+
+	if err := os.RemoveAll(parentDir); err != nil {
+		return fmt.Errorf("failed to remove original dir: %w", err)
+	}
+
+	return nil
+}

--- a/tools/cxo-observer/selector.go
+++ b/tools/cxo-observer/selector.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type Selector struct {
+	LabelSelector     labels.Selector
+	NamespaceSelector []string
+}
+
+func (s *Selector) Matches(resourceLabels map[string]string, namespace string) bool {
+	return s.LabelSelector.Matches(labels.Set(resourceLabels)) && s.MatchesNamespace(namespace)
+}
+
+func (s *Selector) MatchesNamespace(namespace string) bool {
+	if len(s.NamespaceSelector) == 0 {
+		return true
+	}
+	for _, ns := range s.NamespaceSelector {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+func parseSelector(labelSelector, namespaceSelector string) (*Selector, error) {
+	parsedLabelSelector, err := labels.Parse(labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse label selector: %w", err)
+	}
+
+	return &Selector{
+		LabelSelector:     parsedLabelSelector,
+		NamespaceSelector: parseNamespaceSelector(namespaceSelector),
+	}, nil
+}
+
+func parseNamespaceSelector(namespaceSelector string) []string {
+	trimmed := strings.TrimSpace(namespaceSelector)
+	if trimmed == "" {
+		return []string{""} // empty string means "all namespaces"
+	}
+
+	var namespaceList []string
+	for _, ns := range strings.Split(trimmed, ",") {
+		ns = strings.TrimSpace(ns)
+		if ns != "" {
+			namespaceList = append(namespaceList, ns)
+		}
+	}
+
+	return namespaceList
+}


### PR DESCRIPTION
This PR adds a CLI tool named  `cxo-observer` that collects Kubernetes resources related to the Coralogix Operator installation, including both core operator components and custom resources managed by the operator.
