### PR TITLE
chore: Upgrade k8s target version for envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= coralogixrepo/coralogix-operator:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.25.0
+ENVTEST_K8S_VERSION = 1.30.3
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
1.25 is a very old version of k8s, no longer supported. The oldest
still offered version is EKS' 1.30, so we upgrade to that for our test
suite. It may be better to upgrade further to a newer version and even
align it with our fleet's version at some point,

One of the motivators for the upgrade is fixing issues with CEL
budget. When we have CEL expressions, the apiserver pre-computes
expected evaluation complexity and refuses to accept objects that
would exceed it. In 1.25, the test-suite rejects some of our CRDs for
this reason, while 1.30 does not due to a higher CEL budget limit.
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add CRD validations to TCO policies (#506)
</summary>
Add a CRD validation to reject objects with more than 50 subsystems,
encoding an upstream limitation before reconciling starts failing.
</details>
<details>
<summary>
Add e2e test for the CRD validation (#507)
</summary>

</details>
</details>
</details>