### PR TITLE
chore: release 2.4.1 — SDK bump for JSON error-body 404 detection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "2.4.0"
+const OperatorVersion = "2.4.1"
 
 var (
 	scheme   = k8sruntime.NewScheme()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.24.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179 h1:DUC4FA/WdGffwT2f5BHe2/nZ0s8m746FuzQWjqDg+O0=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260628092624-ab4661a00179/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb h1:3OhNyNPwgYdPqzfALHLP64heS1nDIrtezBdlgqYQa/E=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
## What

Patch release **2.4.1** on `release-2.4`:
1. Cherry-picks #529 — bumps `coralogix-management-sdk` to `v1.9.4-0.20260706100328-522977c446eb` (coralogix-management-sdk#653).
2. Bumps `OperatorVersion` `2.4.0` → `2.4.1`.

## Why

The Management API facade now returns errors as JSON (`{"code":404,"message":"Not Found: <msg>"}`). The prior SDK's `cxsdk.IsNotFound` string-matched the plain-text body, so it stopped detecting 404s and the reconciler no longer recreated resources deleted outside the operator. #653 makes `IsNotFound` tolerant of both formats.

## Verification

- `go build ./...` green.
- `go.mod` resolves to the SDK commit containing the fix.

Only `go.mod`, `go.sum`, and `cmd/main.go` (version string) changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
