### PR TITLE
chore: bump coralogix-management-sdk for JSON error-body 404 detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.24.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179 h1:DUC4FA/WdGffwT2f5BHe2/nZ0s8m746FuzQWjqDg+O0=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb h1:3OhNyNPwgYdPqzfALHLP64heS1nDIrtezBdlgqYQa/E=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
## What

Bumps `github.com/coralogix/coralogix-management-sdk` to the merge commit of coralogix-management-sdk#653:

```
v1.9.4-0.20260604135216-368064cf1726 → v1.9.4-0.20260706100328-522977c446eb
```

## Why

The Management API facade now returns errors as JSON (`{"code":404,"message":"Not Found: <msg>"}`) instead of plain text. The previous SDK's `cxsdk.IsNotFound` string-matched the plain-text body, so it stopped detecting 404s — and the reconciler's `HandleUpdate` branch (`oapisdk.IsNotFound(err)`) no longer recreated resources deleted outside the operator (the failing e2e tests). #653 makes `IsNotFound` parse the JSON `message` (falling back to raw text), tolerant of both formats.

## Verification

- `go build ./...` green.
- Confirmed the resolved module contains the fix (`json.Unmarshal` in `isResourceNotFoundBody`).

Only `go.mod`/`go.sum` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
