### PR TITLE
Bump coralogix-management-sdk to latest master

### DIFF
--- a/api/coralogix/v1alpha1/slo_types.go
+++ b/api/coralogix/v1alpha1/slo_types.go
@@ -158,14 +158,14 @@ type SLO struct {
 	Status SLOStatus `json:"status,omitempty"`
 }
 
-func (s *SLO) ExtractSLOCreateRequest() (*slos.SlosServiceCreateSloRequest, error) {
+func (s *SLO) ExtractSLOCreateRequest() (*slos.SlosServiceReplaceSloRequest, error) {
 	if requestBasedMetricSli := s.Spec.SliType.RequestBasedMetricSli; requestBasedMetricSli != nil {
 		requestBased, err := s.Spec.ExtractRequestBasedMetricSli()
 		if err != nil {
 			return nil, fmt.Errorf("error extracting request based metric SLI: %w", err)
 		}
 
-		return &slos.SlosServiceCreateSloRequest{
+		return &slos.SlosServiceReplaceSloRequest{
 			SloRequestBasedMetricSli: requestBased,
 		}, nil
 	} else if windowBasedMetricSli := s.Spec.SliType.WindowBasedMetricSli; windowBasedMetricSli != nil {
@@ -173,7 +173,7 @@ func (s *SLO) ExtractSLOCreateRequest() (*slos.SlosServiceCreateSloRequest, erro
 		if err != nil {
 			return nil, fmt.Errorf("error extracting window based metric SLI: %w", err)
 		}
-		return &slos.SlosServiceCreateSloRequest{
+		return &slos.SlosServiceReplaceSloRequest{
 			SloWindowBasedMetricSli: windowBased,
 		}, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.24.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260601102833-4ca808288d61
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3 h1:s9A0yKgkinPwoed3x1rvSkWDgqzh6UESyeMB8hBANsY=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260419071831-7155b4fd20d3/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260601102833-4ca808288d61 h1:edSVyzZBcC67iIsWEb0cYn6wLig3BYPE12ycGhBbFiU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260601102833-4ca808288d61/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/controller/coralogix/v1alpha1/slo_controller.go
+++ b/internal/controller/coralogix/v1alpha1/slo_controller.go
@@ -59,7 +59,7 @@ func (r *SLOReconciler) HandleCreation(ctx context.Context, log logr.Logger, obj
 	log.Info("Creating remote slo", "slo", utils.FormatJSON(createRequest))
 	createResponse, httpResp, err := r.SLOsClient.
 		SlosServiceCreateSlo(ctx).
-		SlosServiceCreateSloRequest(*createRequest).
+		SlosServiceReplaceSloRequest(*createRequest).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("error on creating remote slo: %w", cxsdk.NewAPIError(httpResp, err))


### PR DESCRIPTION
### Description

Bumps `github.com/coralogix/coralogix-management-sdk` from `v1.9.4-0.20260419071831-7155b4fd20d3` → `v1.9.4-0.20260601102833-4ca808288d61` (latest master HEAD; no `v1.9.4` tag exists yet), matching the SDK version pinned by [terraform-provider-coralogix v3.4.2](https://github.com/coralogix/terraform-provider-coralogix/pull/542).

**Adaptation:** the OpenAPI sync renamed the SLO create request type `SlosServiceCreateSloRequest` → `SlosServiceReplaceSloRequest`, and the create-slo request builder now accepts a `SlosServiceReplaceSloRequest` body. `SLO` Create (`ExtractSLOCreateRequest` + `slo_controller.go`) is adapted to the new type/builder — Update already used the Replace type. This was the **only** compile break from the bump (same as the provider's experience).

### Verified locally

```
go build ./...   # clean
go vet ./...     # clean
```

> **Note:** `make unit-tests` was not validated in this environment — the controller envtest suite connected to a live cluster and failed on RBAC/permissions unrelated to this change. The SDK bump touches many operator-consumed services; the unit/integration suites should be run in CI / a proper envtest environment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)