### PR TITLE
Fix unstable test: remote not found status recovery

### DIFF
--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
@@ -17,6 +17,7 @@ package coralogixreconciler
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -141,13 +142,12 @@ func ReconcileResource(ctx context.Context, req ctrl.Request, obj coralogix.Obje
 	log.Info("Handling update")
 	if err := r.HandleUpdate(ctx, log, obj); err != nil {
 		log.Error(err, "Error handling update")
-		if cxsdk.Code(err) == codes.NotFound || oapisdk.IsNotFound(err) {
+		if isRemoteNotFound(err) {
 			log.Info("resource not found on remote")
 			if err := removeField(ctx, obj, "status", "id"); err != nil {
 				log.Error(err, "Error removing id from status")
 				return ManageErrorWithRequeue(ctx, obj, utils.ReasonInternalK8sError, err)
 			}
-
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonRemoteResourceNotFound, fmt.Errorf("%s not found on remote: %w", gvk, err))
 		} else if oapisdk.IsDeserializationError(err) {
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonDeserializationError, err)
@@ -218,6 +218,18 @@ func ManageErrorWithRequeue(ctx context.Context, obj coralogix.Object, reason st
 	)
 
 	return reconcile.Result{}, err
+}
+
+func isRemoteNotFound(err error) bool {
+	// gRPC-backed SDK clients expose NotFound through cxsdk.Code.
+	if cxsdk.Code(err) == codes.NotFound {
+		return true
+	}
+
+	// This branch runs after updating an object that already has status.id.
+	// Some OpenAPI update calls return HTTP 404 in a body shape that
+	// oapisdk.IsNotFound does not classify as resource-not-found.
+	return oapisdk.IsNotFound(err) || oapisdk.Code(err) == http.StatusNotFound
 }
 
 func ManageSuccessWithRequeue(ctx context.Context, obj coralogix.Object, interval time.Duration) (reconcile.Result, error) {

--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler_test.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coralogixreconciler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	grpcsdk "github.com/coralogix/coralogix-management-sdk/go"
+	oapisdk "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsRemoteNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "grpc not found",
+			err:  grpcsdk.NewSdkAPIError(status.Error(codes.NotFound, "not found"), "", ""),
+			want: true,
+		},
+		{
+			name: "openapi http not found",
+			err:  oapisdk.NewAPIError(&http.Response{StatusCode: http.StatusNotFound}, errors.New("not found")),
+			want: true,
+		},
+		{
+			name: "openapi forbidden",
+			err:  oapisdk.NewAPIError(&http.Response{StatusCode: http.StatusForbidden}, errors.New("forbidden")),
+			want: false,
+		},
+		{
+			name: "unknown",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRemoteNotFound(tt.err); got != tt.want {
+				t.Fatalf("isRemoteNotFound() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fix remote deletion recovery for resources like Scope and Connector.

Related to the failures seen here: https://github.com/coralogix/coralogix-operator/actions/runs/28654435579/job/84991872983?pr=526.

These CRs use `status.id` to decide whether to create or update the remote resource. If the remote object is deleted directly from Coralogix, the operator still sees `status.id` and attempts an update. Scope and Connector can return an OpenAPI HTTP 404 shape that was not detected by the existing NotFound check, so the reconciler treated it as a normal update failure and never entered the existing `status.id` cleanup path.

## What changed

- Added a focused `isRemoteNotFound` helper for update errors.
- Broadened OpenAPI NotFound detection to include HTTP 404 responses that `oapisdk.IsNotFound` does not classify.
- Added focused tests for the NotFound detection behavior.

## Verification

- Added reconciler unit tests for remote NotFound detection.
- Ran reconciler package tests.
- Verified focused Connector/Scope e2e locally with the corrected operator image and 30s reconcile intervals.