### PR TITLE
Reduce number of backend updates

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,7 +21,7 @@ jobs:
       CORALOGIX_REGION: ${{ secrets.CORALOGIX_REGION }}
       CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
       ENABLE_WEBHOOKS: true
-      SCOPE_RECONCILE_INTERVAL_SECONDS: 20
+      SCOPE_RECONCILE_INTERVAL_SECONDS: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -49,7 +49,7 @@ jobs:
             --set coralogixOperator.image.tag="${{ env.IMG_TAG }}" \
             --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}" \
             --set coralogixOperator.webhooks.enabled=true \
-            --set coralogixOperator.reconcileIntervalSeconds.scope=20
+            --set coralogixOperator.reconcileIntervalSeconds.scope=30
       - name: Run e2e Tests
         run: |
           make e2e-tests

--- a/charts/coralogix-operator/templates/deployment.yaml
+++ b/charts/coralogix-operator/templates/deployment.yaml
@@ -46,7 +46,9 @@ spec:
         - -label-selector={{ .Values.coralogixOperator.labelSelector | toJson }}
         - -namespace-selector={{ .Values.coralogixOperator.namespaceSelector | toJson }}
 {{- range $key, $value := .Values.coralogixOperator.reconcileIntervalSeconds }}
+{{- if $value }}
         - -{{ lower $key }}-reconcile-interval-seconds={{ $value }}
+{{- end }}
 {{- end }}
         env:
           - name: CORALOGIX_REGION

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,7 +162,8 @@ func getReconcileIntervals() map[string]*string {
 			&interval,
 			fmt.Sprintf("%s-reconcile-interval-seconds", strings.ToLower(gvk.Kind)),
 			interval,
-			fmt.Sprintf("The interval in seconds between succeding reconciliations for %s", gvk.Kind),
+			fmt.Sprintf("The interval in seconds between succeding reconciliations for %s. "+
+				"Should be at least 30 seconds.", gvk.Kind),
 		)
 		result[gvk.Kind] = &interval
 	}
@@ -183,6 +184,10 @@ func parseReconcileIntervals(intervals map[string]*string) (map[string]time.Dura
 		numericInterval, err := strconv.Atoi(*interval)
 		if err != nil {
 			return nil, fmt.Errorf("invalid interval value for %s: %w", crd, err)
+		}
+
+		if numericInterval != 0 && numericInterval < 30 {
+			return nil, fmt.Errorf("interval value should be at least 30 seconds")
 		}
 
 		result[crd] = time.Second * time.Duration(numericInterval)

--- a/internal/controller/coralogix/v1alpha1/apikey_controller.go
+++ b/internal/controller/coralogix/v1alpha1/apikey_controller.go
@@ -77,7 +77,7 @@ func (r *ApiKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			log.Error(err, "Error on creating ApiKey")
 			return coralogixreconciler.ManageErrorWithRequeue(ctx, apiKey, reason, err)
 		}
-		return coralogixreconciler.ManageSuccessWithRequeue(ctx, apiKey, r.Interval, utils.ReasonRemoteCreatedSuccessfully)
+		return coralogixreconciler.ManageSuccessWithRequeue(ctx, apiKey, r.Interval)
 	}
 
 	if !apiKey.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -101,7 +101,7 @@ func (r *ApiKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return coralogixreconciler.ManageErrorWithRequeue(ctx, apiKey, reason, err)
 	}
 
-	return coralogixreconciler.ManageSuccessWithRequeue(ctx, apiKey, r.Interval, utils.ReasonRemoteUpdatedSuccessfully)
+	return coralogixreconciler.ManageSuccessWithRequeue(ctx, apiKey, r.Interval)
 }
 
 func (r *ApiKeyReconciler) create(ctx context.Context, log logr.Logger, apiKey *coralogixv1alpha1.ApiKey) (error, string) {

--- a/internal/utils/conditions.go
+++ b/internal/utils/conditions.go
@@ -20,13 +20,12 @@ import (
 )
 
 const (
-	ReasonRemoteCreatedSuccessfully = "RemoteCreatedSuccessfully"
-	ReasonRemoteCreationFailed      = "RemoteCreationFailed"
-	ReasonRemoteUpdatedSuccessfully = "RemoteUpdatedSuccessfully"
-	ReasonRemoteUpdateFailed        = "RemoteUpdateFailed"
-	ReasonRemoteDeletionFailed      = "RemoteDeletionFailed"
-	ReasonRemoteResourceNotFound    = "RemoteResourceNotFound"
-	ReasonInternalK8sError          = "InternalK8sError"
+	ReasonRemoteSyncedSuccessfully = "RemoteSyncedSuccessfully"
+	ReasonRemoteCreationFailed     = "RemoteCreationFailed"
+	ReasonRemoteUpdateFailed       = "RemoteUpdateFailed"
+	ReasonRemoteDeletionFailed     = "RemoteDeletionFailed"
+	ReasonRemoteResourceNotFound   = "RemoteResourceNotFound"
+	ReasonInternalK8sError         = "InternalK8sError"
 
 	ConditionTypeRemoteSynced = "RemoteSynced"
 )

--- a/tests/e2e/scope_test.go
+++ b/tests/e2e/scope_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Scope", Ordered, func() {
 				}
 				newScopeID = *fetchedScope.Status.ID
 				return newScopeID != scopeID
-			}, time.Minute, time.Second).Should(BeTrue())
+			}, 2*time.Minute, time.Second).Should(BeTrue())
 
 			By("Verifying Scope with new the ID exists in Coralogix backend")
 			Eventually(func() error {


### PR DESCRIPTION
Reduce number of backend updates, by:
- Limiting reconcile intervals to 30 seconds.
- Unifying `RemoteCreatedSuccessfully` and `RemoteUpdatedSuccessfully` condition to `RemoteSyncedSuccessfully`.