### PR TITLE
Alerts: Use root priority when override isn't set

### DIFF
--- a/api/coralogix/v1alpha1/tcologspolicies_types.go
+++ b/api/coralogix/v1alpha1/tcologspolicies_types.go
@@ -199,20 +199,18 @@ func expandArchiveRetention(ctx context.Context, coralogixClientSet *cxsdk.Clien
 		return nil, nil
 	}
 
-	ArchiveRetentions, err := coralogixClientSet.ArchiveRetentions().Get(ctx, &cxsdk.GetRetentionsRequest{})
+	archiveRetentions, err := coralogixClientSet.ArchiveRetentions().Get(ctx, &cxsdk.GetRetentionsRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get archive retentions: %w", err)
 	}
 
-	var archiveRetentionID *wrapperspb.StringValue
-	for _, retention := range ArchiveRetentions.Retentions {
+	for _, retention := range archiveRetentions.Retentions {
 		if *utils.WrapperspbStringToStringPointer(retention.Name) == archiveRetention.BackendRef.Name {
-			archiveRetentionID = retention.Id
-			break
+			return &cxsdk.ArchiveRetention{Id: retention.Id}, nil
 		}
 	}
 
-	return &cxsdk.ArchiveRetention{Id: archiveRetentionID}, nil
+	return nil, fmt.Errorf("archive retention with name %s not found", archiveRetention.BackendRef.Name)
 }
 
 // TCOLogsPoliciesStatus defines the observed state of TCOLogsPolicies.

--- a/api/coralogix/v1beta1/alert_types.go
+++ b/api/coralogix/v1beta1/alert_types.go
@@ -254,6 +254,7 @@ type AlertSpec struct {
 	Description string `json:"description,omitempty"`
 
 	// Priority of the alert.
+	// +kubebuilder:default=p5
 	Priority AlertPriority `json:"priority"`
 
 	// Enable/disable the alert.
@@ -1840,16 +1841,16 @@ func expandAlertTypeDefinition(properties *cxsdk.AlertDefProperties, definition 
 		properties.TypeDefinition = expandLogsImmediate(logsImmediate)
 		properties.Type = cxsdk.AlertDefTypeLogsImmediateOrUnspecified
 	} else if logsThreshold := definition.LogsThreshold; logsThreshold != nil {
-		properties.TypeDefinition = expandLogsThreshold(logsThreshold)
+		properties.TypeDefinition = expandLogsThreshold(logsThreshold, properties.Priority)
 		properties.Type = cxsdk.AlertDefTypeLogsThreshold
 	} else if logsRatioThreshold := definition.LogsRatioThreshold; logsRatioThreshold != nil {
-		properties.TypeDefinition = expandLogsRatioThreshold(logsRatioThreshold)
+		properties.TypeDefinition = expandLogsRatioThreshold(logsRatioThreshold, properties.Priority)
 		properties.Type = cxsdk.AlertDefTypeLogsRatioThreshold
 	} else if logsTimeRelativeThreshold := definition.LogsTimeRelativeThreshold; logsTimeRelativeThreshold != nil {
-		properties.TypeDefinition = expandLogsTimeRelativeThreshold(logsTimeRelativeThreshold)
+		properties.TypeDefinition = expandLogsTimeRelativeThreshold(logsTimeRelativeThreshold, properties.Priority)
 		properties.Type = cxsdk.AlertDefTypeLogsTimeRelativeThreshold
 	} else if metricThreshold := definition.MetricThreshold; metricThreshold != nil {
-		properties.TypeDefinition = expandMetricThreshold(metricThreshold)
+		properties.TypeDefinition = expandMetricThreshold(metricThreshold, properties.Priority)
 		properties.Type = cxsdk.AlertDefTypeMetricThreshold
 	} else if tracingThreshold := definition.TracingThreshold; tracingThreshold != nil {
 		properties.TypeDefinition = expandTracingThreshold(tracingThreshold)
@@ -2279,12 +2280,12 @@ func expandTracingTimeWindow(timeWindow TracingTimeWindow) *cxsdk.TracingTimeWin
 	}
 }
 
