### PR TITLE
Improve leader election support

### DIFF
--- a/charts/coralogix-operator/README.md
+++ b/charts/coralogix-operator/README.md
@@ -1,6 +1,6 @@
 # coralogix-operator
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
 
 Coralogix Operator Helm Chart
 
@@ -26,15 +26,17 @@ Kubernetes: `>=1.16.0-0`
 |-----|------|---------|-------------|
 | affinity | object | `{}` | ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | certificate.create | bool | `true` | Specifies whether a Certificate should be created. |
-| coralogixOperator | object | `{"domain":"","image":{"pullPolicy":"IfNotPresent","repository":"coralogixrepo/coralogix-operator","tag":""},"labelSelector":"","namespaceSelector":"","prometheusRules":{"enabled":true},"reconcileIntervalSeconds":{"alert":"","alertScheduler":"","apiKey":"","customRole":"","group":"","integration":"","outboundWebhook":"","prometheusRule":"","recordingRuleGroupSet":"","ruleGroup":"","scope":"","tcoLogsPolicies":"","tcoTracesPolicies":""},"region":"","resources":{},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true},"webhooks":{"enabled":true}}` | Coralogix operator container config |
+| coralogixOperator | object | `{"domain":"","image":{"pullPolicy":"IfNotPresent","repository":"coralogixrepo/coralogix-operator","tag":""},"labelSelector":"","leaderElection":{"enabled":true},"namespaceSelector":"","prometheusRules":{"enabled":true},"reconcileIntervalSeconds":{"alert":"","alertScheduler":"","apiKey":"","customRole":"","group":"","integration":"","outboundWebhook":"","prometheusRule":"","recordingRuleGroupSet":"","ruleGroup":"","scope":"","tcoLogsPolicies":"","tcoTracesPolicies":""},"region":"","resources":{},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true},"webhooks":{"enabled":true}}` | Coralogix operator container config |
 | coralogixOperator.domain | string | `""` | Coralogix Account Domain |
 | coralogixOperator.image | object | `{"pullPolicy":"IfNotPresent","repository":"coralogixrepo/coralogix-operator","tag":""}` | Coralogix operator Image |
 | coralogixOperator.labelSelector | string | `""` | A comma-separated list of key=value labels to filter custom resources |
+| coralogixOperator.leaderElection | object | `{"enabled":true}` | Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager. |
 | coralogixOperator.namespaceSelector | string | `""` | A list of namespaces to filter custom resources |
 | coralogixOperator.reconcileIntervalSeconds | object | `{"alert":"","alertScheduler":"","apiKey":"","customRole":"","group":"","integration":"","outboundWebhook":"","prometheusRule":"","recordingRuleGroupSet":"","ruleGroup":"","scope":"","tcoLogsPolicies":"","tcoTracesPolicies":""}` | The interval in seconds to reconcile each custom resource |
 | coralogixOperator.region | string | `""` | Coralogix Account Region |
 | coralogixOperator.resources | object | `{}` | resource config for Coralogix operator |
 | coralogixOperator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security context for Coralogix operator container |
+| deployment.replicas | int | `1` | How many coralogix-operator pods to run |
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources |
 | imagePullSecrets | list | `[]` |  |
 | issuer.create | bool | `true` | Specifies whether an Issuer should be created. |

--- a/charts/coralogix-operator/templates/deployment.yaml
+++ b/charts/coralogix-operator/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "coralogixOperator.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.deployment.replicas }}
   selector:
     matchLabels:
       {{- include "coralogixOperator.selectorLabels" . | nindent 6 }}
@@ -39,7 +39,8 @@ spec:
         args:
         - -health-probe-bind-address=:8081
         - -metrics-bind-address=:8080
-        - -leader-elect
+        - -leader-elect={{.Values.coralogixOperator.leaderElection.enabled}}
+        - -leader-election-id={{ include "coralogixOperator.fullname" . }}
         - -prometheus-rule-controller={{.Values.coralogixOperator.prometheusRules.enabled}}
         - -enable-webhooks={{.Values.coralogixOperator.webhooks.enabled }}
         - -label-selector={{ .Values.coralogixOperator.labelSelector }}

--- a/charts/coralogix-operator/values.yaml
+++ b/charts/coralogix-operator/values.yaml
@@ -6,6 +6,10 @@ fullnameOverride: ""
 
 imagePullSecrets: []
 
+deployment:
+  # -- How many coralogix-operator pods to run
+  replicas: 1
+
 # -- Service account for Coralogix operator to use.
 # -- ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 serviceAccount:
@@ -86,6 +90,10 @@ secret:
 
 # -- Coralogix operator container config
 coralogixOperator:
+  # -- Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
+  leaderElection:
+    enabled: true
+
   # Set this to false if PrometheusRule CRD is not available in the cluster.
   prometheusRules:
     enabled: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,7 +50,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "0.4.0"
