### PR TITLE
Fix CEL cost limit for Enrichment CRD on K8s 1.28

### DIFF
--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -1,3 +1,6 @@
+# Validates that Helm can install the chart (including CRDs) on several Kubernetes versions.
+# Kind ships a small set of pre-built kindest/node images per kind release; many older tags
+# remain on Docker Hub. See: https://github.com/kubernetes-sigs/kind/releases
 name: crd-validation
 on:
   push:
@@ -18,6 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         k8s-version:
+          - "1.26.15"
+          - "1.27.16"
           - "1.28.13"
           - "1.29.10"
           - "1.30.6"
@@ -35,21 +40,29 @@ jobs:
       - name: Install Prometheus Operator CRDs
         run: |
           make install-prometheus-crds
-      - name: Install Coralogix Operator CRDs
+      - name: Install Coralogix Operator (Helm)
         run: |
+          set -euo pipefail
           helm install coralogix-operator ./charts/coralogix-operator \
             --namespace coralogix-operator-system \
             --create-namespace \
             --set secret.data.apiKey="test-key" \
             --set coralogixOperator.region="EU2"
-      - name: Verify CRDs are installed
+          status="$(helm status coralogix-operator -n coralogix-operator-system -o json | jq -r .info.status)"
+          if [ "${status}" != "deployed" ]; then
+            echo "helm install finished but release status is '${status}', expected 'deployed'"
+            exit 1
+          fi
+      - name: Verify Coralogix CRD count matches chart
         run: |
