### PR TITLE
Remove team-iac from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @coralogix/team-iac @coralogix/team-eco-system
+* @coralogix/team-eco-system
 /README.md @coralogix/team-technical-writers
 /docs/metrics.md @coralogix/team-technical-writers
 /charts/coralogix-operator/README.md @coralogix/team-technical-writers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @coralogix/team-iac @coralogix/team-eco-system
+* @coralogix/team-eco-system
 
 # Technical writers own documentation
 README.md @coralogix/team-technical-writers


### PR DESCRIPTION
Jira: [CX-45967](https://coralogix.atlassian.net/browse/CX-45967)

Summary:
- Remove @coralogix/team-iac from CODEOWNERS ownership rules.
- Leave @coralogix/team-eco-system ownership intact where present.

Testing:
- Verified with `git grep -n "@coralogix/team-iac" -- "*CODEOWNERS"` that no CODEOWNERS matches remain.


[CX-45967]: https://coralogix.atlassian.net/browse/CX-45967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