### PR TITLE
Generate independent oneOf schemas for OpenAPI v3

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -27,6 +27,9 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       LOGS_BUCKET: ${{ secrets.LOGS_BUCKET }}
       METRICS_BUCKET: ${{ secrets.METRICS_BUCKET }}
+      SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
+      SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
+      PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -22,6 +22,9 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       LOGS_BUCKET: ${{ secrets.LOGS_BUCKET }}
       METRICS_BUCKET: ${{ secrets.METRICS_BUCKET }}
+      SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
+      SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
+      PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -27,6 +27,9 @@ jobs:
       AWS_REGION: ${{ secrets.AWS_REGION }}
       LOGS_BUCKET: ${{ secrets.LOGS_BUCKET }}
       METRICS_BUCKET: ${{ secrets.METRICS_BUCKET }}
+      SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
+      SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
+      PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/api/coralogix/v1alpha1/aievaluation_types.go
+++ b/api/coralogix/v1alpha1/aievaluation_types.go
@@ -380,48 +380,43 @@ func (c AIEvaluationConfig) ExtractAIEvaluationConfig() (*aievaluations.Evaluati
 }
 
 func (c *AIEvaluationAllowedTopicsConfig) ExtractAIEvaluationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigAllowedTopicsAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigAllowedTopics(aievaluations.AllowedTopicsConfig{
+	return &aievaluations.EvaluationConfig{
+		AllowedTopics: &aievaluations.AllowedTopicsConfig{
 			Topics: append([]string(nil), c.Topics...),
-		}),
-	)
-	return &config
+		},
+	}
 }
 
 func (c *AIEvaluationCompetitionConfig) ExtractAIEvaluationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigCompetitionAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigCompetition(aievaluations.CompetitionConfig{
+	return &aievaluations.EvaluationConfig{
+		Competition: &aievaluations.CompetitionConfig{
 			Competitors: append([]string(nil), c.Competitors...),
-		}),
-	)
-	return &config
+		},
+	}
 }
 
 func (c *AIEvaluationRestrictedTopicsConfig) ExtractAIEvaluationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigRestrictedTopicsAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigRestrictedTopics(aievaluations.RestrictedTopicsConfig{
+	return &aievaluations.EvaluationConfig{
+		RestrictedTopics: &aievaluations.RestrictedTopicsConfig{
 			Topics: append([]string(nil), c.Topics...),
-		}),
-	)
-	return &config
+		},
+	}
 }
 
 func (c *AIEvaluationSQLAllowedTablesConfig) ExtractAIEvaluationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSqlAllowedTablesAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlAllowedTables(aievaluations.SqlAllowedTablesConfig{
+	return &aievaluations.EvaluationConfig{
+		SqlAllowedTables: &aievaluations.SqlAllowedTablesConfig{
 			Tables: append([]string(nil), c.Tables...),
-		}),
-	)
-	return &config
+		},
+	}
 }
 
 func (c *AIEvaluationSQLRestrictedTablesConfig) ExtractAIEvaluationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSqlRestrictedTablesAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlRestrictedTables(aievaluations.SqlRestrictedTablesConfig{
+	return &aievaluations.EvaluationConfig{
+		SqlRestrictedTables: &aievaluations.SqlRestrictedTablesConfig{
 			Tables: append([]string(nil), c.Tables...),
-		}),
-	)
-	return &config
+		},
+	}
 }
 
 func (c *AIEvaluationPIIConfig) ExtractAIEvaluationConfig() *aievaluations.EvaluationConfig {
@@ -430,89 +425,77 @@ func (c *AIEvaluationPIIConfig) ExtractAIEvaluationConfig() *aievaluations.Evalu
 		categories = append(categories, schemaToOpenAPIAIEvaluationPIICategory[category])
 	}
 
-	config := aievaluations.EvaluationConfigPiiAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigPii(aievaluations.PiiConfig{Categories: categories}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		Pii: &aievaluations.PiiConfig{Categories: categories},
+	}
 }
 
 func (c *AIEvaluationPromptInjectionConfig) ExtractAIEvaluationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigPromptInjectionAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigPromptInjection(aievaluations.PromptInjectionConfig{
+	return &aievaluations.EvaluationConfig{
+		PromptInjection: &aievaluations.PromptInjectionConfig{
 			AdditionalContext: aievaluations.PtrString(c.AdditionalContext),
-		}),
-	)
-	return &config
+		},
+	}
 }
 
 func newOpenAPIAIEvaluationHallucinationCompletenessConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationCompletenessAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationCompleteness(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		HallucinationCompleteness: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationHallucinationContextAdherenceConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationContextAdherenceAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationContextAdherence(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		HallucinationContextAdherence: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationHallucinationContextRelevanceConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationContextRelevanceAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationContextRelevance(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		HallucinationContextRelevance: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationHallucinationCorrectnessConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationCorrectnessAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationCorrectness(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		HallucinationCorrectness: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationHallucinationTaskAdherenceConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigHallucinationTaskAdherenceAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigHallucinationTaskAdherence(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		HallucinationTaskAdherence: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationLanguageMismatchConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigLanguageMismatchAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigLanguageMismatch(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		LanguageMismatch: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationSexismConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSexismAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSexism(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		Sexism: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationSQLHallucinationConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSqlHallucinationAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlHallucination(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		SqlHallucination: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationSQLReadOnlyConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigSqlReadOnlyAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigSqlReadOnly(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		SqlReadOnly: map[string]interface{}{},
+	}
 }
 
 func newOpenAPIAIEvaluationToxicityConfig() *aievaluations.EvaluationConfig {
-	config := aievaluations.EvaluationConfigToxicityAsEvaluationConfig(
-		aievaluations.NewEvaluationConfigToxicity(map[string]interface{}{}),
-	)
-	return &config
+	return &aievaluations.EvaluationConfig{
+		Toxicity: map[string]interface{}{},
+	}
 }
 
 // NewAIEvaluationHallucinationCompletenessConfig returns the empty object required to enable hallucination completeness evaluation.

--- a/api/coralogix/v1alpha1/aievaluation_types_test.go
+++ b/api/coralogix/v1alpha1/aievaluation_types_test.go
@@ -584,110 +584,86 @@ func TestAIEvaluationExtractRequestsRejectEmptyConfig(t *testing.T) {
 }
 
 func assertPII(t *testing.T, config aievaluations.EvaluationConfig, values ...aievaluations.PiiCategory) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigPii)
-	require.True(t, ok)
-	pii := actual.GetPii()
-	require.ElementsMatch(t, values, (&pii).GetCategories())
+	require.NotNil(t, config.Pii)
+	require.ElementsMatch(t, values, config.Pii.GetCategories())
 }
 
 func assertAllowedTopics(t *testing.T, config aievaluations.EvaluationConfig, values ...string) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigAllowedTopics)
-	require.True(t, ok)
-	allowedTopics := actual.GetAllowedTopics()
-	require.ElementsMatch(t, values, allowedTopics.GetTopics())
+	require.NotNil(t, config.AllowedTopics)
+	require.ElementsMatch(t, values, config.AllowedTopics.GetTopics())
 }
 
 func assertCompetition(t *testing.T, config aievaluations.EvaluationConfig, values ...string) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigCompetition)
-	require.True(t, ok)
-	competition := actual.GetCompetition()
-	require.ElementsMatch(t, values, competition.GetCompetitors())
+	require.NotNil(t, config.Competition)
+	require.ElementsMatch(t, values, config.Competition.GetCompetitors())
 }
 
 func assertHallucinationCompleteness(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigHallucinationCompleteness)
-	require.True(t, ok)
-	require.Empty(t, actual.GetHallucinationCompleteness())
+	require.NotNil(t, config.HallucinationCompleteness)
+	require.Empty(t, config.HallucinationCompleteness)
 }
 
 func assertHallucinationContextAdherence(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigHallucinationContextAdherence)
-	require.True(t, ok)
-	require.Empty(t, actual.GetHallucinationContextAdherence())
+	require.NotNil(t, config.HallucinationContextAdherence)
+	require.Empty(t, config.HallucinationContextAdherence)
 }
 
 func assertHallucinationContextRelevance(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigHallucinationContextRelevance)
-	require.True(t, ok)
-	require.Empty(t, actual.GetHallucinationContextRelevance())
+	require.NotNil(t, config.HallucinationContextRelevance)
+	require.Empty(t, config.HallucinationContextRelevance)
 }
 
 func assertHallucinationCorrectness(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigHallucinationCorrectness)
-	require.True(t, ok)
-	require.Empty(t, actual.GetHallucinationCorrectness())
+	require.NotNil(t, config.HallucinationCorrectness)
+	require.Empty(t, config.HallucinationCorrectness)
 }
 
 func assertHallucinationTaskAdherence(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigHallucinationTaskAdherence)
-	require.True(t, ok)
-	require.Empty(t, actual.GetHallucinationTaskAdherence())
+	require.NotNil(t, config.HallucinationTaskAdherence)
+	require.Empty(t, config.HallucinationTaskAdherence)
 }
 
 func assertLanguageMismatch(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigLanguageMismatch)
-	require.True(t, ok)
-	require.Empty(t, actual.GetLanguageMismatch())
+	require.NotNil(t, config.LanguageMismatch)
+	require.Empty(t, config.LanguageMismatch)
 }
 
 func assertPromptInjection(t *testing.T, config aievaluations.EvaluationConfig, additionalContext string) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigPromptInjection)
-	require.True(t, ok)
-	promptInjection := actual.GetPromptInjection()
-	require.Equal(t, additionalContext, promptInjection.GetAdditionalContext())
+	require.NotNil(t, config.PromptInjection)
+	require.Equal(t, additionalContext, config.PromptInjection.GetAdditionalContext())
 }
 
 func assertRestrictedTopics(t *testing.T, config aievaluations.EvaluationConfig, values ...string) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigRestrictedTopics)
-	require.True(t, ok)
-	restrictedTopics := actual.GetRestrictedTopics()
-	require.ElementsMatch(t, values, restrictedTopics.GetTopics())
+	require.NotNil(t, config.RestrictedTopics)
+	require.ElementsMatch(t, values, config.RestrictedTopics.GetTopics())
 }
 
 func assertSexism(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigSexism)
-	require.True(t, ok)
-	require.Empty(t, actual.GetSexism())
+	require.NotNil(t, config.Sexism)
+	require.Empty(t, config.Sexism)
 }
 
 func assertSQLAllowedTables(t *testing.T, config aievaluations.EvaluationConfig, values ...string) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigSqlAllowedTables)
-	require.True(t, ok)
-	sqlAllowedTables := actual.GetSqlAllowedTables()
-	require.ElementsMatch(t, values, sqlAllowedTables.GetTables())
+	require.NotNil(t, config.SqlAllowedTables)
+	require.ElementsMatch(t, values, config.SqlAllowedTables.GetTables())
 }
 
 func assertSQLHallucination(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigSqlHallucination)
-	require.True(t, ok)
-	require.Empty(t, actual.GetSqlHallucination())
+	require.NotNil(t, config.SqlHallucination)
+	require.Empty(t, config.SqlHallucination)
 }
 
 func assertSQLReadOnly(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigSqlReadOnly)
-	require.True(t, ok)
-	require.Empty(t, actual.GetSqlReadOnly())
+	require.NotNil(t, config.SqlReadOnly)
+	require.Empty(t, config.SqlReadOnly)
 }
 
 func assertSQLRestrictedTables(t *testing.T, config aievaluations.EvaluationConfig, values ...string) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigSqlRestrictedTables)
-	require.True(t, ok)
-	sqlRestrictedTables := actual.GetSqlRestrictedTables()
-	require.ElementsMatch(t, values, sqlRestrictedTables.GetTables())
+	require.NotNil(t, config.SqlRestrictedTables)
+	require.ElementsMatch(t, values, config.SqlRestrictedTables.GetTables())
 }
 
 func assertToxicity(t *testing.T, config aievaluations.EvaluationConfig) {
-	actual, ok := config.GetActualInstance().(*aievaluations.EvaluationConfigToxicity)
-	require.True(t, ok)
-	require.Empty(t, actual.GetToxicity())
+	require.NotNil(t, config.Toxicity)
+	require.Empty(t, config.Toxicity)
 }

--- a/api/coralogix/v1alpha1/alertscheduler_types.go
+++ b/api/coralogix/v1alpha1/alertscheduler_types.go
@@ -273,11 +273,9 @@ func (a *AlertScheduler) extractFilter() (*alertscheduler.AlertSchedulerRuleProt
 	if a.Spec.Filter.MetaLabels != nil {
 		metaLabels := extractMetaLabels(a.Spec.Filter.MetaLabels)
 		return &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-			AlertSchedulerRuleProtobufV1FilterAlertMetaLabels: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertMetaLabels{
-				WhatExpression: ptr.To(a.Spec.Filter.WhatExpression),
-				AlertMetaLabels: alertscheduler.MetaLabels{
-					Value: metaLabels,
-				},
+			WhatExpression: ptr.To(a.Spec.Filter.WhatExpression),
+			AlertMetaLabels: &alertscheduler.MetaLabels{
+				Value: metaLabels,
 			},
 		}, nil
 	} else if a.Spec.Filter.Alerts != nil {
@@ -287,11 +285,9 @@ func (a *AlertScheduler) extractFilter() (*alertscheduler.AlertSchedulerRuleProt
 		}
 
 		return &alertscheduler.AlertSchedulerRuleProtobufV1Filter{
-			AlertSchedulerRuleProtobufV1FilterAlertUniqueIds: &alertscheduler.AlertSchedulerRuleProtobufV1FilterAlertUniqueIds{
-				WhatExpression: ptr.To(a.Spec.Filter.WhatExpression),
-				AlertUniqueIds: alertscheduler.AlertUniqueIds{
-					Value: alertsIds,
-				},
+			WhatExpression: ptr.To(a.Spec.Filter.WhatExpression),
+			AlertUniqueIds: &alertscheduler.AlertUniqueIds{
+				Value: alertsIds,
 			},
 		}, nil
 	}
@@ -353,58 +349,48 @@ func (a *AlertScheduler) extractSchedule() (*alertscheduler.Schedule, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error on extracting one time schedule: %w", err)
 		}
-		oneTime.ScheduleOperation = &scheduleOperation
 		return &alertscheduler.Schedule{
-			ScheduleOneTime: oneTime,
+			OneTime:           oneTime,
+			ScheduleOperation: &scheduleOperation,
 		}, nil
 	} else if a.Spec.Schedule.Recurring != nil {
 		recurring, err := a.extractRecurring()
 		if err != nil {
 			return nil, fmt.Errorf("error on extracting recurring schedule: %w", err)
 		}
-		recurring.ScheduleOperation = &scheduleOperation
 		return &alertscheduler.Schedule{
-			ScheduleRecurring: recurring,
+			Recurring:         recurring,
+			ScheduleOperation: &scheduleOperation,
 		}, nil
 	}
 
 	return nil, fmt.Errorf("exactly one of `oneTime` or `recurring` must be set")
 }
 