-          expected=$(ls -1 charts/coralogix-operator/templates/crds/*.yaml | wc -l)
-          actual=$(kubectl get crds -o name | grep -c coralogix.com)
-          echo "Expected CRDs: $expected, Installed CRDs: $actual"
-          if [ "$expected" -ne "$actual" ]; then
-            echo "ERROR: CRD count mismatch!"
-            kubectl get crds | grep coralogix.com
+          set -euo pipefail
+          expected="$(find charts/coralogix-operator/templates/crds -maxdepth 1 -type f -name '*.yaml' | wc -l | awk '{print $1}')"
+          installed="$(kubectl get crd -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -cE '\.coralogix\.com$' || true)"
+          echo "CRD YAML files in chart: ${expected}"
+          echo "Installed *.coralogix.com CRDs: ${installed}"
+          if [ "${expected}" != "${installed}" ]; then
+            echo "Mismatch: chart defines ${expected} CRD files but cluster has ${installed} coralogix.com CRDs"
+            kubectl get crd -o name | grep coralogix.com || true
             exit 1
           fi
       - name: Verify operator deployment

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -17,16 +17,27 @@ jobs:
   validate-crds:
     name: Validate CRDs (K8s ${{ matrix.k8s-version }})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        k8s-version:
-          - "1.26.15"
-          - "1.27.16"
-          - "1.28.13"
-          - "1.29.10"
-          - "1.30.6"
-          - "1.31.2"
+        include:
+          - k8s-version: "1.28.15"
+            experimental: false
+          - k8s-version: "1.29.14"
+            experimental: false
+          - k8s-version: "1.30.13"
+            experimental: false
+          - k8s-version: "1.31.14"
+            experimental: false
+          - k8s-version: "1.32.11"
+            experimental: false
+          - k8s-version: "1.33.7"
+            experimental: false
+          - k8s-version: "1.34.3"
+            experimental: false
+          - k8s-version: "1.35.1"
+            experimental: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -44,8 +44,14 @@ jobs:
             --set coralogixOperator.region="EU2"
       - name: Verify CRDs are installed
         run: |
-          kubectl get crds | grep coralogix.com
-          kubectl get crd enrichments.coralogix.com -o yaml | head -20
+          expected=$(ls -1 charts/coralogix-operator/templates/crds/*.yaml | wc -l)
+          actual=$(kubectl get crds -o name | grep -c coralogix.com)
+          echo "Expected CRDs: $expected, Installed CRDs: $actual"
+          if [ "$expected" -ne "$actual" ]; then
+            echo "ERROR: CRD count mismatch!"
+            kubectl get crds | grep coralogix.com
+            exit 1
+          fi
       - name: Verify operator deployment
         run: |
           kubectl -n coralogix-operator-system wait --for=condition=available deployment/coralogix-operator --timeout=120s

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -10,6 +10,8 @@ on:
       - release-*
 permissions:
   contents: read
+permissions:
+  contents: read
 jobs:
   validate-crds:
     name: Validate CRDs (K8s ${{ matrix.k8s-version }})

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -10,8 +10,6 @@ on:
       - release-*
 permissions:
   contents: read
-permissions:
-  contents: read
 jobs:
   validate-crds:
     name: Validate CRDs (K8s ${{ matrix.k8s-version }})

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -1,0 +1,51 @@
+name: crd-validation
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+    branches:
+      - main
+      - release-*
+permissions:
+  contents: read
+jobs:
+  validate-crds:
+    name: Validate CRDs (K8s ${{ matrix.k8s-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s-version:
+          - "1.28.13"
+          - "1.29.10"
+          - "1.30.6"
+          - "1.31.2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create Kind cluster (K8s ${{ matrix.k8s-version }})
+        uses: helm/kind-action@v1.10.0
+        with:
+          node_image: kindest/node:v${{ matrix.k8s-version }}
+          cluster_name: crd-test
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Install Prometheus Operator CRDs
+        run: |
+          make install-prometheus-crds
+      - name: Install Coralogix Operator CRDs
+        run: |
+          helm install coralogix-operator ./charts/coralogix-operator \
+            --namespace coralogix-operator-system \
+            --create-namespace \
+            --set secret.data.apiKey="test-key" \
+            --set coralogixOperator.region="EU2"
+      - name: Verify CRDs are installed
+        run: |
+          kubectl get crds | grep coralogix.com
+          kubectl get crd enrichments.coralogix.com -o yaml | head -20
+      - name: Verify operator deployment
+        run: |
+          kubectl -n coralogix-operator-system wait --for=condition=available deployment/coralogix-operator --timeout=120s

--- a/api/coralogix/v1alpha1/enrichment_types.go
+++ b/api/coralogix/v1alpha1/enrichment_types.go
@@ -28,6 +28,7 @@ import (
 // EnrichmentSpec defines the desired state of Enrichment.
 type EnrichmentSpec struct {
 	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=100
 	// List of enrichments to apply. Each enrichment must have exactly one of GeoIp, SuspiciousIp, Aws, or Custom set.
 	// Will overwrite the existing enrichments on the Coralogix side,
 	// so it should contain all enrichments that should be applied, not just the new ones.

--- a/charts/coralogix-operator/templates/crds/coralogix.com_enrichments.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_enrichments.yaml
@@ -148,6 +148,7 @@ spec:
                     rule: '(has(self.geoIp) ? 1 : 0) + (has(self.suspiciousIp) ? 1
                       : 0) + (has(self.aws) ? 1 : 0) + (has(self.custom) ? 1 : 0)
                       == 1'
+                maxItems: 100
                 minItems: 1
                 type: array
             required:

--- a/config/crd/bases/coralogix.com_enrichments.yaml
+++ b/config/crd/bases/coralogix.com_enrichments.yaml
@@ -147,6 +147,7 @@ spec:
                     rule: '(has(self.geoIp) ? 1 : 0) + (has(self.suspiciousIp) ? 1
                       : 0) + (has(self.aws) ? 1 : 0) + (has(self.custom) ? 1 : 0)
                       == 1'
+                maxItems: 100
                 minItems: 1
                 type: array
             required:


### PR DESCRIPTION
## Summary
- Adds `maxItems=100` to the `enrichments` array in the Enrichment CRD
- Fixes CRD installation failure on Kubernetes 1.28 clusters
- Adds new CI workflow to validate CRDs across multiple K8s versions

## Problem
On K8s 1.28, the Enrichment CRD fails to install with:
```
CustomResourceDefinition.apiextensions.k8s.io "enrichments.coralogix.com" is invalid: 
spec.validation.openAPIV3Schema.properties[spec].properties[enrichments].items.x-kubernetes-validations[0].rule: 
Forbidden: estimated rule cost exceeds budget by factor of 1.258291x
```

This happens because the CEL validation rule on each array item has no bounded cost - without `maxItems`, K8s assumes the array could be arbitrarily large.

## Solution
Add `// +kubebuilder:validation:MaxItems=100` to bound the CEL cost calculation. 100 enrichments is a reasonable upper limit for real-world usage.

## CI Improvement
Added `.github/workflows/crd-validation.yaml` - a new workflow that tests CRD installation via Helm across a K8s version matrix (1.28, 1.29, 1.30, 1.31). This ensures we catch CEL cost and other CRD compatibility issues before they reach production.

## Test plan
- [x] Verified fix locally on Kind v1.28.13
- [ ] CI passes (including new crd-validation workflow)