### PR TITLE
fix: remove finalizer when resource doesn't match selector

### DIFF
--- a/charts/coralogix-operator/README.md
+++ b/charts/coralogix-operator/README.md
@@ -1,6 +1,6 @@
 # coralogix-operator
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 Coralogix Operator Helm Chart
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,7 +50,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "0.4.3"
+const OperatorVersion = "0.4.4"
 
 var (
 	scheme   = k8sruntime.NewScheme()

--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
@@ -111,6 +111,11 @@ func ReconcileResource(ctx context.Context, req ctrl.Request, obj client.Object,
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonRemoteDeletionFailed, err)
 		}
 
+		if err := RemoveFinalizer(ctx, log, obj, r); err != nil {
+			log.Error(err, "Error removing finalizer")
+			return ManageErrorWithRequeue(ctx, obj, utils.ReasonInternalK8sError, err)
+		}
+
 		if err := removeField(ctx, obj, "status"); err != nil {
 			log.Error(err, "Error removing id from status")
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonInternalK8sError, err)

--- a/tests/e2e/scope_test.go
+++ b/tests/e2e/scope_test.go
@@ -96,12 +96,15 @@ var _ = Describe("Scope", Ordered, func() {
 
 			By("Verifying Scope is populated with a new ID after configured interval")
 			var newScopeID string
-			Eventually(func() string {
+			Eventually(func() bool {
 				fetchedScope := &coralogixv1alpha1.Scope{}
 				Expect(crClient.Get(ctx, types.NamespacedName{Name: scopeName, Namespace: testNamespace}, fetchedScope)).To(Succeed())
+				if fetchedScope.Status.ID == nil {
+					return false
+				}
 				newScopeID = *fetchedScope.Status.ID
-				return newScopeID
-			}, time.Minute, time.Second).Should(Not(Equal(scopeID)))
+				return newScopeID != scopeID
+			}, time.Minute, time.Second).Should(BeTrue())
 
 			By("Verifying Scope with new the ID exists in Coralogix backend")
 			Eventually(func() error {


### PR DESCRIPTION
When a remote resource is deleted due to unmatching selectors, remove finalizer to allow easier deletion of the k8s resource.