### PR TITLE
ci(docs-sync): fix path filter and trigger on main pushes

### DIFF
--- a/.github/workflows/dispatch-event-on-docs-change.yml
+++ b/.github/workflows/dispatch-event-on-docs-change.yml
@@ -6,15 +6,16 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
     paths:
-      - '/README.md'
-      - '/docs/metrics.md'
-      - '/charts/coralogix-operator/README.md'
-      - '/docs/prometheus-integration.md'
-      - '/docs/api.md'
-      - '/tools/cxo-observer/README.md'
+      - 'README.md'
+      - 'docs/metrics.md'
+      - 'charts/coralogix-operator/README.md'
+      - 'docs/prometheus-integration.md'
+      - 'docs/api.md'
+      - 'tools/cxo-observer/README.md'
+
 jobs:
   trigger_action:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The docs-sync dispatch in `dispatch-event-on-docs-change.yml` never fires today:
  - Paths used a leading `/` (`'/README.md'`, `'/docs/metrics.md'`, ...) which doesn't match GitHub Actions path filter syntax — the filter never matches.
  - The trigger was scoped to tag pushes (`v*`) only, so even with valid paths the docs portal would only sync on releases, not when README or docs files change directly on `main`.
- Switch to push-on-`main` with relative paths, matching the canonical docs-sync workflow in `terraform-coralogix-aws`, `coralogix-aws-shipper`, and `telemetry-shippers`. `workflow_dispatch` is preserved for manual triggers.

Found while auditing all `coralogix/documentation` source repos for trigger coverage.

## Test plan
- [ ] Trigger via the **Run workflow** button (`workflow_dispatch`) and confirm the docs deploy in `coralogix/documentation` is dispatched.
- [ ] After merge, push a trivial change to `README.md` on `main` and verify the workflow runs and the deploy is triggered.
- [ ] Push a change to a non-listed file (e.g. `Makefile`) on `main` and confirm the workflow does **not** fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)