### PR TITLE
CI: Add upgrade lane

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -1,0 +1,76 @@
+name: upgrade-test
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  upgrade-test:
+    name: Upgrade Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        operator_version: [ "0.5", "1.0" ]
+    env:
+      IMG_REPO: coralogix-operator-image
+      IMG_TAG: 0.0.1
+      CORALOGIX_REGION: ${{ secrets.CORALOGIX_REGION }}
+      CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      LOGS_BUCKET: ${{ secrets.LOGS_BUCKET }}
+      METRICS_BUCKET: ${{ secrets.METRICS_BUCKET }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Create Kind cluster
+        uses: helm/kind-action@v1.4.0
+      - name: Install Prometheus Operator CRDs
+        run: |
+          make install-prometheus-crds
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Add Coralogix Helm repository
+        run: |
+          helm repo add coralogix https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+          helm repo update
+      - name: Install Coralogix Operator from remote Helm repository, version ${{ matrix.operator_version }}.latest
+        run: |
+          helm install coralogix-operator coralogix/coralogix-operator \
+            --version=${{ matrix.operator_version }} \
+            --namespace coralogix-operator-system \
+            --create-namespace \
+            --set secret.data.apiKey="${{ secrets.CORALOGIX_API_KEY }}" \
+            --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}"
+      - name: Build PR image
+        run: |
+          make docker-build IMG=${{ env.IMG_REPO }}:v${{ env.IMG_TAG }}
+      - name: Load PR image into Kind
+        run: |
+          kind load docker-image ${{ env.IMG_REPO }}:v${{ env.IMG_TAG }} --name chart-testing
+      - name: Upgrade to PR version
+        run: |
+          helm upgrade coralogix-operator ./charts/coralogix-operator \
+            --namespace coralogix-operator-system \
+            --set secret.data.apiKey="${{ secrets.CORALOGIX_API_KEY }}" \
+            --set coralogixOperator.image.repository="${{ env.IMG_REPO }}" \
+            --set coralogixOperator.image.tag="${{ env.IMG_TAG }}" \
+            --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}" \
+            --set coralogixOperator.reconcileIntervalSeconds.scope=30
+      - name: Run e2e Tests
+        run: |
+          make e2e-tests
+      - name: Collect Operator Logs
+        if: always()
+        run: |
+          scripts/collect-logs.sh


### PR DESCRIPTION
Add an action that:
- Installs 2 latest minor versions, currently it's `v1.0.latest` and `v0.5.latest`.
- Upgrades to the PR from each version.
- Runs e2e tests for each upgrade.