### PR TITLE
Support ServiceMonitor NamespaceSelector

### DIFF
--- a/charts/coralogix-operator/README.md
+++ b/charts/coralogix-operator/README.md
@@ -54,8 +54,10 @@ Kubernetes: `>=1.16.0-0`
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | If not set and create is true, a name is generated using the fullname template |
-| serviceMonitor | object | `{"create":true,"labels":{}}` | Service monitor for Prometheus to use. |
+| serviceMonitor | object | `{"create":true,"labels":{},"namespace":"","namespaceSelector":{"enabled":false}}` | Service monitor for Prometheus to use. |
 | serviceMonitor.create | bool | `true` | Specifies whether a service monitor should be created. |
-| serviceMonitor.labels | object | `{}` | Additional labels to add for ServiceMonitor  |
+| serviceMonitor.labels | object | `{}` | Additional labels to add for ServiceMonitor |
+| serviceMonitor.namespace | string | `""` | If not set, the service monitor will be created in the same namespace as the operator. |
+| serviceMonitor.namespaceSelector.enabled | bool | `false` | Useful when the service monitor is deployed in a different namespace than the operator. |
 | tolerations | list | `[]` | ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ |
 

--- a/charts/coralogix-operator/templates/service_monitor.yaml
+++ b/charts/coralogix-operator/templates/service_monitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "coralogixOperator.fullname" . }}-service-monitor
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
     {{- include "coralogixOperator.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}
@@ -16,4 +17,9 @@ spec:
   selector:
     matchLabels:
       {{- include "coralogixOperator.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.namespaceSelector.enabled }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/coralogix-operator/values.yaml
+++ b/charts/coralogix-operator/values.yaml
@@ -37,7 +37,16 @@ serviceMonitor:
   # -- Specifies whether a service monitor should be created.
   create: true
 
-  # -- Additional labels to add for ServiceMonitor 
+    # -- The namespace in which the service monitor should be created.
+    # -- If not set, the service monitor will be created in the same namespace as the operator.
+  namespace: ""
+
+  namespaceSelector:
+    # -- Specifies whether the service monitor should select the namespace where the operator is deployed.
+    # -- Useful when the service monitor is deployed in a different namespace than the operator.
+    enabled: false
+
+  # -- Additional labels to add for ServiceMonitor
   labels: {}
 
 # -- SecurityContext holds pod-level security attributes and common container settings.

--- a/tests/e2e/global_router_test.go
+++ b/tests/e2e/global_router_test.go
@@ -7,7 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/grpc/codes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,11 +80,12 @@ var _ = Describe("GlobalRouter", Ordered, func() {
 		By("Deleting the GlobalRouter")
 		Expect(crClient.Delete(ctx, globalRouter)).To(Succeed())
 
-		By("Verifying GlobalRouter is deleted from Coralogix backend")
-		Eventually(func() codes.Code {
-			_, err := notificationsClient.GetGlobalRouter(ctx, &cxsdk.GetGlobalRouterRequest{Id: globalRouterID})
-			return cxsdk.Code(err)
-		}, time.Minute, time.Second).Should(Equal(codes.NotFound))
+		By("Verifying GlobalRouter is empty in Coralogix backend")
+		Eventually(func() []*cxsdk.RoutingRule {
+			router, err := notificationsClient.GetGlobalRouter(ctx, &cxsdk.GetGlobalRouterRequest{Id: globalRouterID})
+			Expect(err).ToNot(HaveOccurred())
+			return router.GetRouter().Rules
+		}, time.Minute, time.Second).Should(BeEmpty())
 	})
 })
 


### PR DESCRIPTION
Allow configuring the service selector namespace and its NamespaceSelector, so it can be deployed to a different namespace than the operator's.

Also, update GlobalRouter test to follow recent router deletion changes.