### PR TITLE
chore: bump coralogix-management-sdk to consume BYOC domain endpoint fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.24.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260604135216-368064cf1726
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260604135216-368064cf1726 h1:O1y/vpgOJCKMJBkU7WB35rvcew/y/vO0sFmSL5gnTmo=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260604135216-368064cf1726/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179 h1:DUC4FA/WdGffwT2f5BHe2/nZ0s8m746FuzQWjqDg+O0=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
## What

Bumps `github.com/coralogix/coralogix-management-sdk` to pick up the gRPC/REST endpoint resolution fix for custom (BYOC) domains.

```
v1.9.4-0.20260604135216-368064cf1726  ->  v1.9.4-0.20260628092624-ab4661a00179
```

Pulls in the **merged** coralogix-management-sdk#649 (master commit `ab4661a00`).

## Why

When a customer configures the operator with a custom domain, the operator passes the single `CORALOGIX_DOMAIN` / `--domain` value to **both** the gRPC and OpenAPI clients. In the previous SDK those clients disagreed on the domain form, so no single value worked for both:

| `CORALOGIX_DOMAIN` | OpenAPI | gRPC |
|---|---|---|
| `api.<tenant>.coralogix.com` | ✅ correct | ❌ `ng-api-grpc.api.<tenant>…` (NXDOMAIN) |
| `<tenant>.coralogix.com` | ❌ missing `api.` | ✅ correct |

The SDK fix establishes the **base** Coralogix domain as the single convention across protocols and normalizes a leading `api.`, so either input form resolves to the correct host for gRPC, ng-api REST, and OpenAPI. See coralogix-management-sdk#649.

## Scope

- **go.mod / go.sum only** — no operator code change is required; the operator already forwards one domain value to both clients correctly.
- Builds clean (`go build ./...`); `go mod tidy` applied.
- Verified the fix code (`normalizeCoralogixDomain`, `api.`-prefixing `URLFromDomain`) is present in the pinned module.

## Compatibility

Pure fix — no working setup changes behavior:
- Region identifiers (`us2`, `eu1`, …) are unchanged (matched before the normalize path).
- The `api.`-stripping only affects gRPC/REST inputs that previously produced `NXDOMAIN`.
- `URLFromDomain` only changes bare-domain inputs, for which bare-host OpenAPI was never a valid Coralogix endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)