### PR TITLE
fix: AlertScheduler fields should be required

### DIFF
--- a/api/coralogix/v1alpha1/alertscheduler_types.go
+++ b/api/coralogix/v1alpha1/alertscheduler_types.go
@@ -50,12 +50,10 @@ type AlertSchedulerSpec struct {
 
 	// Alert Scheduler filter. Exactly one of `metaLabels` or `alerts` can be set.
 	// If none of them set, all alerts will be affected.
-	// +optional
-	Filter *Filter `json:"filter,omitempty"`
+	Filter *Filter `json:"filter"`
 
 	// Alert Scheduler schedule. Exactly one of `oneTime` or `recurring` must be set.
-	// +optional
-	Schedule *Schedule `json:"schedule,omitempty"`
+	Schedule *Schedule `json:"schedule"`
 }
 
 type Filter struct {

--- a/charts/coralogix-operator/templates/crds/coralogix.com_alertschedulers.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_alertschedulers.yaml
@@ -276,7 +276,9 @@ spec:
                 - operation
                 type: object
             required:
+            - filter
             - name
+            - schedule
             type: object
           status:
             description: AlertSchedulerStatus defines the observed state of AlertScheduler.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,7 +50,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "0.3.6"
+const OperatorVersion = "0.4.0"
 
 var (
 	scheme   = k8sruntime.NewScheme()

--- a/config/crd/bases/coralogix.com_alertschedulers.yaml
+++ b/config/crd/bases/coralogix.com_alertschedulers.yaml
@@ -276,7 +276,9 @@ spec:
                 - operation
                 type: object
             required:
+            - filter
             - name
+            - schedule
             type: object
           status:
             description: AlertSchedulerStatus defines the observed state of AlertScheduler.

--- a/docs/api.md
+++ b/docs/api.md
@@ -2564,10 +2564,25 @@ It is used to suppress or activate alerts based on a schedule.
         </tr>
     </thead>
     <tbody><tr>
+        <td><b><a href="#alertschedulerspecfilter">filter</a></b></td>
+        <td>object</td>
+        <td>
+          Alert Scheduler filter. Exactly one of `metaLabels` or `alerts` can be set.
+If none of them set, all alerts will be affected.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b>name</b></td>
         <td>string</td>
         <td>
           Alert Scheduler name.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b><a href="#alertschedulerspecschedule">schedule</a></b></td>
+        <td>object</td>
+        <td>
+          Alert Scheduler schedule. Exactly one of `oneTime` or `recurring` must be set.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -2587,25 +2602,10 @@ It is used to suppress or activate alerts based on a schedule.
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b><a href="#alertschedulerspecfilter">filter</a></b></td>
-        <td>object</td>
-        <td>
-          Alert Scheduler filter. Exactly one of `metaLabels` or `alerts` can be set.
-If none of them set, all alerts will be affected.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b><a href="#alertschedulerspecmetalabelsindex">metaLabels</a></b></td>
         <td>[]object</td>
         <td>
           Alert Scheduler meta labels.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b><a href="#alertschedulerspecschedule">schedule</a></b></td>
-        <td>object</td>
-        <td>
-          Alert Scheduler schedule. Exactly one of `oneTime` or `recurring` must be set.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -2717,40 +2717,6 @@ Alert custom resource name and namespace. If namespace is not set, the AlertSche
 
 ### AlertScheduler.spec.filter.metaLabels[index]
 <sup><sup>[↩ Parent](#alertschedulerspecfilter)</sup></sup>
-
-
-
-
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>key</b></td>
-        <td>string</td>
-        <td>
-          <br/>
-        </td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>value</b></td>
-        <td>string</td>
-        <td>
-          <br/>
-        </td>
-        <td>false</td>
-      </tr></tbody>
-</table>
-
-
-### AlertScheduler.spec.metaLabels[index]
-<sup><sup>[↩ Parent](#alertschedulerspec)</sup></sup>
 
 
 
@@ -3183,6 +3149,40 @@ if the frequency is set to `hours` and the value is set to `2`, the alert will b
             <i>Enum</i>: minutes, hours, days<br/>
         </td>
         <td>true</td>
+      </tr></tbody>
+</table>
+
+
+### AlertScheduler.spec.metaLabels[index]
+<sup><sup>[↩ Parent](#alertschedulerspec)</sup></sup>
+
+
+
+
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>key</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>value</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 

--- a/internal/webhook/coralogix/v1alpha1/alertscheduler_webhook.go
+++ b/internal/webhook/coralogix/v1alpha1/alertscheduler_webhook.go
@@ -160,6 +160,10 @@ func validateRecurring(recurring *coralogixv1alpha1.Recurring) error {
 }
 
 func validateTimeFrame(timeFrame *coralogixv1alpha1.TimeFrame) error {
+	if timeFrame == nil {
+		return nil
+	}
+
 	if timeFrame.EndTime == nil && timeFrame.Duration == nil {
 		return fmt.Errorf("timeFrame must contain only one of the fields: endTime or duration")
 	}


### PR DESCRIPTION
Make `filter` and `schedule` required, as in AlertScheduler API.