-func (a *AlertScheduler) extractOneTime() (*alertscheduler.ScheduleOneTime, error) {
+func (a *AlertScheduler) extractOneTime() (*alertscheduler.OneTime, error) {
 	timeFrame, err := extractTimeFrame(a.Spec.Schedule.OneTime)
 	if err != nil {
 		return nil, fmt.Errorf("error on extracting time frame: %w", err)
 	}
 
-	return &alertscheduler.ScheduleOneTime{
-		OneTime: alertscheduler.OneTime{
-			Timeframe: timeFrame,
-		},
+	return &alertscheduler.OneTime{
+		Timeframe: timeFrame,
 	}, nil
 }
 
-func (a *AlertScheduler) extractRecurring() (*alertscheduler.ScheduleRecurring, error) {
+func (a *AlertScheduler) extractRecurring() (*alertscheduler.Recurring, error) {
 	if a.Spec.Schedule.Recurring.Dynamic != nil {
 		dynamic, err := a.extractDynamic()
 		if err != nil {
 			return nil, fmt.Errorf("error on extracting dynamic schedule: %w", err)
 		}
 
-		return &alertscheduler.ScheduleRecurring{
-			Recurring: alertscheduler.Recurring{
-				RecurringSchedule: &alertscheduler.RecurringSchedule{
-					Schedule: *dynamic,
-				},
-			},
+		return &alertscheduler.Recurring{
+			Schedule: dynamic,
 		}, nil
 	} else if a.Spec.Schedule.Recurring.Always != nil {
-		return &alertscheduler.ScheduleRecurring{
-			Recurring: alertscheduler.Recurring{
-				RecurringAlwaysActive: &alertscheduler.RecurringAlwaysActive{
-					AlwaysActive: map[string]interface{}{},
-				},
-			},
+		return &alertscheduler.Recurring{
+			AlwaysActive: map[string]interface{}{},
 		}, nil
 	}
 
@@ -421,12 +407,10 @@ func (a *AlertScheduler) extractDynamic() (*alertscheduler.RecurringDynamic, err
 
 	if a.Spec.Schedule.Recurring.Dynamic.Frequency.Daily != nil {
 		return &alertscheduler.RecurringDynamic{
-			RecurringDynamicDaily: &alertscheduler.RecurringDynamicDaily{
-				Daily:           map[string]interface{}{},
-				RepeatEvery:     &repeatEvery,
-				Timeframe:       timeFrame,
-				TerminationDate: a.Spec.Schedule.Recurring.Dynamic.TerminationDate,
-			},
+			Daily:           map[string]interface{}{},
+			RepeatEvery:     &repeatEvery,
+			Timeframe:       timeFrame,
+			TerminationDate: a.Spec.Schedule.Recurring.Dynamic.TerminationDate,
 		}, nil
 	} else if weekly := a.Spec.Schedule.Recurring.Dynamic.Frequency.Weekly; weekly != nil {
 		var daysOfWeek []int32
@@ -434,25 +418,21 @@ func (a *AlertScheduler) extractDynamic() (*alertscheduler.RecurringDynamic, err
 			daysOfWeek = append(daysOfWeek, daysToValue[day])
 		}
 		return &alertscheduler.RecurringDynamic{
-			RecurringDynamicWeekly: &alertscheduler.RecurringDynamicWeekly{
-				Weekly: alertscheduler.Weekly{
-					DaysOfWeek: daysOfWeek,
-				},
-				RepeatEvery:     &repeatEvery,
-				Timeframe:       timeFrame,
-				TerminationDate: a.Spec.Schedule.Recurring.Dynamic.TerminationDate,
+			Weekly: &alertscheduler.Weekly{
+				DaysOfWeek: daysOfWeek,
 			},
+			RepeatEvery:     &repeatEvery,
+			Timeframe:       timeFrame,
+			TerminationDate: a.Spec.Schedule.Recurring.Dynamic.TerminationDate,
 		}, nil
 	} else if monthly := a.Spec.Schedule.Recurring.Dynamic.Frequency.Monthly; monthly != nil {
 		return &alertscheduler.RecurringDynamic{
-			RecurringDynamicMonthly: &alertscheduler.RecurringDynamicMonthly{
-				Monthly: alertscheduler.Monthly{
-					DaysOfMonth: monthly.Days,
-				},
-				RepeatEvery:     &repeatEvery,
-				Timeframe:       timeFrame,
-				TerminationDate: a.Spec.Schedule.Recurring.Dynamic.TerminationDate,
+			Monthly: &alertscheduler.Monthly{
+				DaysOfMonth: monthly.Days,
 			},
+			RepeatEvery:     &repeatEvery,
+			Timeframe:       timeFrame,
+			TerminationDate: a.Spec.Schedule.Recurring.Dynamic.TerminationDate,
 		}, nil
 	}
 
@@ -462,22 +442,18 @@ func (a *AlertScheduler) extractDynamic() (*alertscheduler.RecurringDynamic, err
 func extractTimeFrame(timeFrame *TimeFrame) (*alertscheduler.Timeframe, error) {
 	if timeFrame.EndTime != nil {
 		return &alertscheduler.Timeframe{
-			TimeframeEndTime: &alertscheduler.TimeframeEndTime{
-				StartTime: ptr.To(timeFrame.StartTime),
-				Timezone:  ptr.To(timeFrame.Timezone),
-				EndTime:   *timeFrame.EndTime,
-			},
+			StartTime: ptr.To(timeFrame.StartTime),
+			Timezone:  ptr.To(timeFrame.Timezone),
+			EndTime:   timeFrame.EndTime,
 		}, nil
 	} else if timeFrame.Duration != nil {
 		frequency := schemaToDurationFrequency[timeFrame.Duration.Frequency]
 		return &alertscheduler.Timeframe{
-			TimeframeDuration: &alertscheduler.TimeframeDuration{
-				StartTime: ptr.To(timeFrame.StartTime),
-				Timezone:  ptr.To(timeFrame.Timezone),
-				Duration: alertscheduler.V1Duration{
-					ForOver:   ptr.To(timeFrame.Duration.ForOver),
-					Frequency: &frequency,
-				},
+			StartTime: ptr.To(timeFrame.StartTime),
+			Timezone:  ptr.To(timeFrame.Timezone),
+			Duration: &alertscheduler.V1Duration{
+				ForOver:   ptr.To(timeFrame.Duration.ForOver),
+				Frequency: &frequency,
 			},
 		}, nil
 	}

--- a/api/coralogix/v1alpha1/apikey_types.go
+++ b/api/coralogix/v1alpha1/apikey_types.go
@@ -120,10 +120,10 @@ type ApiKeyList struct {
 func (s *ApiKeySpec) ExtractCreateApiKeyRequest() *apikeys.CreateApiKeyRequest {
 	owner := &apikeys.Owner{}
 	if s.Owner.UserId != nil {
-		owner.OwnerUserId = &apikeys.OwnerUserId{UserId: *s.Owner.UserId}
+		owner.UserId = s.Owner.UserId
 	}
 	if s.Owner.TeamId != nil {
-		owner.OwnerTeamId = &apikeys.OwnerTeamId{TeamId: int64(*s.Owner.TeamId)}
+		owner.TeamId = apikeys.PtrInt64(int64(*s.Owner.TeamId))
 	}
 
 	return &apikeys.CreateApiKeyRequest{

--- a/api/coralogix/v1alpha1/archivelogstarget_types.go
+++ b/api/coralogix/v1alpha1/archivelogstarget_types.go
@@ -67,7 +67,7 @@ func (s *ArchiveLogsTargetSpec) ExtractSetTargetRequest(isTargetActive bool) (*t
 	if s.S3Target != nil {
 		return &targets.SetTargetResponse{
 			IsActive: isTargetActive,
-			S3: &targets.S3TargetSpec{
+			S3: targets.S3TargetSpec{
 				Region: &s.S3Target.Region,
 				Bucket: s.S3Target.BucketName,
 			},

--- a/api/coralogix/v1alpha1/archivemetricstarget_types.go
+++ b/api/coralogix/v1alpha1/archivemetricstarget_types.go
@@ -55,19 +55,17 @@ type ArchiveMetricsTargetStatus struct {
 	PrintableStatus string `json:"printableStatus,omitempty"`
 }
 
-func (s *ArchiveMetricsTargetSpec) ExtractConfigureTenantRequest() (*archivemetrics.MetricsConfiguratorPublicServiceConfigureTenantRequest, error) {
+func (s *ArchiveMetricsTargetSpec) ExtractConfigureTenantRequest() (*archivemetrics.ConfigureTenantRequest, error) {
 	if s.S3Target != nil {
-		return &archivemetrics.MetricsConfiguratorPublicServiceConfigureTenantRequest{
-			ConfigureTenantRequestS3: &archivemetrics.ConfigureTenantRequestS3{
-				RetentionPolicy: &archivemetrics.RetentionPolicyRequest{
-					RawResolution:         s.ResolutionPolicy.RawResolution,
-					FiveMinutesResolution: s.ResolutionPolicy.FiveMinutesResolution,
-					OneHourResolution:     s.ResolutionPolicy.OneHourResolution,
-				},
-				S3: archivemetrics.S3Config{
-					Region: s.S3Target.Region,
-					Bucket: s.S3Target.BucketName,
-				},
+		return &archivemetrics.ConfigureTenantRequest{
+			RetentionPolicy: &archivemetrics.RetentionPolicyRequest{
+				RawResolution:         s.ResolutionPolicy.RawResolution,
+				FiveMinutesResolution: s.ResolutionPolicy.FiveMinutesResolution,
+				OneHourResolution:     s.ResolutionPolicy.OneHourResolution,
+			},
+			S3: &archivemetrics.S3Config{
+				Region: s.S3Target.Region,
+				Bucket: s.S3Target.BucketName,
 			},
 		}, nil
 	}
@@ -75,15 +73,13 @@ func (s *ArchiveMetricsTargetSpec) ExtractConfigureTenantRequest() (*archivemetr
 	return nil, fmt.Errorf("archive metrics target does not have a S3Target")
 }
 
-func (s *ArchiveMetricsTargetSpec) ExtractUpdateRequest() (*archivemetrics.MetricsConfiguratorPublicServiceUpdateRequest, error) {
+func (s *ArchiveMetricsTargetSpec) ExtractUpdateRequest() (*archivemetrics.UpdateTenantRequest, error) {
 	if s.S3Target != nil {
-		return &archivemetrics.MetricsConfiguratorPublicServiceUpdateRequest{
-			UpdateRequestS3: &archivemetrics.UpdateRequestS3{
-				RetentionDays: s.RetentionDays,
-				S3: archivemetrics.S3Config{
-					Region: s.S3Target.Region,
-					Bucket: s.S3Target.BucketName,
-				},
+		return &archivemetrics.UpdateTenantRequest{
+			RetentionDays: s.RetentionDays,
+			S3: &archivemetrics.S3Config{
+				Region: s.S3Target.Region,
+				Bucket: s.S3Target.BucketName,
 			},
 		}, nil
 	}

--- a/api/coralogix/v1alpha1/customenrichment_types.go
+++ b/api/coralogix/v1alpha1/customenrichment_types.go
@@ -72,11 +72,9 @@ func (c *CustomEnrichment) ExtractCreateCustomEnrichmentRequest(ctx context.Cont
 		Name:        c.Spec.Name,
 		Description: c.Spec.Description,
 		File: customenrichments.File{
-			FileTextual: &customenrichments.FileTextual{
-				Name:      customenrichments.PtrString(name),
-				Extension: customenrichments.PtrString("csv"),
-				Textual:   *fileContent,
-			},
+			Name:      customenrichments.PtrString(name),
+			Extension: customenrichments.PtrString("csv"),
+			Textual:   fileContent,
 		},
 	}, nil
 }
@@ -115,11 +113,9 @@ func (c *CustomEnrichment) ExtractUpdateCustomEnrichmentRequest(ctx context.Cont
 		Name:               c.Spec.Name,
 		Description:        c.Spec.Description,
 		File: customenrichments.File{
-			FileTextual: &customenrichments.FileTextual{
-				Name:      customenrichments.PtrString(name),
-				Extension: customenrichments.PtrString("csv"),
-				Textual:   *fileContent,
-			},
+			Name:      customenrichments.PtrString(name),
+			Extension: customenrichments.PtrString("csv"),
+			Textual:   fileContent,
 		},
 	}, nil
 }

--- a/api/coralogix/v1alpha1/customrole_types.go
+++ b/api/coralogix/v1alpha1/customrole_types.go
@@ -39,12 +39,10 @@ type CustomRoleSpec struct {
 
 func (s *CustomRoleSpec) ExtractCreateCustomRoleRequest() *customroles.RoleManagementServiceCreateRoleRequest {
 	return &customroles.RoleManagementServiceCreateRoleRequest{
-		CreateRoleRequestParentRoleName: &customroles.CreateRoleRequestParentRoleName{
-			Name:           customroles.PtrString(s.Name),
-			Description:    customroles.PtrString(s.Description),
-			ParentRoleName: s.ParentRoleName,
-			Permissions:    s.Permissions,
-		},
+		Name:           customroles.PtrString(s.Name),
+		Description:    customroles.PtrString(s.Description),
+		ParentRoleName: customroles.PtrString(s.ParentRoleName),
+		Permissions:    s.Permissions,
 	}
 }
 

--- a/api/coralogix/v1alpha1/enrichment_types.go
+++ b/api/coralogix/v1alpha1/enrichment_types.go
@@ -186,10 +186,8 @@ func (e *Enrichment) ExtractAtomicOverwriteRequest(ctx context.Context) (
 			model := enrichments.EnrichmentRequestModel{
 				FieldName: enrichment.GeoIp.FieldName,
 				EnrichmentType: enrichments.EnrichmentType{
-					EnrichmentTypeGeoIp: &enrichments.EnrichmentTypeGeoIp{
-						GeoIp: enrichments.GeoIpType{
-							WithAsn: enrichment.GeoIp.WithAsn,
-						},
+					GeoIp: &enrichments.GeoIpType{
+						WithAsn: enrichment.GeoIp.WithAsn,
 					},
 				},
 			}
@@ -199,9 +197,7 @@ func (e *Enrichment) ExtractAtomicOverwriteRequest(ctx context.Context) (
 			model := enrichments.EnrichmentRequestModel{
 				FieldName: enrichment.SuspiciousIp.FieldName,
 				EnrichmentType: enrichments.EnrichmentType{
-					EnrichmentTypeSuspiciousIp: &enrichments.EnrichmentTypeSuspiciousIp{
-						SuspiciousIp: map[string]any{},
-					},
+					SuspiciousIp: map[string]any{},
 				},
 			}
 			applyEnrichmentFieldOptions(
@@ -214,10 +210,8 @@ func (e *Enrichment) ExtractAtomicOverwriteRequest(ctx context.Context) (
 			model := enrichments.EnrichmentRequestModel{
 				FieldName: enrichment.Aws.FieldName,
 				EnrichmentType: enrichments.EnrichmentType{
-					EnrichmentTypeAws: &enrichments.EnrichmentTypeAws{
-						Aws: enrichments.AwsType{
-							ResourceType: enrichments.PtrString(enrichment.Aws.ResourceType),
-						},
+					Aws: &enrichments.AwsType{
+						ResourceType: enrichments.PtrString(enrichment.Aws.ResourceType),
 					},
 				},
 			}
@@ -232,10 +226,8 @@ func (e *Enrichment) ExtractAtomicOverwriteRequest(ctx context.Context) (
 			model := enrichments.EnrichmentRequestModel{
 				FieldName: enrichment.Custom.FieldName,
 				EnrichmentType: enrichments.EnrichmentType{
-					EnrichmentTypeCustomEnrichment: &enrichments.EnrichmentTypeCustomEnrichment{
-						CustomEnrichment: enrichments.CustomEnrichmentType{
-							Id: &customEnrichmentID,
-						},
+					CustomEnrichment: &enrichments.CustomEnrichmentType{
+						Id: &customEnrichmentID,
 					},
 				},
 			}

--- a/api/coralogix/v1alpha1/enrichment_types_test.go
+++ b/api/coralogix/v1alpha1/enrichment_types_test.go
@@ -61,10 +61,10 @@ func TestEnrichmentExtractAtomicOverwriteRequestIncludesNonCustomFieldOptions(t 
 	}
 
 	assertRequestFieldOptions(t, &req.RequestEnrichments[0], "attributes.client_ip", "client_geo", []string{"city", "country"})
-	if req.RequestEnrichments[0].EnrichmentType.EnrichmentTypeGeoIp == nil {
+	if req.RequestEnrichments[0].EnrichmentType.GeoIp == nil {
 		t.Fatal("geo_ip enrichment type was not set")
 	}
-	if got := req.RequestEnrichments[0].EnrichmentType.EnrichmentTypeGeoIp.GeoIp.WithAsn; got == nil || !*got {
+	if got := req.RequestEnrichments[0].EnrichmentType.GeoIp.WithAsn; got == nil || !*got {
 		t.Fatalf("geo_ip WithAsn = %v, want true", got)
 	}
 
@@ -75,7 +75,7 @@ func TestEnrichmentExtractAtomicOverwriteRequestIncludesNonCustomFieldOptions(t 
 		"source_threat",
 		[]string{"classification", "threat_score"},
 	)
-	if req.RequestEnrichments[1].EnrichmentType.EnrichmentTypeSuspiciousIp == nil {
+	if req.RequestEnrichments[1].EnrichmentType.SuspiciousIp == nil {
 		t.Fatal("suspicious_ip enrichment type was not set")
 	}
 
@@ -86,11 +86,11 @@ func TestEnrichmentExtractAtomicOverwriteRequestIncludesNonCustomFieldOptions(t 
 		"aws_resource",
 		[]string{"resourceId", "accountId"},
 	)
-	awsType := req.RequestEnrichments[2].EnrichmentType.EnrichmentTypeAws
+	awsType := req.RequestEnrichments[2].EnrichmentType.Aws
 	if awsType == nil {
 		t.Fatal("aws enrichment type was not set")
 	}
-	if got := awsType.Aws.ResourceType; got == nil || *got != "AWS::EC2::Instance" {
+	if got := awsType.ResourceType; got == nil || *got != "AWS::EC2::Instance" {
 		t.Fatalf("aws ResourceType = %v, want AWS::EC2::Instance", got)
 	}
 }

--- a/api/coralogix/v1alpha1/group_types.go
+++ b/api/coralogix/v1alpha1/group_types.go
@@ -155,28 +155,25 @@ func (g *Group) ExtractUpdateGroupRequest(
 		GroupType:   groupType,
 		UserUpdates: &groups.UserUpdates{
 			Operation: &groups.UserUpdatesOperation{
-				UserUpdatesOperationSet: &groups.UserUpdatesOperationSet{
-					Set: groups.UserIdList{
-						UserIds: usersIds,
-					},
+				OperationType: "set",
+				Set: &groups.UserIdList{
+					UserIds: usersIds,
 				},
 			},
 		},
 		RoleUpdate: &groups.RoleUpdate{
 			Action: &groups.RoleUpdateAction{
-				RoleUpdateActionSetRoleId: &groups.RoleUpdateActionSetRoleId{
-					SetRoleId: groups.SetRoleId{
-						Value: &roleId,
-					},
+				ActionType: "set_role_id",
+				SetRoleId: &groups.SetRoleId{
+					Value: &roleId,
 				},
 			},
 		},
 		ScopeUpdate: &groups.ScopeUpdate{
 			Action: &groups.ScopeUpdateAction{
-				ScopeUpdateActionSetScopeId: &groups.ScopeUpdateActionSetScopeId{
-					SetScopeId: groups.SetScopeId{
-						Value: scopeId,
-					},
+				ActionType: "set_scope_id",
+				SetScopeId: &groups.SetScopeId{
+					Value: scopeId,
 				},
 			},
 		},

--- a/api/coralogix/v1alpha1/integration_types.go
+++ b/api/coralogix/v1alpha1/integration_types.go
@@ -150,24 +150,18 @@ func (s *IntegrationSpec) ExtractParameters(ctx context.Context, namespace strin
 		switch v := value.(type) {
 		case string:
 			parameters = append(parameters, integrations.Parameter{
-				ParameterStringValue: &integrations.ParameterStringValue{
-					Key:         integrations.PtrString(key),
-					StringValue: v,
-				},
+				Key:         integrations.PtrString(key),
+				StringValue: integrations.PtrString(v),
 			})
 		case float64:
 			parameters = append(parameters, integrations.Parameter{
-				ParameterNumericValue: &integrations.ParameterNumericValue{
-					Key:          integrations.PtrString(key),
-					NumericValue: v,
-				},
+				Key:          integrations.PtrString(key),
+				NumericValue: integrations.PtrFloat64(v),
 			})
 		case bool:
 			parameters = append(parameters, integrations.Parameter{
-				ParameterBooleanValue: &integrations.ParameterBooleanValue{
-					Key:          integrations.PtrString(key),
-					BooleanValue: v,
-				},
+				Key:          integrations.PtrString(key),
+				BooleanValue: integrations.PtrBool(v),
 			})
 		case []interface{}:
 			var stringList integrations.StringList
@@ -177,10 +171,8 @@ func (s *IntegrationSpec) ExtractParameters(ctx context.Context, namespace strin
 				}
 			}
 			parameters = append(parameters, integrations.Parameter{
-				ParameterStringList: &integrations.ParameterStringList{
-					Key:        integrations.PtrString(key),
-					StringList: stringList,
-				},
+				Key:        integrations.PtrString(key),
+				StringList: &stringList,
 			})
 		default:
 			return nil, fmt.Errorf("unsupported value type for parameter %s", key)

--- a/api/coralogix/v1alpha1/integration_types_test.go
+++ b/api/coralogix/v1alpha1/integration_types_test.go
@@ -178,8 +178,8 @@ func TestExtractParameters(t *testing.T) {
 func stringParamsByKey(params []integrations.Parameter) map[string]string {
 	out := map[string]string{}
 	for _, p := range params {
-		if p.ParameterStringValue != nil && p.ParameterStringValue.Key != nil {
-			out[*p.ParameterStringValue.Key] = p.ParameterStringValue.StringValue
+		if p.StringValue != nil && p.Key != nil {
+			out[*p.Key] = *p.StringValue
 		}
 	}
 	return out

--- a/api/coralogix/v1alpha1/outboundwebhook_types.go
+++ b/api/coralogix/v1alpha1/outboundwebhook_types.go
@@ -411,93 +411,73 @@ func (in *OutboundWebhook) ExtractUpdateOutboundWebhookRequest() (*webhooks.Upda
 func (in *OutboundWebhookSpec) ExtractOutgoingWebhookInputData() (*webhooks.OutgoingWebhookInputData, error) {
 	if genericWebhook := in.OutboundWebhookType.GenericWebhook; genericWebhook != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataGenericWebhook: &webhooks.OutgoingWebhookInputDataGenericWebhook{
-				Name:           webhooks.PtrString(in.Name),
-				Type:           webhooks.WEBHOOKTYPE_GENERIC.Ptr(),
-				Url:            webhooks.PtrString(genericWebhook.Url),
-				GenericWebhook: *genericWebhook.extractGenericWebhookConfig(),
-			},
+			Name:           webhooks.PtrString(in.Name),
+			Type:           webhooks.WEBHOOKTYPE_GENERIC.Ptr(),
+			Url:            webhooks.PtrString(genericWebhook.Url),
+			GenericWebhook: genericWebhook.extractGenericWebhookConfig(),
 		}, nil
 	} else if slack := in.OutboundWebhookType.Slack; slack != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataSlack: &webhooks.OutgoingWebhookInputDataSlack{
-				Name:  webhooks.PtrString(in.Name),
-				Type:  webhooks.WEBHOOKTYPE_SLACK.Ptr(),
-				Url:   webhooks.PtrString(slack.Url),
-				Slack: *slack.extractSlackConfig(),
-			},
+			Name:  webhooks.PtrString(in.Name),
+			Type:  webhooks.WEBHOOKTYPE_SLACK.Ptr(),
+			Url:   webhooks.PtrString(slack.Url),
+			Slack: slack.extractSlackConfig(),
 		}, nil
 	} else if pagerDuty := in.OutboundWebhookType.PagerDuty; pagerDuty != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataPagerDuty: &webhooks.OutgoingWebhookInputDataPagerDuty{
-				Name:      webhooks.PtrString(in.Name),
-				Type:      webhooks.WEBHOOKTYPE_PAGERDUTY.Ptr(),
-				PagerDuty: *pagerDuty.extractPagerDutyConfig(),
-			},
+			Name:      webhooks.PtrString(in.Name),
+			Type:      webhooks.WEBHOOKTYPE_PAGERDUTY.Ptr(),
+			PagerDuty: pagerDuty.extractPagerDutyConfig(),
 		}, nil
 	} else if sendLog := in.OutboundWebhookType.SendLog; sendLog != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataSendLog: &webhooks.OutgoingWebhookInputDataSendLog{
-				Name:    webhooks.PtrString(in.Name),
-				Type:    webhooks.WEBHOOKTYPE_SEND_LOG.Ptr(),
-				Url:     webhooks.PtrString(sendLog.Url),
-				SendLog: *sendLog.extractSendLogConfig(),
-			},
+			Name:    webhooks.PtrString(in.Name),
+			Type:    webhooks.WEBHOOKTYPE_SEND_LOG.Ptr(),
+			Url:     webhooks.PtrString(sendLog.Url),
+			SendLog: sendLog.extractSendLogConfig(),
 		}, nil
 	} else if emailGroup := in.OutboundWebhookType.EmailGroup; emailGroup != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataEmailGroup: &webhooks.OutgoingWebhookInputDataEmailGroup{
-				Name:       webhooks.PtrString(in.Name),
-				Type:       webhooks.WEBHOOKTYPE_EMAIL_GROUP.Ptr(),
-				EmailGroup: *emailGroup.extractEmailGroupConfig(),
-			},
+			Name:       webhooks.PtrString(in.Name),
+			Type:       webhooks.WEBHOOKTYPE_EMAIL_GROUP.Ptr(),
+			EmailGroup: emailGroup.extractEmailGroupConfig(),
 		}, nil
 	} else if microsoftTeams := in.OutboundWebhookType.MicrosoftTeams; microsoftTeams != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataMicrosoftTeams: &webhooks.OutgoingWebhookInputDataMicrosoftTeams{
-				Name:           webhooks.PtrString(in.Name),
-				Type:           webhooks.WEBHOOKTYPE_MICROSOFT_TEAMS.Ptr(),
-				Url:            webhooks.PtrString(microsoftTeams.Url),
-				MicrosoftTeams: map[string]interface{}{},
-			},
+			Name:           webhooks.PtrString(in.Name),
+			Type:           webhooks.WEBHOOKTYPE_MICROSOFT_TEAMS.Ptr(),
+			Url:            webhooks.PtrString(microsoftTeams.Url),
+			MicrosoftTeams: map[string]interface{}{},
 		}, nil
 	} else if jira := in.OutboundWebhookType.Jira; jira != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataJira: &webhooks.OutgoingWebhookInputDataJira{
-				Name: webhooks.PtrString(in.Name),
-				Type: webhooks.WEBHOOKTYPE_JIRA.Ptr(),
-				Url:  webhooks.PtrString(jira.Url),
-				Jira: *jira.extractJiraConfig(),
-			},
+			Name: webhooks.PtrString(in.Name),
+			Type: webhooks.WEBHOOKTYPE_JIRA.Ptr(),
+			Url:  webhooks.PtrString(jira.Url),
+			Jira: jira.extractJiraConfig(),
 		}, nil
 	} else if opsgenie := in.OutboundWebhookType.Opsgenie; opsgenie != nil {
 		//data.Config = opsgenie.extractOpsgenieConfig()
 		//data.Type = cxsdk.WebhookTypeOpsgenie
 		//data.Url = opsgenie.Url)
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataOpsgenie: &webhooks.OutgoingWebhookInputDataOpsgenie{
-				Name:     webhooks.PtrString(in.Name),
-				Type:     webhooks.WEBHOOKTYPE_OPSGENIE.Ptr(),
-				Url:      webhooks.PtrString(opsgenie.Url),
-				Opsgenie: map[string]interface{}{},
-			},
+			Name:     webhooks.PtrString(in.Name),
+			Type:     webhooks.WEBHOOKTYPE_OPSGENIE.Ptr(),
+			Url:      webhooks.PtrString(opsgenie.Url),
+			Opsgenie: map[string]interface{}{},
 		}, nil
 	} else if demisto := in.OutboundWebhookType.Demisto; demisto != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataDemisto: &webhooks.OutgoingWebhookInputDataDemisto{
-				Name:    webhooks.PtrString(in.Name),
-				Type:    webhooks.WEBHOOKTYPE_DEMISTO.Ptr(),
-				Url:     webhooks.PtrString(demisto.Url),
-				Demisto: *demisto.extractDemistoConfig(),
-			},
+			Name:    webhooks.PtrString(in.Name),
+			Type:    webhooks.WEBHOOKTYPE_DEMISTO.Ptr(),
+			Url:     webhooks.PtrString(demisto.Url),
+			Demisto: demisto.extractDemistoConfig(),
 		}, nil
 	} else if in.OutboundWebhookType.AwsEventBridge != nil {
 		return &webhooks.OutgoingWebhookInputData{
-			OutgoingWebhookInputDataAwsEventBridge: &webhooks.OutgoingWebhookInputDataAwsEventBridge{
-				Name:           webhooks.PtrString(in.Name),
-				Type:           webhooks.WEBHOOKTYPE_AWS_EVENT_BRIDGE.Ptr(),
-				AwsEventBridge: *in.OutboundWebhookType.AwsEventBridge.extractAwsEventBridgeConfig(),
-			},
+			Name:           webhooks.PtrString(in.Name),
+			Type:           webhooks.WEBHOOKTYPE_AWS_EVENT_BRIDGE.Ptr(),
+			AwsEventBridge: in.OutboundWebhookType.AwsEventBridge.extractAwsEventBridgeConfig(),
 		}, nil
 	}
 

--- a/api/coralogix/v1alpha1/preset_types.go
+++ b/api/coralogix/v1alpha1/preset_types.go
@@ -170,16 +170,12 @@ func ExtractConfigOverrides(overrides []ConfigOverride) []presets.ConfigOverride
 
 		if override.ConditionType.MatchEntityType != nil {
 			configOverride.ConditionType = &presets.NotificationCenterConditionType{
-				NotificationCenterConditionTypeMatchEntityType: &presets.NotificationCenterConditionTypeMatchEntityType{
-					MatchEntityType: map[string]interface{}{},
-				},
+				MatchEntityType: map[string]interface{}{},
 			}
 		} else if override.ConditionType.MatchEntityTypeAndSubType != nil {
 			configOverride.ConditionType = &presets.NotificationCenterConditionType{
-				NotificationCenterConditionTypeMatchEntityTypeAndSubType: &presets.NotificationCenterConditionTypeMatchEntityTypeAndSubType{
-					MatchEntityTypeAndSubType: presets.MatchEntityTypeAndSubTypeCondition{
-						EntitySubType: presets.PtrString(override.ConditionType.MatchEntityTypeAndSubType.EntitySubType),
-					},
+				MatchEntityTypeAndSubType: &presets.MatchEntityTypeAndSubTypeCondition{
+					EntitySubType: presets.PtrString(override.ConditionType.MatchEntityTypeAndSubType.EntitySubType),
 				},
 			}
 		}

--- a/api/coralogix/v1alpha1/recordingrulegroupset_types.go
+++ b/api/coralogix/v1alpha1/recordingrulegroupset_types.go
@@ -49,7 +49,7 @@ func expandRecordingRuleGroup(group RecordingRuleGroup) *recordingrules.InRuleGr
 	rules := expandRecordingRules(group.Rules)
 
 	return &recordingrules.InRuleGroup{
-		Name:     recordingrules.PtrString(group.Name),
+		Name:     group.Name,
 		Interval: interval,
 		Limit:    limit,
 		Rules:    rules,
@@ -67,8 +67,8 @@ func expandRecordingRules(rules []RecordingRule) []recordingrules.InRule {
 
 func extractRecordingRule(rule RecordingRule) *recordingrules.InRule {
 	return &recordingrules.InRule{
-		Record: recordingrules.PtrString(rule.Record),
-		Expr:   recordingrules.PtrString(rule.Expr),
+		Record: rule.Record,
+		Expr:   rule.Expr,
 		Labels: ptr.To(rule.Labels),
 	}
 }

--- a/api/coralogix/v1alpha1/rulegroup_types.go
+++ b/api/coralogix/v1alpha1/rulegroup_types.go
@@ -387,33 +387,27 @@ func expandSourceFiledAndParameters(rule Rule) (sourceField string, parameters *
 	if parse := rule.Parse; parse != nil {
 		sourceField = parse.SourceField
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersParseParameters: &rulegroups.RuleParametersParseParameters{
-				ParseParameters: rulegroups.ParseParameters{
-					DestinationField: rulegroups.PtrString(parse.DestinationField),
-					Rule:             rulegroups.PtrString(parse.Regex),
-				},
+			ParseParameters: &rulegroups.ParseParameters{
+				DestinationField: rulegroups.PtrString(parse.DestinationField),
+				Rule:             rulegroups.PtrString(parse.Regex),
 			},
 		}
 	} else if parseJsonField := rule.ParseJsonField; parseJsonField != nil {
 		sourceField = parseJsonField.SourceField
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersJsonParseParameters: &rulegroups.RuleParametersJsonParseParameters{
-				JsonParseParameters: rulegroups.JsonParseParameters{
-					DestinationField: rulegroups.PtrString(parseJsonField.DestinationField),
-					DeleteSource:     rulegroups.PtrBool(!parseJsonField.KeepSourceField),
-					OverrideDest:     rulegroups.PtrBool(!parseJsonField.KeepDestinationField),
-					EscapedValue:     rulegroups.PtrBool(true),
-				},
+			JsonParseParameters: &rulegroups.JsonParseParameters{
+				DestinationField: rulegroups.PtrString(parseJsonField.DestinationField),
+				DeleteSource:     rulegroups.PtrBool(!parseJsonField.KeepSourceField),
+				OverrideDest:     rulegroups.PtrBool(!parseJsonField.KeepDestinationField),
+				EscapedValue:     rulegroups.PtrBool(true),
 			},
 		}
 	} else if jsonStringify := rule.JsonStringify; jsonStringify != nil {
 		sourceField = jsonStringify.SourceField
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersJsonStringifyParameters: &rulegroups.RuleParametersJsonStringifyParameters{
-				JsonStringifyParameters: rulegroups.JsonStringifyParameters{
-					DestinationField: rulegroups.PtrString(jsonStringify.DestinationField),
-					DeleteSource:     rulegroups.PtrBool(!jsonStringify.KeepSourceField),
-				},
+			JsonStringifyParameters: &rulegroups.JsonStringifyParameters{
+				DestinationField: rulegroups.PtrString(jsonStringify.DestinationField),
+				DeleteSource:     rulegroups.PtrBool(!jsonStringify.KeepSourceField),
 			},
 		}
 	} else if jsonExtract := rule.JsonExtract; jsonExtract != nil {
@@ -421,20 +415,16 @@ func expandSourceFiledAndParameters(rule Rule) (sourceField string, parameters *
 		destinationField := RulesSchemaDestinationFieldToOpenAPISeverityDestinationField[jsonExtract.DestinationField]
 		jsonKey := rulegroups.PtrString(jsonExtract.JsonKey)
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersJsonExtractParameters: &rulegroups.RuleParametersJsonExtractParameters{
-				JsonExtractParameters: rulegroups.JsonExtractParameters{
-					DestinationFieldType: destinationField.Ptr(),
-					Rule:                 jsonKey,
-				},
+			JsonExtractParameters: &rulegroups.JsonExtractParameters{
+				DestinationFieldType: destinationField.Ptr(),
+				Rule:                 jsonKey,
 			},
 		}
 	} else if removeFields := rule.RemoveFields; removeFields != nil {
 		sourceField = "text"
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersRemoveFieldsParameters: &rulegroups.RuleParametersRemoveFieldsParameters{
-				RemoveFieldsParameters: rulegroups.RemoveFieldsParameters{
-					Fields: removeFields.ExcludedFields,
-				},
+			RemoveFieldsParameters: &rulegroups.RemoveFieldsParameters{
+				Fields: removeFields.ExcludedFields,
 			},
 		}
 	} else if extractTimestamp := rule.ExtractTimestamp; extractTimestamp != nil {
@@ -442,52 +432,42 @@ func expandSourceFiledAndParameters(rule Rule) (sourceField string, parameters *
 		standard := RulesSchemaFormatStandardToOpenAPIFormatStandard[extractTimestamp.FieldFormatStandard]
 		format := rulegroups.PtrString(extractTimestamp.TimeFormat)
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersExtractTimestampParameters: &rulegroups.RuleParametersExtractTimestampParameters{
-				ExtractTimestampParameters: rulegroups.ExtractTimestampParameters{
-					Standard: standard.Ptr(),
-					Format:   format,
-				},
+			ExtractTimestampParameters: &rulegroups.ExtractTimestampParameters{
+				Standard: standard.Ptr(),
+				Format:   format,
 			},
 		}
 	} else if block := rule.Block; block != nil {
 		sourceField = block.SourceField
 		if block.BlockingAllMatchingBlocks {
 			parameters = &rulegroups.RuleParameters{
-				RuleParametersBlockParameters: &rulegroups.RuleParametersBlockParameters{
-					BlockParameters: rulegroups.BlockParameters{
-						KeepBlockedLogs: rulegroups.PtrBool(block.KeepBlockedLogs),
-						Rule:            rulegroups.PtrString(block.Regex),
-					},
+				BlockParameters: &rulegroups.BlockParameters{
+					KeepBlockedLogs: rulegroups.PtrBool(block.KeepBlockedLogs),
+					Rule:            rulegroups.PtrString(block.Regex),
 				},
 			}
 		} else {
 			parameters = &rulegroups.RuleParameters{
-				RuleParametersAllowParameters: &rulegroups.RuleParametersAllowParameters{
-					AllowParameters: rulegroups.AllowParameters{
-						KeepBlockedLogs: rulegroups.PtrBool(block.KeepBlockedLogs),
-						Rule:            rulegroups.PtrString(block.Regex),
-					},
+				AllowParameters: &rulegroups.AllowParameters{
+					KeepBlockedLogs: rulegroups.PtrBool(block.KeepBlockedLogs),
+					Rule:            rulegroups.PtrString(block.Regex),
 				},
 			}
 		}
 	} else if replace := rule.Replace; replace != nil {
 		sourceField = replace.SourceField
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersReplaceParameters: &rulegroups.RuleParametersReplaceParameters{
-				ReplaceParameters: rulegroups.ReplaceParameters{
-					DestinationField: rulegroups.PtrString(replace.DestinationField),
-					ReplaceNewVal:    rulegroups.PtrString(replace.ReplacementString),
-					Rule:             rulegroups.PtrString(replace.Regex),
-				},
+			ReplaceParameters: &rulegroups.ReplaceParameters{
+				DestinationField: rulegroups.PtrString(replace.DestinationField),
+				ReplaceNewVal:    rulegroups.PtrString(replace.ReplacementString),
+				Rule:             rulegroups.PtrString(replace.Regex),
 			},
 		}
 	} else if extract := rule.Extract; extract != nil {
 		sourceField = extract.SourceField
 		parameters = &rulegroups.RuleParameters{
-			RuleParametersExtractParameters: &rulegroups.RuleParametersExtractParameters{
-				ExtractParameters: rulegroups.ExtractParameters{
-					Rule: rulegroups.PtrString(extract.Regex),
-				},
+			ExtractParameters: &rulegroups.ExtractParameters{
+				Rule: rulegroups.PtrString(extract.Regex),
 			},
 		}
 	}
@@ -501,22 +481,19 @@ func expandRuleMatchers(applications, subsystems []string, severities []RuleSeve
 	for _, app := range applications {
 		constraintStr := rulegroups.PtrString(app)
 		applicationNameConstraint := rulegroups.ApplicationNameConstraint{Value: constraintStr}
-		ruleMatcherApplicationName := rulegroups.RuleMatcherApplicationName{ApplicationName: applicationNameConstraint}
-		ruleMatchers = append(ruleMatchers, rulegroups.RuleMatcher{RuleMatcherApplicationName: &ruleMatcherApplicationName})
+		ruleMatchers = append(ruleMatchers, rulegroups.RuleMatcher{ApplicationName: &applicationNameConstraint})
 	}
 
 	for _, subSys := range subsystems {
 		constraintStr := rulegroups.PtrString(subSys)
 		subsystemNameConstraint := rulegroups.SubsystemNameConstraint{Value: constraintStr}
-		ruleMatcherApplicationName := rulegroups.RuleMatcherSubsystemName{SubsystemName: subsystemNameConstraint}
-		ruleMatchers = append(ruleMatchers, rulegroups.RuleMatcher{RuleMatcherSubsystemName: &ruleMatcherApplicationName})
+		ruleMatchers = append(ruleMatchers, rulegroups.RuleMatcher{SubsystemName: &subsystemNameConstraint})
 	}
 
 	for _, sev := range severities {
 		constraintEnum := RulesSchemaSeverityToOpenAPISeverity[sev]
 		severityConstraint := rulegroups.SeverityConstraint{Value: constraintEnum.Ptr()}
-		ruleMatcherSeverity := rulegroups.RuleMatcherSeverity{Severity: severityConstraint}
-		ruleMatchers = append(ruleMatchers, rulegroups.RuleMatcher{RuleMatcherSeverity: &ruleMatcherSeverity})
+		ruleMatchers = append(ruleMatchers, rulegroups.RuleMatcher{Severity: &severityConstraint})
 	}
 
 	return ruleMatchers

--- a/api/coralogix/v1alpha1/slo_types.go
+++ b/api/coralogix/v1alpha1/slo_types.go
@@ -158,30 +158,26 @@ type SLO struct {
 	Status SLOStatus `json:"status,omitempty"`
 }
 
-func (s *SLO) ExtractSLOCreateRequest() (*slos.SlosServiceReplaceSloRequest, error) {
+func (s *SLO) ExtractSLOCreateRequest() (*slos.Slo1, error) {
 	if requestBasedMetricSli := s.Spec.SliType.RequestBasedMetricSli; requestBasedMetricSli != nil {
 		requestBased, err := s.Spec.ExtractRequestBasedMetricSli()
 		if err != nil {
 			return nil, fmt.Errorf("error extracting request based metric SLI: %w", err)
 		}
 
-		return &slos.SlosServiceReplaceSloRequest{
-			SloRequestBasedMetricSli: requestBased,
-		}, nil
+		return requestBased, nil
 	} else if windowBasedMetricSli := s.Spec.SliType.WindowBasedMetricSli; windowBasedMetricSli != nil {
 		windowBased, err := s.Spec.ExtractWindowBasedMetricSli()
 		if err != nil {
 			return nil, fmt.Errorf("error extracting window based metric SLI: %w", err)
 		}
-		return &slos.SlosServiceReplaceSloRequest{
-			SloWindowBasedMetricSli: windowBased,
-		}, nil
+		return windowBased, nil
 	}
 
 	return nil, fmt.Errorf("sliType must be set to either requestBasedMetricSli or windowBasedMetricSli")
 }
 
-func (s *SLO) ExtractSLOUpdateRequest() (*slos.SlosServiceReplaceSloRequest, error) {
+func (s *SLO) ExtractSLOUpdateRequest() (*slos.Slo1, error) {
 	if requestBasedMetricSli := s.Spec.SliType.RequestBasedMetricSli; requestBasedMetricSli != nil {
 		requestBased, err := s.Spec.ExtractRequestBasedMetricSli()
 		if err != nil {
@@ -189,9 +185,7 @@ func (s *SLO) ExtractSLOUpdateRequest() (*slos.SlosServiceReplaceSloRequest, err
 		}
 
 		requestBased.Id = s.Status.ID
-		return &slos.SlosServiceReplaceSloRequest{
-			SloRequestBasedMetricSli: requestBased,
-		}, nil
+		return requestBased, nil
 	} else if windowBasedMetricSli := s.Spec.SliType.WindowBasedMetricSli; windowBasedMetricSli != nil {
 		windowBased, err := s.Spec.ExtractWindowBasedMetricSli()
 		if err != nil {
@@ -199,27 +193,25 @@ func (s *SLO) ExtractSLOUpdateRequest() (*slos.SlosServiceReplaceSloRequest, err
 		}
 
 		windowBased.Id = s.Status.ID
-		return &slos.SlosServiceReplaceSloRequest{
-			SloWindowBasedMetricSli: windowBased,
-		}, nil
+		return windowBased, nil
 	}
 
 	return nil, fmt.Errorf("sliType must be set to either requestBasedMetricSli or windowBasedMetricSli")
 }
 
-func (s *SLOSpec) ExtractRequestBasedMetricSli() (*slos.SloRequestBasedMetricSli, error) {
+func (s *SLOSpec) ExtractRequestBasedMetricSli() (*slos.Slo1, error) {
 	timeFrame, err := s.Window.ExpandTimeFrame()
 	if err != nil {
 		return nil, fmt.Errorf("error expanding time frame: %w", err)
 	}
 
-	return &slos.SloRequestBasedMetricSli{
+	return &slos.Slo1{
 		Name:                      slos.PtrString(s.Name),
 		Description:               s.Description,
 		Labels:                    s.Labels,
 		SloTimeFrame:              timeFrame,
 		TargetThresholdPercentage: slos.PtrFloat32(float32(s.TargetThresholdPercentage.AsApproximateFloat64())),
-		RequestBasedMetricSli: slos.RequestBasedMetricSli{
+		RequestBasedMetricSli: &slos.RequestBasedMetricSli{
 			GoodEvents: &slos.Metric{
 				Query: slos.PtrString(s.SliType.RequestBasedMetricSli.GoodEvents.Query),
 			},
@@ -230,19 +222,19 @@ func (s *SLOSpec) ExtractRequestBasedMetricSli() (*slos.SloRequestBasedMetricSli
 	}, nil
 }
 
-func (s *SLOSpec) ExtractWindowBasedMetricSli() (*slos.SloWindowBasedMetricSli, error) {
+func (s *SLOSpec) ExtractWindowBasedMetricSli() (*slos.Slo1, error) {
 	timeFrame, err := s.Window.ExpandTimeFrame()
 	if err != nil {
 		return nil, fmt.Errorf("error expanding time frame: %w", err)
 	}
 
-	return &slos.SloWindowBasedMetricSli{
+	return &slos.Slo1{
 		Name:                      slos.PtrString(s.Name),
 		Description:               s.Description,
 		Labels:                    s.Labels,
 		SloTimeFrame:              timeFrame,
 		TargetThresholdPercentage: slos.PtrFloat32(float32(s.TargetThresholdPercentage.AsApproximateFloat64())),
-		WindowBasedMetricSli: slos.WindowBasedMetricSli{
+		WindowBasedMetricSli: &slos.WindowBasedMetricSli{
 			Query: &slos.Metric{
 				Query: slos.PtrString(s.SliType.WindowBasedMetricSli.Query.Query),
 			},

--- a/api/coralogix/v1alpha1/view_types.go
+++ b/api/coralogix/v1alpha1/view_types.go
@@ -179,19 +179,15 @@ func (v *View) ExtractFolderId(ctx context.Context, log logr.Logger) (*string, e
 func (s *ViewSpec) ExtractTimeSelection() (*views.TimeSelection, error) {
 	if s.TimeSelection.QuickSelection != nil {
 		return &views.TimeSelection{
-			TimeSelectionQuickSelection: &views.TimeSelectionQuickSelection{
-				QuickSelection: views.QuickTimeSelection{
-					Seconds: int64(s.TimeSelection.QuickSelection.Seconds),
-				},
+			QuickSelection: &views.QuickTimeSelection{
+				Seconds: int64(s.TimeSelection.QuickSelection.Seconds),
 			},
 		}, nil
 	} else if s.TimeSelection.CustomSelection != nil {
 		return &views.TimeSelection{
-			TimeSelectionCustomSelection: &views.TimeSelectionCustomSelection{
-				CustomSelection: views.CustomTimeSelection{
-					FromTime: s.TimeSelection.CustomSelection.FromTime.Time,
-					ToTime:   s.TimeSelection.CustomSelection.ToTime.Time,
-				},
+			CustomSelection: &views.CustomTimeSelection{
+				FromTime: s.TimeSelection.CustomSelection.FromTime.Time,
+				ToTime:   s.TimeSelection.CustomSelection.ToTime.Time,
 			},
 		}, nil
 	}

--- a/api/coralogix/v1beta1/alert_types.go
+++ b/api/coralogix/v1beta1/alert_types.go
@@ -1599,219 +1599,195 @@ func (in *AlertSpec) ExtractAlertDefProperties(listingAlertsAndWebhooksPropertie
 
 	if logsImmediate := in.TypeDefinition.LogsImmediate; logsImmediate != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesLogsImmediate: &alerts.AlertDefPropertiesLogsImmediate{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_IMMEDIATE_OR_UNSPECIFIED.Ptr(),
-				LogsImmediate:           expandLogsImmediate(logsImmediate),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_IMMEDIATE_OR_UNSPECIFIED.Ptr(),
+			LogsImmediate:           expandLogsImmediate(logsImmediate),
 		}, nil
 	} else if logsThreshold := in.TypeDefinition.LogsThreshold; logsThreshold != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesLogsThreshold: &alerts.AlertDefPropertiesLogsThreshold{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_THRESHOLD.Ptr(),
-				LogsThreshold:           *expandLogsThreshold(logsThreshold, priority),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_THRESHOLD.Ptr(),
+			LogsThreshold:           expandLogsThreshold(logsThreshold, priority),
 		}, nil
 	} else if logsRatioThreshold := in.TypeDefinition.LogsRatioThreshold; logsRatioThreshold != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesLogsRatioThreshold: &alerts.AlertDefPropertiesLogsRatioThreshold{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_RATIO_THRESHOLD.Ptr(),
-				LogsRatioThreshold:      *expandLogsRatioThreshold(logsRatioThreshold, priority),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_RATIO_THRESHOLD.Ptr(),
+			LogsRatioThreshold:      expandLogsRatioThreshold(logsRatioThreshold, priority),
 		}, nil
 	} else if logsTimeRelativeThreshold := in.TypeDefinition.LogsTimeRelativeThreshold; logsTimeRelativeThreshold != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesLogsTimeRelativeThreshold: &alerts.AlertDefPropertiesLogsTimeRelativeThreshold{
-				Name:                      alerts.PtrString(in.Name),
-				Description:               alerts.PtrString(in.Description),
-				Enabled:                   in.Enabled,
-				Priority:                  priority.Ptr(),
-				GroupByKeys:               in.GroupByKeys,
-				IncidentsSettings:         expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:         notificationGroup,
-				NotificationGroupExcess:   notificationGroupExcess,
-				EntityLabels:              ptr.To(in.EntityLabels),
-				PhantomMode:               alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                  expandAlertSchedule(in.Schedule),
-				Type:                      alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_TIME_RELATIVE_THRESHOLD.Ptr(),
-				LogsTimeRelativeThreshold: *expandLogsTimeRelativeThreshold(logsTimeRelativeThreshold, priority),
-			},
+			Name:                      alerts.PtrString(in.Name),
+			Description:               alerts.PtrString(in.Description),
+			Enabled:                   in.Enabled,
+			Priority:                  priority.Ptr(),
+			GroupByKeys:               in.GroupByKeys,
+			IncidentsSettings:         expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:         notificationGroup,
+			NotificationGroupExcess:   notificationGroupExcess,
+			EntityLabels:              ptr.To(in.EntityLabels),
+			PhantomMode:               alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                  expandAlertSchedule(in.Schedule),
+			Type:                      alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_TIME_RELATIVE_THRESHOLD.Ptr(),
+			LogsTimeRelativeThreshold: expandLogsTimeRelativeThreshold(logsTimeRelativeThreshold, priority),
 		}, nil
 	} else if metricThreshold := in.TypeDefinition.MetricThreshold; metricThreshold != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesMetricThreshold: &alerts.AlertDefPropertiesMetricThreshold{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_THRESHOLD.Ptr(),
-				MetricThreshold:         *expandMetricThreshold(metricThreshold, priority),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_THRESHOLD.Ptr(),
+			MetricThreshold:         expandMetricThreshold(metricThreshold, priority),
 		}, nil
 	} else if tracingThreshold := in.TypeDefinition.TracingThreshold; tracingThreshold != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesTracingThreshold: &alerts.AlertDefPropertiesTracingThreshold{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_THRESHOLD.Ptr(),
-				TracingThreshold:        *expandTracingThreshold(tracingThreshold),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_THRESHOLD.Ptr(),
+			TracingThreshold:        expandTracingThreshold(tracingThreshold),
 		}, nil
 	} else if tracingImmediate := in.TypeDefinition.TracingImmediate; tracingImmediate != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesTracingImmediate: &alerts.AlertDefPropertiesTracingImmediate{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_IMMEDIATE.Ptr(),
-				TracingImmediate:        *expandTracingImmediate(tracingImmediate),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_TRACING_IMMEDIATE.Ptr(),
+			TracingImmediate:        expandTracingImmediate(tracingImmediate),
 		}, nil
 	} else if flow := in.TypeDefinition.Flow; flow != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesFlow: &alerts.AlertDefPropertiesFlow{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_FLOW.Ptr(),
-				Flow:                    *expandFlow(listingAlertsAndWebhooksProperties, flow),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_FLOW.Ptr(),
+			Flow:                    expandFlow(listingAlertsAndWebhooksProperties, flow),
 		}, nil
 	} else if logsAnomaly := in.TypeDefinition.LogsAnomaly; logsAnomaly != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesLogsAnomaly: &alerts.AlertDefPropertiesLogsAnomaly{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_ANOMALY.Ptr(),
-				LogsAnomaly:             *expandLogsAnomaly(logsAnomaly),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_ANOMALY.Ptr(),
+			LogsAnomaly:             expandLogsAnomaly(logsAnomaly),
 		}, nil
 	} else if metricAnomaly := in.TypeDefinition.MetricAnomaly; metricAnomaly != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesMetricAnomaly: &alerts.AlertDefPropertiesMetricAnomaly{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_ANOMALY.Ptr(),
-				MetricAnomaly:           *expandMetricAnomaly(metricAnomaly),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_METRIC_ANOMALY.Ptr(),
+			MetricAnomaly:           expandMetricAnomaly(metricAnomaly),
 		}, nil
 	} else if logsNewValue := in.TypeDefinition.LogsNewValue; logsNewValue != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesLogsNewValue: &alerts.AlertDefPropertiesLogsNewValue{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_NEW_VALUE.Ptr(),
-				LogsNewValue:            *expandLogsNewValue(logsNewValue),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_NEW_VALUE.Ptr(),
+			LogsNewValue:            expandLogsNewValue(logsNewValue),
 		}, nil
 	} else if logsUniqueCount := in.TypeDefinition.LogsUniqueCount; logsUniqueCount != nil {
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesLogsUniqueCount: &alerts.AlertDefPropertiesLogsUniqueCount{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_UNIQUE_COUNT.Ptr(),
-				LogsUniqueCount:         *expandLogsUniqueCount(logsUniqueCount),
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_LOGS_UNIQUE_COUNT.Ptr(),
+			LogsUniqueCount:         expandLogsUniqueCount(logsUniqueCount),
 		}, nil
 	} else if sloThreshold := in.TypeDefinition.SloThreshold; sloThreshold != nil {
 		sloThresholdType, err := expandSloThreshold(listingAlertsAndWebhooksProperties, sloThreshold)
@@ -1819,21 +1795,19 @@ func (in *AlertSpec) ExtractAlertDefProperties(listingAlertsAndWebhooksPropertie
 			return nil, fmt.Errorf("failed to expand SLO threshold: %w", err)
 		}
 		return &alerts.AlertDefProperties{
-			AlertDefPropertiesSloThreshold: &alerts.AlertDefPropertiesSloThreshold{
-				Name:                    alerts.PtrString(in.Name),
-				Description:             alerts.PtrString(in.Description),
-				Enabled:                 in.Enabled,
-				Priority:                priority.Ptr(),
-				GroupByKeys:             in.GroupByKeys,
-				IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
-				NotificationGroup:       notificationGroup,
-				NotificationGroupExcess: notificationGroupExcess,
-				EntityLabels:            ptr.To(in.EntityLabels),
-				PhantomMode:             alerts.PtrBool(in.PhantomMode),
-				ActiveOn:                expandAlertSchedule(in.Schedule),
-				Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_SLO_THRESHOLD.Ptr(),
-				SloThreshold:            *sloThresholdType,
-			},
+			Name:                    alerts.PtrString(in.Name),
+			Description:             alerts.PtrString(in.Description),
+			Enabled:                 in.Enabled,
+			Priority:                priority.Ptr(),
+			GroupByKeys:             in.GroupByKeys,
+			IncidentsSettings:       expandIncidentsSettings(in.IncidentsSettings),
+			NotificationGroup:       notificationGroup,
+			NotificationGroupExcess: notificationGroupExcess,
+			EntityLabels:            ptr.To(in.EntityLabels),
+			PhantomMode:             alerts.PtrBool(in.PhantomMode),
+			ActiveOn:                expandAlertSchedule(in.Schedule),
+			Type:                    alerts.ALERTDEFTYPE_ALERT_DEF_TYPE_SLO_THRESHOLD.Ptr(),
+			SloThreshold:            sloThresholdType,
 		}, nil
 	}
 
@@ -1966,16 +1940,12 @@ func expandIntegration(integration IntegrationType, listingWebhooksProperties *G
 		}
 
 		return &alerts.V3IntegrationType{
-			V3IntegrationTypeIntegrationId: &alerts.V3IntegrationTypeIntegrationId{
-				IntegrationId: *integrationID,
-			},
+			IntegrationId: integrationID,
 		}, nil
 	} else if recipients := integration.Recipients; recipients != nil {
 		return &alerts.V3IntegrationType{
-			V3IntegrationTypeRecipients: &alerts.V3IntegrationTypeRecipients{
-				Recipients: alerts.Recipients{
-					Emails: recipients,
-				},
+			Recipients: &alerts.Recipients{
+				Emails: recipients,
 			},
 		}, nil
 	}
@@ -2281,16 +2251,12 @@ func convertSloBackendNameToId(listingSloProperties *GetResourceRefProperties, n
 	filters := []slos.SloFilter{
 		{
 			Field: &slos.SloFilterField{
-				SloFilterFieldConstFilter: &slos.SloFilterFieldConstFilter{
-					ConstFilter: slos.SLOCONSTANTFILTERFIELD_SLO_CONST_FILTER_FIELD_SLO_NAME,
-				},
+				ConstFilter: slos.SLOCONSTANTFILTERFIELD_SLO_CONST_FILTER_FIELD_SLO_NAME.Ptr(),
 			},
 			Predicate: &slos.SloFilterPredicate{
-				Is: &slos.SloFilterPredicateIs{
-					IsFilterPredicateStringValues: &slos.IsFilterPredicateStringValues{
-						StringValues: slos.StringValues{
-							Values: []string{*name},
-						},
+				Is: &slos.IsFilterPredicate{
+					StringValues: slos.MultipleValues{
+						Values: []string{*name},
 					},
 				},
 			},
@@ -2304,19 +2270,8 @@ func convertSloBackendNameToId(listingSloProperties *GetResourceRefProperties, n
 		return "", fmt.Errorf("failed to list SLOs: %w", oapicxsdk.NewAPIError(httpResp, err))
 	}
 	for _, slo := range listResp.Slos {
-		switch {
-		case slo.SloWindowBasedMetricSli != nil:
-			if ptr.Deref(slo.SloWindowBasedMetricSli.Name, "") == *name {
-				if slo.SloWindowBasedMetricSli.Id != nil {
-					return *slo.SloWindowBasedMetricSli.Id, nil
-				}
-			}
-		case slo.SloRequestBasedMetricSli != nil:
-			if ptr.Deref(slo.SloRequestBasedMetricSli.Name, "") == *name {
-				if slo.SloRequestBasedMetricSli.Id != nil {
-					return *slo.SloRequestBasedMetricSli.Id, nil
-				}
-			}
+		if ptr.Deref(slo.Name, "") == *name && slo.Id != nil {
+			return *slo.Id, nil
 		}
 	}
 	return "", fmt.Errorf("SLO with name %s not found", *name)
@@ -2353,22 +2308,18 @@ func convertSloCrNameToID(listingSloProperties *GetResourceRefProperties, sloCrN
 func expandSloThresholdType(sloId string, sloThreshold *SloThreshold) (*alerts.SloThresholdType, error) {
 	if errorBudget := sloThreshold.ErrorBudget; errorBudget != nil {
 		return &alerts.SloThresholdType{
-			SloThresholdTypeErrorBudget: &alerts.SloThresholdTypeErrorBudget{
-				ErrorBudget: alerts.ErrorBudgetThreshold{
-					Rules: expandSloErrorBudgetRules(errorBudget.Rules),
-				},
-				SloDefinition: &alerts.V3SloDefinition{
-					SloId: alerts.PtrString(sloId),
-				},
+			ErrorBudget: &alerts.ErrorBudgetThreshold{
+				Rules: expandSloErrorBudgetRules(errorBudget.Rules),
+			},
+			SloDefinition: &alerts.V3SloDefinition{
+				SloId: alerts.PtrString(sloId),
 			},
 		}, nil
 	} else if burnRate := sloThreshold.BurnRate; burnRate != nil {
 		return &alerts.SloThresholdType{
-			SloThresholdTypeBurnRate: &alerts.SloThresholdTypeBurnRate{
-				BurnRate: *expandSloBurnRate(*burnRate),
-				SloDefinition: &alerts.V3SloDefinition{
-					SloId: alerts.PtrString(sloId),
-				},
+			BurnRate: expandSloBurnRate(*burnRate),
+			SloDefinition: &alerts.V3SloDefinition{
+				SloId: alerts.PtrString(sloId),
 			},
 		}, nil
 	}
@@ -2401,26 +2352,22 @@ func expandSloBurnRate(burnRate BurnRate) *alerts.BurnRateThreshold {
 	if burnRate.BurnRateType.Single != nil {
 		duration := strconv.Itoa(burnRate.BurnRateType.Single.TimeDuration.Duration)
 		return &alerts.BurnRateThreshold{
-			BurnRateThresholdSingle: &alerts.BurnRateThresholdSingle{
-				Rules: expandSloBurnRateRules(burnRate.Rules),
-				Single: alerts.BurnRateTypeSingle{
-					TimeDuration: &alerts.TimeDuration{
-						Unit:     expandDurationUnit(burnRate.BurnRateType.Single.TimeDuration.Unit),
-						Duration: &duration,
-					},
+			Rules: expandSloBurnRateRules(burnRate.Rules),
+			Single: &alerts.BurnRateTypeSingle{
+				TimeDuration: &alerts.TimeDuration{
+					Unit:     expandDurationUnit(burnRate.BurnRateType.Single.TimeDuration.Unit),
+					Duration: &duration,
 				},
 			},
 		}
 	}
 	duration := strconv.Itoa(burnRate.BurnRateType.Dual.TimeDuration.Duration)
 	return &alerts.BurnRateThreshold{
-		BurnRateThresholdDual: &alerts.BurnRateThresholdDual{
-			Rules: expandSloBurnRateRules(burnRate.Rules),
-			Dual: alerts.BurnRateTypeDual{
-				TimeDuration: &alerts.TimeDuration{
-					Duration: &duration,
-					Unit:     expandDurationUnit(burnRate.BurnRateType.Dual.TimeDuration.Unit),
-				},
+		Rules: expandSloBurnRateRules(burnRate.Rules),
+		Dual: &alerts.BurnRateTypeDual{
+			TimeDuration: &alerts.TimeDuration{
+				Duration: &duration,
+				Unit:     expandDurationUnit(burnRate.BurnRateType.Dual.TimeDuration.Unit),
 			},
 		},
 	}
@@ -2711,42 +2658,13 @@ func convertAlertNameToID(listingAlertsProperties *GetResourceRefProperties, ale
 		}
 
 		for _, alert := range listAlertsResp.GetAlertDefs() {
-			var name string
-
 			props := alert.GetAlertDefProperties()
-			switch {
-			case props.AlertDefPropertiesFlow != nil && props.AlertDefPropertiesFlow.Name != nil:
-				name = *props.AlertDefPropertiesFlow.Name
-			case props.AlertDefPropertiesLogsAnomaly != nil && props.AlertDefPropertiesLogsAnomaly.Name != nil:
-				name = *props.AlertDefPropertiesLogsAnomaly.Name
-			case props.AlertDefPropertiesLogsImmediate != nil && props.AlertDefPropertiesLogsImmediate.Name != nil:
-				name = *props.AlertDefPropertiesLogsImmediate.Name
-			case props.AlertDefPropertiesLogsNewValue != nil && props.AlertDefPropertiesLogsNewValue.Name != nil:
-				name = *props.AlertDefPropertiesLogsNewValue.Name
-			case props.AlertDefPropertiesLogsRatioThreshold != nil && props.AlertDefPropertiesLogsRatioThreshold.Name != nil:
-				name = *props.AlertDefPropertiesLogsRatioThreshold.Name
-			case props.AlertDefPropertiesLogsThreshold != nil && props.AlertDefPropertiesLogsThreshold.Name != nil:
-				name = *props.AlertDefPropertiesLogsThreshold.Name
-			case props.AlertDefPropertiesLogsTimeRelativeThreshold != nil && props.AlertDefPropertiesLogsTimeRelativeThreshold.Name != nil:
-				name = *props.AlertDefPropertiesLogsTimeRelativeThreshold.Name
-			case props.AlertDefPropertiesLogsUniqueCount != nil && props.AlertDefPropertiesLogsUniqueCount.Name != nil:
-				name = *props.AlertDefPropertiesLogsUniqueCount.Name
-			case props.AlertDefPropertiesMetricAnomaly != nil && props.AlertDefPropertiesMetricAnomaly.Name != nil:
-				name = *props.AlertDefPropertiesMetricAnomaly.Name
-			case props.AlertDefPropertiesMetricThreshold != nil && props.AlertDefPropertiesMetricThreshold.Name != nil:
-				name = *props.AlertDefPropertiesMetricThreshold.Name
-			case props.AlertDefPropertiesSloThreshold != nil && props.AlertDefPropertiesSloThreshold.Name != nil:
-				name = *props.AlertDefPropertiesSloThreshold.Name
-			case props.AlertDefPropertiesTracingImmediate != nil && props.AlertDefPropertiesTracingImmediate.Name != nil:
-				name = *props.AlertDefPropertiesTracingImmediate.Name
-			case props.AlertDefPropertiesTracingThreshold != nil && props.AlertDefPropertiesTracingThreshold.Name != nil:
-				name = *props.AlertDefPropertiesTracingThreshold.Name
-			default:
+			if props.Name == nil {
 				log.V(1).Info("Skipping alert with missing name", "alertID", alert.GetId())
 				continue
 			}
 
-			listingAlertsProperties.AlertNameToId[name] = alert.GetId()
+			listingAlertsProperties.AlertNameToId[*props.Name] = alert.GetId()
 		}
 	}
 
@@ -2937,15 +2855,11 @@ func expandMetricThresholdCondition(condition MetricThresholdRuleCondition) *ale
 func expandMetricTimeWindow(timeWindow MetricTimeWindow) *alerts.MetricTimeWindow {
 	if specificValue := timeWindow.SpecificValue; specificValue != nil {
 		return &alerts.MetricTimeWindow{
-			MetricTimeWindowMetricTimeWindowSpecificValue: &alerts.MetricTimeWindowMetricTimeWindowSpecificValue{
-				MetricTimeWindowSpecificValue: MetricTimeWindowToOpenAPI[*specificValue],
-			},
+			MetricTimeWindowSpecificValue: MetricTimeWindowToOpenAPI[*specificValue].Ptr(),
 		}
 	} else if dynamicTimeWindow := timeWindow.DynamicDuration; dynamicTimeWindow != nil {
 		return &alerts.MetricTimeWindow{
-			MetricTimeWindowMetricTimeWindowDynamicDuration: &alerts.MetricTimeWindowMetricTimeWindowDynamicDuration{
-				MetricTimeWindowDynamicDuration: *dynamicTimeWindow,
-			},
+			MetricTimeWindowDynamicDuration: dynamicTimeWindow,
 		}
 	}
 
@@ -2954,9 +2868,7 @@ func expandMetricTimeWindow(timeWindow MetricTimeWindow) *alerts.MetricTimeWindo
 
 func expandAnomalyMetricTimeWindow(timeWindow MetricAnomalyTimeWindow) *alerts.MetricTimeWindow {
 	return &alerts.MetricTimeWindow{
-		MetricTimeWindowMetricTimeWindowSpecificValue: &alerts.MetricTimeWindowMetricTimeWindowSpecificValue{
-			MetricTimeWindowSpecificValue: MetricTimeWindowToOpenAPI[timeWindow.SpecificValue],
-		},
+		MetricTimeWindowSpecificValue: MetricTimeWindowToOpenAPI[timeWindow.SpecificValue].Ptr(),
 	}
 }
 
@@ -2965,23 +2877,19 @@ func expandMetricMissingValues(missingValues *MetricMissingValues) *alerts.Metri
 		return nil
 	} else if missingValues.ReplaceWithZero {
 		return &alerts.MetricMissingValues{
-			MetricMissingValuesReplaceWithZero: &alerts.MetricMissingValuesReplaceWithZero{
-				ReplaceWithZero: true,
-			},
+			ReplaceWithZero: alerts.PtrBool(true),
 		}
 	} else if missingValues.MinNonNullValuesPct != nil {
 		return &alerts.MetricMissingValues{
-			MetricMissingValuesMinNonNullValuesPct: &alerts.MetricMissingValuesMinNonNullValuesPct{
-				MinNonNullValuesPct: *missingValues.MinNonNullValuesPct,
-			},
+			MinNonNullValuesPct: missingValues.MinNonNullValuesPct,
 		}
 	}
 
 	return nil
 }
 
-func expandLogsImmediate(immediate *LogsImmediate) alerts.LogsImmediateType {
-	return alerts.LogsImmediateType{
+func expandLogsImmediate(immediate *LogsImmediate) *alerts.LogsImmediateType {
+	return &alerts.LogsImmediateType{
 		LogsFilter:                expandLogsFilter(immediate.LogsFilter),
 		NotificationPayloadFilter: immediate.NotificationPayloadFilter,
 	}

--- a/api/coralogix/v1beta1/alert_types.go
+++ b/api/coralogix/v1beta1/alert_types.go
@@ -2255,7 +2255,7 @@ func convertSloBackendNameToId(listingSloProperties *GetResourceRefProperties, n
 			},
 			Predicate: &slos.SloFilterPredicate{
 				Is: &slos.IsFilterPredicate{
-					StringValues: slos.MultipleValues{
+					StringValues: &slos.StringValues{
 						Values: []string{*name},
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.24.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706144421-c48a3ca5fa15
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.24.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706144421-c48a3ca5fa15
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4
@@ -94,7 +94,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251014184007-4626949a642f // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.33.2 // indirect
 	k8s.io/component-base v0.33.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706144421-c48a3ca5fa15 h1:vBYixfu/pPPbUOSbCnGXsGm6vgID1KyJWTguP2HkCkc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706144421-c48a3ca5fa15/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39 h1:Ng94C0STKyjwhe0PisPAf72EwfWygiE6VIROidRApsY=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb h1:3OhNyNPwgYdPqzfALHLP64heS1nDIrtezBdlgqYQa/E=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706100328-522977c446eb/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706144421-c48a3ca5fa15 h1:vBYixfu/pPPbUOSbCnGXsGm6vgID1KyJWTguP2HkCkc=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260706144421-c48a3ca5fa15/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -300,8 +300,6 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
-gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/controller/coralogix/v1alpha1/archivemetricstarget_controller.go
+++ b/internal/controller/coralogix/v1alpha1/archivemetricstarget_controller.go
@@ -68,7 +68,7 @@ func (r *ArchiveMetricsTargetReconciler) HandleCreation(ctx context.Context, log
 	log.Info("Creating remote archivemetricstarget", "archivemetricstarget", utils.FormatJSON(configureTenantRequest))
 	createResponse, httpResp, err := r.ArchiveMetricsTargetsClient.
 		MetricsConfiguratorPublicServiceConfigureTenant(ctx).
-		MetricsConfiguratorPublicServiceConfigureTenantRequest(*configureTenantRequest).
+		ConfigureTenantRequest(*configureTenantRequest).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("error on creating remote archivemetricstarget: %w", cxsdk.NewAPIError(httpResp, err))
@@ -79,7 +79,7 @@ func (r *ArchiveMetricsTargetReconciler) HandleCreation(ctx context.Context, log
 	}
 	_, httpResp, err = r.ArchiveMetricsTargetsClient.
 		MetricsConfiguratorPublicServiceUpdate(ctx).
-		MetricsConfiguratorPublicServiceUpdateRequest(*updateRequest).
+		UpdateTenantRequest(*updateRequest).
 		Execute()
 	if err != nil {
 		return cxsdk.NewAPIError(httpResp, err)
@@ -103,7 +103,7 @@ func (r *ArchiveMetricsTargetReconciler) HandleUpdate(ctx context.Context, log l
 	log.Info("Updating remote archivemetricstarget", "archivemetricstarget", utils.FormatJSON(updateRequest))
 	_, httpResp, err := r.ArchiveMetricsTargetsClient.
 		MetricsConfiguratorPublicServiceUpdate(ctx).
-		MetricsConfiguratorPublicServiceUpdateRequest(*updateRequest).
+		UpdateTenantRequest(*updateRequest).
 		Execute()
 	if err != nil {
 		return cxsdk.NewAPIError(httpResp, err)

--- a/internal/controller/coralogix/v1alpha1/outboundwebhook_controller.go
+++ b/internal/controller/coralogix/v1alpha1/outboundwebhook_controller.go
@@ -128,46 +128,15 @@ func getOutboundWebhookStatus(webhook *webhooks.OutgoingWebhook) (*v1alpha1.Outb
 		return nil, fmt.Errorf("outbound-webhook is nil")
 	}
 
-	status := &v1alpha1.OutboundWebhookStatus{}
-
-	extract := func(id *string, externalID *int64) (*string, *string) {
-		if id == nil {
-			return nil, nil
-		}
-		var ext *string
-		if externalID != nil {
-			ext = ptr.To(strconv.Itoa(int(*externalID)))
-		}
-		return id, ext
+	if webhook.Id == nil {
+		return nil, fmt.Errorf("outbound-webhook id is not set")
 	}
 
-	switch {
-	case webhook.OutgoingWebhookAwsEventBridge != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookAwsEventBridge.Id, webhook.OutgoingWebhookAwsEventBridge.ExternalId)
-	case webhook.OutgoingWebhookDemisto != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookDemisto.Id, webhook.OutgoingWebhookDemisto.ExternalId)
-	case webhook.OutgoingWebhookEmailGroup != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookEmailGroup.Id, webhook.OutgoingWebhookEmailGroup.ExternalId)
-	case webhook.OutgoingWebhookGenericWebhook != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookGenericWebhook.Id, webhook.OutgoingWebhookGenericWebhook.ExternalId)
-	case webhook.OutgoingWebhookIbmEventNotifications != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookIbmEventNotifications.Id, webhook.OutgoingWebhookIbmEventNotifications.ExternalId)
-	case webhook.OutgoingWebhookJira != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookJira.Id, webhook.OutgoingWebhookJira.ExternalId)
-	case webhook.OutgoingWebhookMicrosoftTeams != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookMicrosoftTeams.Id, webhook.OutgoingWebhookMicrosoftTeams.ExternalId)
-	case webhook.OutgoingWebhookMsTeamsWorkflow != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookMsTeamsWorkflow.Id, webhook.OutgoingWebhookMsTeamsWorkflow.ExternalId)
-	case webhook.OutgoingWebhookOpsgenie != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookOpsgenie.Id, webhook.OutgoingWebhookOpsgenie.ExternalId)
-	case webhook.OutgoingWebhookPagerDuty != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookPagerDuty.Id, webhook.OutgoingWebhookPagerDuty.ExternalId)
-	case webhook.OutgoingWebhookSendLog != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookSendLog.Id, webhook.OutgoingWebhookSendLog.ExternalId)
-	case webhook.OutgoingWebhookSlack != nil:
-		status.ID, status.ExternalID = extract(webhook.OutgoingWebhookSlack.Id, webhook.OutgoingWebhookSlack.ExternalId)
-	default:
-		return nil, fmt.Errorf("unsupported or unknown outbound-webhook type")
+	status := &v1alpha1.OutboundWebhookStatus{
+		ID: webhook.Id,
+	}
+	if webhook.ExternalId != nil {
+		status.ExternalID = ptr.To(strconv.Itoa(int(*webhook.ExternalId)))
 	}
 
 	return status, nil

--- a/internal/controller/coralogix/v1alpha1/recordingrulegroupset_controller.go
+++ b/internal/controller/coralogix/v1alpha1/recordingrulegroupset_controller.go
@@ -72,7 +72,7 @@ func (r *RecordingRuleGroupSetReconciler) HandleCreation(ctx context.Context, lo
 	}
 	log.Info("Remote recordingRuleGroupSet created", "response", utils.FormatJSON(createResponse))
 	recordingRuleGroupSet.Status = coralogixv1alpha1.RecordingRuleGroupSetStatus{
-		ID: createResponse.Id,
+		ID: ptr.To(createResponse.Id),
 	}
 
 	return nil

--- a/internal/controller/coralogix/v1alpha1/slo_controller.go
+++ b/internal/controller/coralogix/v1alpha1/slo_controller.go
@@ -59,7 +59,7 @@ func (r *SLOReconciler) HandleCreation(ctx context.Context, log logr.Logger, obj
 	log.Info("Creating remote slo", "slo", utils.FormatJSON(createRequest))
 	createResponse, httpResp, err := r.SLOsClient.
 		SlosServiceCreateSlo(ctx).
-		SlosServiceReplaceSloRequest(*createRequest).
+		Slo1(*createRequest).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("error on creating remote slo: %w", cxsdk.NewAPIError(httpResp, err))
@@ -67,18 +67,8 @@ func (r *SLOReconciler) HandleCreation(ctx context.Context, log logr.Logger, obj
 	log.Info("Remote slo created", "response", utils.FormatJSON(createResponse))
 	receivedSLO := createResponse.GetSlo()
 
-	var sloID string
-	var revision int32
-	switch {
-	case receivedSLO.SloRequestBasedMetricSli != nil:
-		sloID = receivedSLO.SloRequestBasedMetricSli.GetId()
-		revision = ptr.To(receivedSLO.SloRequestBasedMetricSli.GetRevision()).GetRevision()
-	case receivedSLO.SloWindowBasedMetricSli != nil:
-		sloID = receivedSLO.SloWindowBasedMetricSli.GetId()
-		revision = ptr.To(receivedSLO.SloWindowBasedMetricSli.GetRevision()).GetRevision()
-	default:
-		return fmt.Errorf("unknown slo type")
-	}
+	sloID := receivedSLO.GetId()
+	revision := ptr.To(receivedSLO.GetRevision()).GetRevision()
 
 	slo.Status = coralogixv1alpha1.SLOStatus{
 		ID:       ptr.To(sloID),
@@ -101,7 +91,7 @@ func (r *SLOReconciler) HandleUpdate(ctx context.Context, log logr.Logger, obj c
 	log.Info("Updating remote slo", "slo", utils.FormatJSON(updateRequest))
 	updateResponse, httpResp, err := r.SLOsClient.
 		SlosServiceReplaceSlo(ctx).
-		SlosServiceReplaceSloRequest(*updateRequest).
+		Slo1(*updateRequest).
 		Execute()
 	if err != nil {
 		return cxsdk.NewAPIError(httpResp, err)

--- a/tests/e2e/aievaluation_test.go
+++ b/tests/e2e/aievaluation_test.go
@@ -1653,9 +1653,8 @@ func expectRemoteAIEvaluationPIICategories(
 	expected []coralogixv1alpha1.AIEvaluationPIICategory,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigPii).ToNot(BeNil())
-	piiConfig := config.EvaluationConfigPii.GetPii()
-	g.Expect(schemaPIICategories(piiConfig.GetCategories())).To(ConsistOf(expectedPIICategories(expected)...))
+	g.Expect(config.Pii).ToNot(BeNil())
+	g.Expect(schemaPIICategories(config.Pii.GetCategories())).To(ConsistOf(expectedPIICategories(expected)...))
 }
 
 func expectRemoteAIEvaluationAllowedTopics(
@@ -1664,9 +1663,8 @@ func expectRemoteAIEvaluationAllowedTopics(
 	expected []string,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigAllowedTopics).ToNot(BeNil())
-	allowedTopicsConfig := config.EvaluationConfigAllowedTopics.GetAllowedTopics()
-	g.Expect(allowedTopicsConfig.GetTopics()).To(ConsistOf(expectedStrings(expected)...))
+	g.Expect(config.AllowedTopics).ToNot(BeNil())
+	g.Expect(config.AllowedTopics.GetTopics()).To(ConsistOf(expectedStrings(expected)...))
 }
 
 func expectRemoteAIEvaluationCompetition(
@@ -1675,9 +1673,8 @@ func expectRemoteAIEvaluationCompetition(
 	expected []string,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigCompetition).ToNot(BeNil())
-	competitionConfig := config.EvaluationConfigCompetition.GetCompetition()
-	g.Expect(competitionConfig.GetCompetitors()).To(ConsistOf(expectedStrings(expected)...))
+	g.Expect(config.Competition).ToNot(BeNil())
+	g.Expect(config.Competition.GetCompetitors()).To(ConsistOf(expectedStrings(expected)...))
 }
 
 func expectRemoteAIEvaluationHallucinationCompleteness(
@@ -1685,8 +1682,8 @@ func expectRemoteAIEvaluationHallucinationCompleteness(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigHallucinationCompleteness).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigHallucinationCompleteness.GetHallucinationCompleteness()).To(BeEmpty())
+	g.Expect(config.HallucinationCompleteness).ToNot(BeNil())
+	g.Expect(config.HallucinationCompleteness).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationHallucinationContextAdherence(
@@ -1694,8 +1691,8 @@ func expectRemoteAIEvaluationHallucinationContextAdherence(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigHallucinationContextAdherence).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigHallucinationContextAdherence.GetHallucinationContextAdherence()).To(BeEmpty())
+	g.Expect(config.HallucinationContextAdherence).ToNot(BeNil())
+	g.Expect(config.HallucinationContextAdherence).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationHallucinationContextRelevance(
@@ -1703,8 +1700,8 @@ func expectRemoteAIEvaluationHallucinationContextRelevance(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigHallucinationContextRelevance).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigHallucinationContextRelevance.GetHallucinationContextRelevance()).To(BeEmpty())
+	g.Expect(config.HallucinationContextRelevance).ToNot(BeNil())
+	g.Expect(config.HallucinationContextRelevance).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationHallucinationCorrectness(
@@ -1712,8 +1709,8 @@ func expectRemoteAIEvaluationHallucinationCorrectness(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigHallucinationCorrectness).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigHallucinationCorrectness.GetHallucinationCorrectness()).To(BeEmpty())
+	g.Expect(config.HallucinationCorrectness).ToNot(BeNil())
+	g.Expect(config.HallucinationCorrectness).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationHallucinationTaskAdherence(
@@ -1721,8 +1718,8 @@ func expectRemoteAIEvaluationHallucinationTaskAdherence(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigHallucinationTaskAdherence).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigHallucinationTaskAdherence.GetHallucinationTaskAdherence()).To(BeEmpty())
+	g.Expect(config.HallucinationTaskAdherence).ToNot(BeNil())
+	g.Expect(config.HallucinationTaskAdherence).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationLanguageMismatch(
@@ -1730,8 +1727,8 @@ func expectRemoteAIEvaluationLanguageMismatch(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigLanguageMismatch).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigLanguageMismatch.GetLanguageMismatch()).To(BeEmpty())
+	g.Expect(config.LanguageMismatch).ToNot(BeNil())
+	g.Expect(config.LanguageMismatch).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationPromptInjection(
@@ -1740,9 +1737,8 @@ func expectRemoteAIEvaluationPromptInjection(
 	additionalContext string,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigPromptInjection).ToNot(BeNil())
-	promptInjectionConfig := config.EvaluationConfigPromptInjection.GetPromptInjection()
-	g.Expect(promptInjectionConfig.GetAdditionalContext()).To(Equal(additionalContext))
+	g.Expect(config.PromptInjection).ToNot(BeNil())
+	g.Expect(config.PromptInjection.GetAdditionalContext()).To(Equal(additionalContext))
 }
 
 func expectRemoteAIEvaluationRestrictedTopics(
@@ -1751,9 +1747,8 @@ func expectRemoteAIEvaluationRestrictedTopics(
 	expected []string,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigRestrictedTopics).ToNot(BeNil())
-	restrictedTopicsConfig := config.EvaluationConfigRestrictedTopics.GetRestrictedTopics()
-	g.Expect(restrictedTopicsConfig.GetTopics()).To(ConsistOf(expectedStrings(expected)...))
+	g.Expect(config.RestrictedTopics).ToNot(BeNil())
+	g.Expect(config.RestrictedTopics.GetTopics()).To(ConsistOf(expectedStrings(expected)...))
 }
 
 func expectRemoteAIEvaluationSexism(
@@ -1761,8 +1756,8 @@ func expectRemoteAIEvaluationSexism(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigSexism).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigSexism.GetSexism()).To(BeEmpty())
+	g.Expect(config.Sexism).ToNot(BeNil())
+	g.Expect(config.Sexism).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationSQLAllowedTables(
@@ -1771,9 +1766,8 @@ func expectRemoteAIEvaluationSQLAllowedTables(
 	expected []string,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigSqlAllowedTables).ToNot(BeNil())
-	sqlAllowedTablesConfig := config.EvaluationConfigSqlAllowedTables.GetSqlAllowedTables()
-	g.Expect(sqlAllowedTablesConfig.GetTables()).To(ConsistOf(expectedStrings(expected)...))
+	g.Expect(config.SqlAllowedTables).ToNot(BeNil())
+	g.Expect(config.SqlAllowedTables.GetTables()).To(ConsistOf(expectedStrings(expected)...))
 }
 
 func expectRemoteAIEvaluationSQLHallucination(
@@ -1781,8 +1775,8 @@ func expectRemoteAIEvaluationSQLHallucination(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigSqlHallucination).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigSqlHallucination.GetSqlHallucination()).To(BeEmpty())
+	g.Expect(config.SqlHallucination).ToNot(BeNil())
+	g.Expect(config.SqlHallucination).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationSQLReadOnly(
@@ -1790,8 +1784,8 @@ func expectRemoteAIEvaluationSQLReadOnly(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigSqlReadOnly).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigSqlReadOnly.GetSqlReadOnly()).To(BeEmpty())
+	g.Expect(config.SqlReadOnly).ToNot(BeNil())
+	g.Expect(config.SqlReadOnly).To(BeEmpty())
 }
 
 func expectRemoteAIEvaluationSQLRestrictedTables(
@@ -1800,9 +1794,8 @@ func expectRemoteAIEvaluationSQLRestrictedTables(
 	expected []string,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigSqlRestrictedTables).ToNot(BeNil())
-	sqlRestrictedTablesConfig := config.EvaluationConfigSqlRestrictedTables.GetSqlRestrictedTables()
-	g.Expect(sqlRestrictedTablesConfig.GetTables()).To(ConsistOf(expectedStrings(expected)...))
+	g.Expect(config.SqlRestrictedTables).ToNot(BeNil())
+	g.Expect(config.SqlRestrictedTables.GetTables()).To(ConsistOf(expectedStrings(expected)...))
 }
 
 func expectRemoteAIEvaluationToxicity(
@@ -1810,8 +1803,8 @@ func expectRemoteAIEvaluationToxicity(
 	evaluation aievaluations.AiEvaluation,
 ) {
 	config := evaluation.GetConfig()
-	g.Expect(config.EvaluationConfigToxicity).ToNot(BeNil())
-	g.Expect(config.EvaluationConfigToxicity.GetToxicity()).To(BeEmpty())
+	g.Expect(config.Toxicity).ToNot(BeNil())
+	g.Expect(config.Toxicity).To(BeEmpty())
 }
 
 func schemaPIICategories(categories []aievaluations.PiiCategory) []string {

--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -17,6 +17,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,6 +35,10 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
+
+var slackIntegrationId = os.Getenv("SLACK_INTEGRATION_ID")
+var slackIntegrationChannel = os.Getenv("SLACK_INTEGRATION_CHANNEL")
+var pagerDutyIntegrationId = os.Getenv("PD_INTEGRATION_ID")
 
 var _ = Describe("Connector", Ordered, func() {
 	var (
@@ -157,7 +162,7 @@ var _ = Describe("Connector with SecretKeyRef", Ordered, func() {
 	It("Should create connector with secret reference successfully", func(ctx context.Context) {
 		By("Creating a Secret with the integration key")
 		secretName = fmt.Sprintf("pagerduty-secret-%d", time.Now().Unix())
-		secret = createTestSecret(secretName, testNamespace, "integration-key", "test-integration-key-value")
+		secret = createTestSecret(secretName, testNamespace, "integration-key", pagerDutyIntegrationId)
 		Expect(crClient.Create(ctx, secret)).To(Succeed())
 
 		By("Creating Connector with SecretKeyRef")
@@ -214,8 +219,8 @@ func getSampleSlackConnector(name, namespace string) *coralogixv1alpha1.Connecto
 			Type:        "slack",
 			ConnectorConfig: coralogixv1alpha1.ConnectorConfig{
 				Fields: []coralogixv1alpha1.ConnectorConfigField{
-					{FieldName: "channel", Value: ptr.To("general")},
-					{FieldName: "integrationId", Value: ptr.To("Slack")},
+					{FieldName: "channel", Value: ptr.To(slackIntegrationChannel)},
+					{FieldName: "integrationId", Value: ptr.To(slackIntegrationId)},
 					{FieldName: "fallbackChannel", Value: ptr.To("fallback_general")},
 				},
 			},

--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -45,11 +45,14 @@ var _ = Describe("Connector", Ordered, func() {
 	)
 
 	BeforeAll(func() {
+		Skip("Skipping test due to a breaking change in BE")
+
 		crClient = ClientsInstance.GetControllerRuntimeClient()
 		notificationsClient = ClientsInstance.GetCoralogixClientSet().Notifications()
 	})
 
 	It("Should be created successfully", func(ctx context.Context) {
+
 		By("Creating Connector")
 		connectorName = fmt.Sprintf("slack-connector-%d", time.Now().Unix())
 		connector = getSampleSlackConnector(connectorName, testNamespace)

--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -45,8 +45,6 @@ var _ = Describe("Connector", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Skip("Skipping test due to a breaking change in BE")
-
 		crClient = ClientsInstance.GetControllerRuntimeClient()
 		notificationsClient = ClientsInstance.GetCoralogixClientSet().Notifications()
 	})

--- a/tests/e2e/enrichment_test.go
+++ b/tests/e2e/enrichment_test.go
@@ -165,13 +165,13 @@ func assertBackendEnrichmentFieldOptions(
 func backendEnrichmentHasType(backendEnrichment enrichments.Enrichment, enrichmentType string) bool {
 	switch enrichmentType {
 	case "suspiciousIp":
-		return backendEnrichment.EnrichmentType.EnrichmentTypeSuspiciousIp != nil
+		return backendEnrichment.EnrichmentType.SuspiciousIp != nil
 	case "geoIp":
-		return backendEnrichment.EnrichmentType.EnrichmentTypeGeoIp != nil
+		return backendEnrichment.EnrichmentType.GeoIp != nil
 	case "customEnrichment":
-		return backendEnrichment.EnrichmentType.EnrichmentTypeCustomEnrichment != nil
+		return backendEnrichment.EnrichmentType.CustomEnrichment != nil
 	case "aws":
-		return backendEnrichment.EnrichmentType.EnrichmentTypeAws != nil
+		return backendEnrichment.EnrichmentType.Aws != nil
 	default:
 		return false
 	}

--- a/tests/e2e/global_router_test.go
+++ b/tests/e2e/global_router_test.go
@@ -30,8 +30,6 @@ var _ = Describe("GlobalRouter", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		Skip("Skipping test due to a breaking change in BE")
-
 		crClient = ClientsInstance.GetControllerRuntimeClient()
 		notificationsClient = ClientsInstance.GetCoralogixClientSet().Notifications()
 	})

--- a/tests/e2e/global_router_test.go
+++ b/tests/e2e/global_router_test.go
@@ -30,6 +30,8 @@ var _ = Describe("GlobalRouter", Ordered, func() {
 	)
 
 	BeforeAll(func() {
+		Skip("Skipping test due to a breaking change in BE")
+
 		crClient = ClientsInstance.GetControllerRuntimeClient()
 		notificationsClient = ClientsInstance.GetCoralogixClientSet().Notifications()
 	})


### PR DESCRIPTION
### Description

Updates the Operator to use the merged `coralogix-management-sdk` version that was regenerated from the independent OpenAPI `oneOf` schema model.

The SDK no longer exposes generated Cartesian wrapper structs for many OpenAPI `oneOf` shapes. Instead, affected fields are exposed directly on the parent SDK model. This PR updates the Operator code to use those new direct fields.
