### PR TITLE
docs(slo): mark 90d timeFrame as deprecated in CRD

### DIFF
--- a/api/coralogix/v1alpha1/slo_types.go
+++ b/api/coralogix/v1alpha1/slo_types.go
@@ -106,7 +106,8 @@ type SloMetricEvent struct {
 
 type SloWindow struct {
 	// +optional
-	// TimeFrame defines the time frame for the SLO window. Valid values are "unspecified", "7d", "14d", "21d", "28d", and "90d".
+	// TimeFrame defines the time frame for the SLO window. Valid values are "unspecified", "7d", "14d", "21d", and "28d".
+	// Deprecated: "90d" is no longer supported by the Coralogix API and will be rejected by the operator.
 	TimeFrame *SloTimeFrame `json:"timeFrame,omitempty"`
 }
 

--- a/charts/coralogix-operator/templates/crds/coralogix.com_slos.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_slos.yaml
@@ -150,9 +150,9 @@ spec:
                 description: Window defines the time window for the SLO.
                 properties:
                   timeFrame:
-                    description: TimeFrame defines the time frame for the SLO window.
-                      Valid values are "unspecified", "7d", "14d", "21d", "28d", and
-                      "90d".
+                    description: |-
+                      TimeFrame defines the time frame for the SLO window. Valid values are "unspecified", "7d", "14d", "21d", and "28d".
+                      Deprecated: "90d" is no longer supported by the Coralogix API and will be rejected by the operator.
                     enum:
                     - unspecified
                     - 7d

--- a/config/crd/bases/coralogix.com_slos.yaml
+++ b/config/crd/bases/coralogix.com_slos.yaml
@@ -149,9 +149,9 @@ spec:
                 description: Window defines the time window for the SLO.
                 properties:
                   timeFrame:
-                    description: TimeFrame defines the time frame for the SLO window.
-                      Valid values are "unspecified", "7d", "14d", "21d", "28d", and
-                      "90d".
+                    description: |-
+                      TimeFrame defines the time frame for the SLO window. Valid values are "unspecified", "7d", "14d", "21d", and "28d".
+                      Deprecated: "90d" is no longer supported by the Coralogix API and will be rejected by the operator.
                     enum:
                     - unspecified
                     - 7d

--- a/docs/api.md
+++ b/docs/api.md
@@ -15978,7 +15978,8 @@ Window defines the time window for the SLO.
         <td><b>timeFrame</b></td>
         <td>enum</td>
         <td>
-          TimeFrame defines the time frame for the SLO window. Valid values are "unspecified", "7d", "14d", "21d", "28d", and "90d".<br/>
+          TimeFrame defines the time frame for the SLO window. Valid values are "unspecified", "7d", "14d", "21d", and "28d".
+Deprecated: "90d" is no longer supported by the Coralogix API and will be rejected by the operator.<br/>
           <br/>
             <i>Enum</i>: unspecified, 7d, 14d, 21d, 28d, 90d<br/>
         </td>


### PR DESCRIPTION
## Summary
- The Coralogix API no longer accepts `90d` as a valid `SloTimeFrame`; the operator already rejects it at reconcile (no entry in `sloTimeFrameSchemaToOpenAPI`), but the CRD still advertised it as a valid value.
- Updated the `SloWindow.TimeFrame` godoc to drop `90d` from the valid-values list and add a `Deprecated:` note that propagates to `config/crd/bases/coralogix.com_slos.yaml`, the helm chart copy, and `docs/api.md` via `make manifests generate generate-api-docs helm-update-crds`.
- The enum itself still includes `90d` so existing manifests don't fail validation at apply time — they'll get a clear reconcile error instead, plus the new deprecation note steering them away.

## Test plan
- [x] `make manifests generate generate-api-docs helm-update-crds` — generated files are in sync
- [ ] Confirm the deprecation phrasing reads well in `docs/api.md` (rendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)