### PR TITLE
docs: add TW as blocking reviewer for synced documentation files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,9 @@
 * @coralogix/team-iac @coralogix/team-eco-system
+
+# Technical writers own documentation
+README.md @coralogix/team-technical-writers
+charts/coralogix-operator/README.md @coralogix/team-technical-writers
+docs/metrics.md @coralogix/team-technical-writers
+docs/prometheus-integration.md @coralogix/team-technical-writers
+docs/api.md @coralogix/team-technical-writers
+tools/cxo-observer/README.md @coralogix/team-technical-writers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,6 @@
 
 # Technical writers own documentation
 README.md @coralogix/team-technical-writers
-charts/coralogix-operator/README.md @coralogix/team-technical-writers
 docs/metrics.md @coralogix/team-technical-writers
 docs/prometheus-integration.md @coralogix/team-technical-writers
-docs/api.md @coralogix/team-technical-writers
 tools/cxo-observer/README.md @coralogix/team-technical-writers


### PR DESCRIPTION
## Why

Six files from this repo are synced automatically into the Coralogix documentation portal via `external_repos.json`. Any change to these files triggers an immediate docs redeploy.

Adding the TW team as a required reviewer ensures no change to synced docs content merges without sign-off from the Technical Writing team.

## Files covered

- `README.md`
- `charts/coralogix-operator/README.md`
- `docs/metrics.md`
- `docs/prometheus-integration.md`
- `docs/api.md`
- `tools/cxo-observer/README.md`