### PR TITLE
Add "helm.sh/resource-policy: keep" annotation to crds

### DIFF
--- a/charts/coralogix-operator/templates/crds/coralogix.com_alerts.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_alerts.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: alerts.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_alertschedulers.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_alertschedulers.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: alertschedulers.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_apikeys.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_apikeys.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: apikeys.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_archivelogstargets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_archivelogstargets.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: archivelogstargets.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_archivemetricstargets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_archivemetricstargets.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: archivemetricstargets.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: connectors.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_customroles.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_customroles.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: customroles.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_dashboards.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_dashboards.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: dashboards.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_dashboardsfolders.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_dashboardsfolders.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: dashboardsfolders.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_events2metrics.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_events2metrics.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: events2metrics.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_globalrouters.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_globalrouters.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: globalrouters.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_groups.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_groups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: groups.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_integrations.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_integrations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: integrations.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_outboundwebhooks.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_outboundwebhooks.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: outboundwebhooks.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: presets.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_recordingrulegroupsets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_recordingrulegroupsets.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: recordingrulegroupsets.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_rulegroups.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_rulegroups.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: rulegroups.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_scopes.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_scopes.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: scopes.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: tcologspolicies.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_tcotracespolicies.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_tcotracespolicies.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: tcotracespolicies.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_viewfolders.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_viewfolders.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: viewfolders.coralogix.com
 spec:
   group: coralogix.com

--- a/charts/coralogix-operator/templates/crds/coralogix.com_views.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_views.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.2
+    helm.sh/resource-policy: keep
   name: views.coralogix.com
 spec:
   group: coralogix.com


### PR DESCRIPTION
In the next minor release of the operator (v1.1.0), we’re moving all CRDs from the `/templates` directory to the dedicated `/crds` folder. This is the recommended Helm practice because it ensures CRDs get installed before the rest of the chart ([details here](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)).

However, older versions of the chart had the CRDs inside `/templates`, so during an upgrade, Helm might delete them. To prevent that, we’re adding the annotation `helm.sh/resource-policy: keep` so they stick around.