### PR TITLE
docs(readme): fix upgrade command and add region examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ helm install <my-release> coralogix/coralogix-operator \
   --set secret.data.apiKey="<api-key>" \
   --set coralogixOperator.region="<region>"
 ```
-For a complete list of configuration options, refer to the [Helm Chart Docs](./charts/coralogix-operator/README.md).
+Replace `<region>` with one of: `EU1`, `EU2`, `AP1`, `AP2`, `AP3`, `US1`, `US2`. For a complete list of configuration options, refer to the [Helm Chart Docs](./charts/coralogix-operator/README.md).
 
 3. Upgrade the operator:
-```sh  
+```sh
 helm upgrade <my-release> coralogix/coralogix-operator \
-  --set secret.data.api
+  --set secret.data.apiKey="<api-key>" \
   --set coralogixOperator.region="<region>"
 ```
 


### PR DESCRIPTION
## Summary

Two small README fixes surfaced while auditing the Coralogix docs sync of this repo.

### 1. Broken upgrade command (copy-paste fails)

README lines 35-40 previously:
\`\`\`sh
helm upgrade <my-release> coralogix/coralogix-operator \\
  --set secret.data.api
  --set coralogixOperator.region="<region>"
\`\`\`

Issues:
- \`--set secret.data.api\` is missing \`Key="<api-key>"\` — the \`apiKey\` flag value is dropped
- The line is missing the trailing backslash, so the second \`--set\` is interpreted as a separate command

Copy-pasting this command does not work. Fixed to mirror the install snippet above it.

### 2. Region placeholder without examples

Both install and upgrade snippets use \`<region>\` with no hint at the expected format. Added the supported region codes (\`EU1\`, \`EU2\`, \`AP1\`, \`AP2\`, \`AP3\`, \`US1\`, \`US2\`) so users don't have to guess whether it's \`EU1\` / \`eu1\` / \`eu-west-1\`.

## Context

The Coralogix docs portal syncs this README automatically, so these issues surface there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)