+const OperatorVersion = "0.4.2"
 
 var (
 	scheme   = k8sruntime.NewScheme()
@@ -109,7 +109,7 @@ func main() {
 		Metrics:                metricsServerOptions,
 		HealthProbeBindAddress: cfg.ProbeAddr,
 		LeaderElection:         cfg.EnableLeaderElection,
-		LeaderElectionID:       "9e1892e3.coralogix",
+		LeaderElectionID:       cfg.LeaderElectionID,
 		PprofBindAddress:       "0.0.0.0:8888",
 	}
 

--- a/docs/multi-deployment-installation.md
+++ b/docs/multi-deployment-installation.md
@@ -1,6 +1,6 @@
-# Running Multiple Instances of the Coralogix Operator
+# Running Multiple Deployments of the Coralogix Operator
 
-The Coralogix Operator supports running multiple instances within the same Kubernetes cluster, each managing only a subset of custom resources. 
+The Coralogix Operator supports running multiple deployments within the same Kubernetes cluster, each managing only a subset of custom resources. 
 This is achieved using **`label-selector`** flag, which filters custom resources based on specific labels,
 and **`namespace-selector`** flag, which filters custom resources based on the namespace they are deployed in.
 
@@ -8,7 +8,7 @@ and **`namespace-selector`** flag, which filters custom resources based on the n
 
 - By setting the `--label-selector` flag, the operator will **only reconcile resources that match the specified label selector**. 
 - By setting the `--namespace-selector` flag, the operator will **only reconcile resources that are deployed in the specified namespaces**.
-This allows for multiple independent instances of the operator, each managing a different subset of resources.
+This allows for multiple independent deployments of the operator, each managing a different subset of resources.
 
 #### Example: Deploying an Operator using the label-selector flag
 ```sh
@@ -17,7 +17,7 @@ helm install coralogix-operator-staging coralogix/coralogix-operator \
   --set coralogixOperator.domain="app.stg.domain" \
   --set coralogixOperator.labelSelector="env=stg,team=a"
 ```
-This instance will **only reconcile custom resources** labeled:
+This operator installation will **only reconcile custom resources** labeled:
 ```yaml
 metadata:
   labels:
@@ -34,9 +34,9 @@ helm install coralogix-operator-staging coralogix/coralogix-operator \
   --set coralogixOperator.domain="app.stg.domain" \
   --set coralogixOperator.namespaceSelector="staging,production"
 ```
-This instance will **only reconcile custom resources** deployed in either the `staging` or `production` namespaces.
+This operator installation will **only reconcile custom resources** deployed in either the `staging` or `production` namespaces.
 
 ---
  
-This setup requires **isolation** between multiple operator instances, to prevent conflicts between resources managed by different instances.
+This setup requires **isolation** between multiple operator deployments, to prevent conflicts between resources managed by different installations.
 Leaving both the `--label-selector` and `--namespace-selector` flags empty will cause the operator to reconcile all resources, which may lead to conflicts between instances.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	MetricsAddr                 string
 	ProbeAddr                   string
 	EnableLeaderElection        bool
+	LeaderElectionID            string
 	SecureMetrics               bool
 	EnableHTTP2                 bool
 }
@@ -81,9 +82,11 @@ func InitConfig(setupLog logr.Logger) *Config {
 	once.Do(func() {
 		flag.StringVar(&cfg.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 		flag.StringVar(&cfg.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-		flag.BoolVar(&cfg.EnableLeaderElection, "leader-elect", false,
+		flag.BoolVar(&cfg.EnableLeaderElection, "leader-elect", true,
 			"Enable leader election for controller manager. "+
 				"Enabling this will ensure there is only one active controller manager.")
+		flag.StringVar(&cfg.LeaderElectionID, "leader-election-id", "coralogix-operator",
+			"Name of the leader election lease. Used to manage the leader election process.")
 		flag.BoolVar(&cfg.SecureMetrics, "metrics-secure", false,
 			"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 		flag.BoolVar(&cfg.EnableHTTP2, "enable-http2", false,
@@ -180,8 +183,6 @@ func parseReconcileIntervals(setupLog logr.Logger, intervals map[string]*string)
 		if *interval == "" {
 			*interval = "0"
 		}
-
-		setupLog.Info(fmt.Sprintf("Reconcile interval for CRD %s is %s seconds", crd, *interval))
 
 		numericInterval, err := strconv.Atoi(*interval)
 		if err != nil {


### PR DESCRIPTION
This PR does the following:
- Allow users to configure operator's deployment `replicas` from helm.
- Prevent race conditions between the deployment's replicas, by enabling leader election by default. This way, only one pod would operate and reconcile resources. 
- Change the lease name (`LeaderElectionID`) to equal the deployment name - This allows having multiple deployments in the same namespace, where each deployment's replicas have a dedicated `lease` resource.