### PR TITLE
chore: bump OperatorVersion to 2.4.0

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "2.3.0"
+const OperatorVersion = "2.4.0"
 
 var (
 	scheme   = k8sruntime.NewScheme()


### PR DESCRIPTION
Bumps the operator version constant in `cmd/main.go` to `2.4.0` ahead of cutting the `release-2.4` branch.

```
cmd/main.go: const OperatorVersion = "2.3.0" -> "2.4.0"
```

2.4.0 is the next minor: the latest released line is 2.3.x, and main carries features beyond it plus the BYOC custom-domain endpoint fix (#521), so a minor release is the right vehicle.

Scope: **`cmd/main.go` only** — no chart/README changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)