-func expandMetricThreshold(threshold *MetricThreshold) *cxsdk.AlertDefPropertiesMetricThreshold {
+func expandMetricThreshold(threshold *MetricThreshold, priority cxsdk.AlertDefPriority) *cxsdk.AlertDefPropertiesMetricThreshold {
 	return &cxsdk.AlertDefPropertiesMetricThreshold{
 		MetricThreshold: &cxsdk.MetricThresholdType{
 			MetricFilter:               expandMetricFilter(threshold.MetricFilter),
 			MissingValues:              expandMetricMissingValues(&threshold.MissingValues),
-			Rules:                      expandMetricThresholdRules(threshold.Rules),
+			Rules:                      expandMetricThresholdRules(threshold.Rules, priority),
 			UndetectedValuesManagement: expandUndetectedValuesManagement(threshold.UndetectedValuesManagement),
 		},
 	}
@@ -2298,19 +2299,19 @@ func expandMetricFilter(metricFilter MetricFilter) *cxsdk.MetricFilter {
 	}
 }
 
-func expandMetricThresholdRules(rules []MetricThresholdRule) []*cxsdk.MetricThresholdRule {
+func expandMetricThresholdRules(rules []MetricThresholdRule, priority cxsdk.AlertDefPriority) []*cxsdk.MetricThresholdRule {
 	result := make([]*cxsdk.MetricThresholdRule, len(rules))
 	for i := range rules {
-		result[i] = expandMetricThresholdRule(rules[i])
+		result[i] = expandMetricThresholdRule(rules[i], priority)
 	}
 
 	return result
 }
 
-func expandMetricThresholdRule(rule MetricThresholdRule) *cxsdk.MetricThresholdRule {
+func expandMetricThresholdRule(rule MetricThresholdRule, priority cxsdk.AlertDefPriority) *cxsdk.MetricThresholdRule {
 	return &cxsdk.MetricThresholdRule{
 		Condition: expandMetricThresholdCondition(rule.Condition),
-		Override:  expandAlertOverride(rule.Override),
+		Override:  expandAlertOverride(rule.Override, priority),
 	}
 }
 
@@ -2378,34 +2379,34 @@ func expandLogsImmediate(immediate *LogsImmediate) *cxsdk.AlertDefPropertiesLogs
 	}
 }
 
-func expandLogsThreshold(logsThreshold *LogsThreshold) *cxsdk.AlertDefPropertiesLogsThreshold {
+func expandLogsThreshold(logsThreshold *LogsThreshold, priority cxsdk.AlertDefPriority) *cxsdk.AlertDefPropertiesLogsThreshold {
 	return &cxsdk.AlertDefPropertiesLogsThreshold{
 		LogsThreshold: &cxsdk.LogsThresholdType{
 			LogsFilter:                 expandLogsFilter(logsThreshold.LogsFilter),
 			UndetectedValuesManagement: expandUndetectedValuesManagement(logsThreshold.UndetectedValuesManagement),
-			Rules:                      expandLogsThresholdRules(logsThreshold.Rules),
+			Rules:                      expandLogsThresholdRules(logsThreshold.Rules, priority),
 			NotificationPayloadFilter:  coralogix.StringSliceToWrappedStringSlice(logsThreshold.NotificationPayloadFilter),
 		},
 	}
 }
 
-func expandLogsRatioThreshold(logsRatioThreshold *LogsRatioThreshold) *cxsdk.AlertDefPropertiesLogsRatioThreshold {
+func expandLogsRatioThreshold(logsRatioThreshold *LogsRatioThreshold, priority cxsdk.AlertDefPriority) *cxsdk.AlertDefPropertiesLogsRatioThreshold {
 	return &cxsdk.AlertDefPropertiesLogsRatioThreshold{
 		LogsRatioThreshold: &cxsdk.LogsRatioThresholdType{
 			Numerator:        expandLogsFilter(&logsRatioThreshold.Numerator),
 			NumeratorAlias:   wrapperspb.String(logsRatioThreshold.NumeratorAlias),
 			Denominator:      expandLogsFilter(&logsRatioThreshold.Denominator),
 			DenominatorAlias: wrapperspb.String(logsRatioThreshold.DenominatorAlias),
-			Rules:            expandLogsRatioThresholdRules(logsRatioThreshold.Rules),
+			Rules:            expandLogsRatioThresholdRules(logsRatioThreshold.Rules, priority),
 		},
 	}
 }
 
-func expandLogsTimeRelativeThreshold(threshold *LogsTimeRelativeThreshold) *cxsdk.AlertDefPropertiesLogsTimeRelativeThreshold {
+func expandLogsTimeRelativeThreshold(threshold *LogsTimeRelativeThreshold, priority cxsdk.AlertDefPriority) *cxsdk.AlertDefPropertiesLogsTimeRelativeThreshold {
 	return &cxsdk.AlertDefPropertiesLogsTimeRelativeThreshold{
 		LogsTimeRelativeThreshold: &cxsdk.LogsTimeRelativeThresholdType{
 			LogsFilter:                 expandLogsFilter(&threshold.LogsFilter),
-			Rules:                      expandLogsTimeRelativeRules(threshold.Rules),
+			Rules:                      expandLogsTimeRelativeRules(threshold.Rules, priority),
 			IgnoreInfinity:             wrapperspb.Bool(threshold.IgnoreInfinity),
 			NotificationPayloadFilter:  coralogix.StringSliceToWrappedStringSlice(threshold.NotificationPayloadFilter),
 			UndetectedValuesManagement: expandUndetectedValuesManagement(threshold.UndetectedValuesManagement),
@@ -2413,19 +2414,19 @@ func expandLogsTimeRelativeThreshold(threshold *LogsTimeRelativeThreshold) *cxsd
 	}
 }
 
-func expandLogsTimeRelativeRules(rules []LogsTimeRelativeRule) []*cxsdk.LogsTimeRelativeRule {
+func expandLogsTimeRelativeRules(rules []LogsTimeRelativeRule, priority cxsdk.AlertDefPriority) []*cxsdk.LogsTimeRelativeRule {
 	result := make([]*cxsdk.LogsTimeRelativeRule, len(rules))
 	for i := range rules {
-		result[i] = expandLogsTimeRelativeRule(rules[i])
+		result[i] = expandLogsTimeRelativeRule(rules[i], priority)
 	}
 
 	return result
 }
 
-func expandLogsTimeRelativeRule(rule LogsTimeRelativeRule) *cxsdk.LogsTimeRelativeRule {
+func expandLogsTimeRelativeRule(rule LogsTimeRelativeRule, priority cxsdk.AlertDefPriority) *cxsdk.LogsTimeRelativeRule {
 	return &cxsdk.LogsTimeRelativeRule{
 		Condition: expandLogsTimeRelativeCondition(rule.Condition),
-		Override:  expandAlertOverride(rule.Override),
+		Override:  expandAlertOverride(rule.Override, priority),
 	}
 }
 
@@ -2437,18 +2438,18 @@ func expandLogsTimeRelativeCondition(condition LogsTimeRelativeCondition) *cxsdk
 	}
 }
 
-func expandLogsRatioThresholdRules(rules []LogsRatioThresholdRule) []*cxsdk.LogsRatioRules {
+func expandLogsRatioThresholdRules(rules []LogsRatioThresholdRule, priority cxsdk.AlertDefPriority) []*cxsdk.LogsRatioRules {
 	result := make([]*cxsdk.LogsRatioRules, len(rules))
 	for i := range rules {
-		result[i] = expandLogsRatioThresholdRule(rules[i])
+		result[i] = expandLogsRatioThresholdRule(rules[i], priority)
 	}
 	return result
 }
 
-func expandLogsRatioThresholdRule(rule LogsRatioThresholdRule) *cxsdk.LogsRatioRules {
+func expandLogsRatioThresholdRule(rule LogsRatioThresholdRule, priority cxsdk.AlertDefPriority) *cxsdk.LogsRatioRules {
 	return &cxsdk.LogsRatioRules{
 		Condition: expandLogsRatioCondition(rule.Condition),
-		Override:  expandAlertOverride(rule.Override),
+		Override:  expandAlertOverride(rule.Override, priority),
 	}
 }
 
@@ -2468,9 +2469,11 @@ func expandLogsRatioTimeWindow(timeWindow LogsRatioTimeWindow) *cxsdk.LogsRatioT
 	}
 }
 
-func expandAlertOverride(override *AlertOverride) *cxsdk.AlertDefPriorityOverride {
+func expandAlertOverride(override *AlertOverride, priority cxsdk.AlertDefPriority) *cxsdk.AlertDefPriorityOverride {
 	if override == nil {
-		return &cxsdk.AlertDefPriorityOverride{}
+		return &cxsdk.AlertDefPriorityOverride{
+			Priority: priority,
+		}
 	}
 
 	return &cxsdk.AlertDefPriorityOverride{
@@ -2537,19 +2540,19 @@ func expandUndetectedValuesManagement(management *UndetectedValuesManagement) *c
 	}
 }
 
-func expandLogsThresholdRules(rules []LogsThresholdRule) []*cxsdk.LogsThresholdRule {
+func expandLogsThresholdRules(rules []LogsThresholdRule, priority cxsdk.AlertDefPriority) []*cxsdk.LogsThresholdRule {
 	result := make([]*cxsdk.LogsThresholdRule, len(rules))
 	for i := range rules {
-		result[i] = expandLogsThresholdRule(rules[i])
+		result[i] = expandLogsThresholdRule(rules[i], priority)
 	}
 
 	return result
 }
 
-func expandLogsThresholdRule(rule LogsThresholdRule) *cxsdk.LogsThresholdRule {
+func expandLogsThresholdRule(rule LogsThresholdRule, priority cxsdk.AlertDefPriority) *cxsdk.LogsThresholdRule {
 	return &cxsdk.LogsThresholdRule{
 		Condition: expandLogsThresholdRuleCondition(rule.Condition),
-		Override:  expandAlertOverride(rule.Override),
+		Override:  expandAlertOverride(rule.Override, priority),
 	}
 }
 

--- a/charts/coralogix-operator/templates/crds/coralogix.com_alerts.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_alerts.yaml
@@ -2372,6 +2372,7 @@ spec:
                 default: false
                 type: boolean
               priority:
+                default: p5
                 description: Priority of the alert.
                 enum:
                 - p1

--- a/config/crd/bases/coralogix.com_alerts.yaml
+++ b/config/crd/bases/coralogix.com_alerts.yaml
@@ -2372,6 +2372,7 @@ spec:
                 default: false
                 type: boolean
               priority:
+                default: p5
                 description: Priority of the alert.
                 enum:
                 - p1

--- a/config/samples/v1beta1/alerts/logs_ratio_threshold.yaml
+++ b/config/samples/v1beta1/alerts/logs_ratio_threshold.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   name: logs-ratio-threshold alert example
   description: alert from k8s operator
-  priority: p4
   entityLabels:
     alert_type: security
     security_severity: high

--- a/config/samples/v1beta1/alerts/logs_threshold.yaml
+++ b/config/samples/v1beta1/alerts/logs_threshold.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   name: logs-threshold alert example
   description: alert from k8s operator
-  priority: p5
   entityLabels:
     alert_type: security
     security_severity: high
@@ -37,6 +36,8 @@ spec:
               specificValue: 5m
             threshold: "100.4"
             logsThresholdConditionType: moreThan
+          override:
+            priority: p3
   notificationGroup:
     webhooks:
       - retriggeringPeriod:

--- a/config/samples/v1beta1/alerts/logs_time_relative_threshold.yaml
+++ b/config/samples/v1beta1/alerts/logs_time_relative_threshold.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   name: logs-time-relative-threshold alert example
   description: alert from k8s operator
-  priority: p1
   entityLabels:
     alert_type: security
     security_severity: high
@@ -35,6 +34,8 @@ spec:
             threshold: "100.4"
             comparedTo: previousHour
             conditionType: moreThan
+          override:
+            priority: p1
   notificationGroup:
     webhooks:
       - retriggeringPeriod:

--- a/config/samples/v1beta1/alerts/metric_threshold.yaml
+++ b/config/samples/v1beta1/alerts/metric_threshold.yaml
@@ -11,7 +11,6 @@ metadata:
 spec:
   name: metric-threshold alert example
   description: alert from k8s operator
-  priority: p4
   entityLabels:
     alert_type: security
     security_severity: high
@@ -29,6 +28,8 @@ spec:
             ofTheLast:
               dynamicDuration: 1h15m
             conditionType: moreThan
+          override:
+            priority: p4
   notificationGroup:
     webhooks:
       - notifyOn: triggeredOnly

--- a/docs/api.md
+++ b/docs/api.md
@@ -113,6 +113,7 @@ AlertSpec defines the desired state of a Coralogix Alert. For more info check - 
           Priority of the alert.<br/>
           <br/>
             <i>Enum</i>: p1, p2, p3, p4, p5<br/>
+            <i>Default</i>: p5<br/>
         </td>
         <td>true</td>
       </tr><tr>

--- a/tests/e2e/alert_test.go
+++ b/tests/e2e/alert_test.go
@@ -164,6 +164,9 @@ var _ = Describe("Alert", Ordered, func() {
 										DynamicDuration: ptr.To("12h"),
 									},
 								},
+								Override: &coralogixv1beta1.AlertOverride{
+									Priority: coralogixv1beta1.AlertPriorityP1,
+								},
 							},
 						},
 					},
@@ -185,11 +188,12 @@ var _ = Describe("Alert", Ordered, func() {
 
 		}, time.Minute, time.Second).Should(Succeed())
 
-		By("Verifying Alert exists in Coralogix backend")
-		Eventually(func() error {
-			_, err := alertsClient.Get(ctx, &cxsdk.GetAlertDefRequest{Id: wrapperspb.String(alertID)})
-			return err
-		}, time.Minute, time.Second).Should(Succeed())
+		By("Verifying Alert exists in Coralogix backend with the correct priority")
+		Eventually(func(g Gomega) cxsdk.AlertDefPriority {
+			alertDef, err := alertsClient.Get(ctx, &cxsdk.GetAlertDefRequest{Id: wrapperspb.String(alertID)})
+			g.Expect(err).ToNot(HaveOccurred())
+			return alertDef.GetAlertDef().GetAlertDefProperties().GetPriority()
+		}, time.Minute, time.Second).Should(Equal(cxsdk.AlertDefPriorityP1))
 	})
 
 	It("Should be updated successfully", func(ctx context.Context) {


### PR DESCRIPTION
Also, in TCO, log error when archive retention is not found by its name.