### PR TITLE
Add CRD validations to TCO policies

### DIFF
--- a/api/coralogix/v1alpha1/tcologspolicies_types.go
+++ b/api/coralogix/v1alpha1/tcologspolicies_types.go
@@ -108,6 +108,8 @@ type TCOPolicySeverity string
 
 // A sincle TCO policy rule.
 type TCOPolicyRule struct {
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=50
 	// Names to match.
 	Names []string `json:"names"`
 

--- a/api/coralogix/v1alpha1/tcotracespolicies_types.go
+++ b/api/coralogix/v1alpha1/tcotracespolicies_types.go
@@ -80,6 +80,8 @@ type TCOPolicyTag struct {
 	// Tag names to match.
 	Name string `json:"name"`
 
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=50
 	// Values to match for
 	Values []string `json:"values"`
 

--- a/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
@@ -69,6 +69,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -135,6 +137,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.

--- a/charts/coralogix-operator/templates/crds/coralogix.com_tcotracespolicies.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_tcotracespolicies.yaml
@@ -69,6 +69,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -90,6 +92,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -143,6 +147,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -164,6 +170,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -199,6 +207,8 @@ spec:
                             description: Values to match for
                             items:
                               type: string
+                            maxItems: 50
+                            minItems: 1
                             type: array
                         required:
                         - name

--- a/config/crd/bases/coralogix.com_tcologspolicies.yaml
+++ b/config/crd/bases/coralogix.com_tcologspolicies.yaml
@@ -68,6 +68,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -134,6 +136,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.

--- a/config/crd/bases/coralogix.com_tcotracespolicies.yaml
+++ b/config/crd/bases/coralogix.com_tcotracespolicies.yaml
@@ -68,6 +68,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -89,6 +91,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -142,6 +146,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -163,6 +169,8 @@ spec:
                           description: Names to match.
                           items:
                             type: string
+                          maxItems: 50
+                          minItems: 1
                           type: array
                         ruleType:
                           description: Type of matching for the name.
@@ -198,6 +206,8 @@ spec:
                             description: Values to match for
                             items:
                               type: string
+                            maxItems: 50
+                            minItems: 1
                             type: array
                         required:
                         - name

--- a/internal/controller/coralogix/v1alpha1/suite_test.go
+++ b/internal/controller/coralogix/v1alpha1/suite_test.go
@@ -50,7 +50,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 

--- a/internal/controller/coralogix/v1alpha1/tcologspolicies_validation_test.go
+++ b/internal/controller/coralogix/v1alpha1/tcologspolicies_validation_test.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
+)
+
+var _ = Describe("TCOLogsPolicies validation", func() {
+	It("should reject a policy with more than 50 subsystem names", func(ctx context.Context) {
+		names := make([]string, 51)
+		for i := range names {
+			names[i] = fmt.Sprintf("subsystem-%d", i)
+		}
+		policy := &coralogixv1alpha1.TCOLogsPolicies{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "too-many-subsystems",
+				Namespace: "default",
+			},
+			Spec: coralogixv1alpha1.TCOLogsPoliciesSpec{
+				Policies: []coralogixv1alpha1.TCOLogsPolicy{{
+					Name:       "over-limit",
+					Priority:   "low",
+					Severities: []coralogixv1alpha1.TCOPolicySeverity{"info"},
+					Subsystems: &coralogixv1alpha1.TCOPolicyRule{
+						Names:    names,
+						RuleType: "is",
+					},
+				}},
+			},
+		}
+		err := k8sClient.Create(ctx, policy)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("Too many"))
+	})
+
+	It("should accept a policy with exactly 50 subsystem names", func(ctx context.Context) {
+		names := make([]string, 50)
+		for i := range names {
+			names[i] = fmt.Sprintf("subsystem-%d", i)
+		}
+		policy := &coralogixv1alpha1.TCOLogsPolicies{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "max-subsystems",
+				Namespace: "default",
+			},
+			Spec: coralogixv1alpha1.TCOLogsPoliciesSpec{
+				Policies: []coralogixv1alpha1.TCOLogsPolicy{{
+					Name:       "at-limit",
+					Priority:   "low",
+					Severities: []coralogixv1alpha1.TCOPolicySeverity{"info"},
+					Subsystems: &coralogixv1alpha1.TCOPolicyRule{
+						Names:    names,
+						RuleType: "is",
+					},
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+	})
+})


### PR DESCRIPTION
Add a CRD validation to reject objects with more than 50 subsystems,
encoding an upstream limitation before reconciling starts failing.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add e2e test for the CRD validation (#507)
</summary>

</details>
</details>
</details>