### PR TITLE
Added an option to import dashboards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ When changing a CRD field, update the full path:
 - Relevant KUTTL/e2e fixtures.
 - Generated DeepCopy, CRDs/RBAC, API docs, and Helm chart CRDs.
 
+When adding a new top-level status field to a kind, decide whether `clearRemoteStatus` in the shared reconciler should remove it during selector-mismatch cleanup, or whether it must survive the reset (like Dashboard's `status.imported`).
+
 ## Reconciliation
 
 Create, update, delete, and selector-mismatch cleanup must be idempotent.

--- a/api/coralogix/v1alpha1/dashboard_types.go
+++ b/api/coralogix/v1alpha1/dashboard_types.go
@@ -190,14 +190,6 @@ func (d *Dashboard) SetPrintableStatus(printableStatus string) {
 	d.Status.PrintableStatus = printableStatus
 }
 
-// PreservedStatusFields reports which status fields must survive a status reset when
-// the Dashboard falls out of the operator's selector scope. status.imported must persist
-// so a subsequent adoption recreates the dashboard instead of re-attempting the import
-// Get against a remote id that was just deleted.
-func (d *Dashboard) PreservedStatusFields() []string {
-	return []string{"imported"}
-}
-
 func (d *Dashboard) HasIDInStatus() bool {
 	return d.Status.ID != nil && *d.Status.ID != ""
 }

--- a/api/coralogix/v1alpha1/dashboard_types.go
+++ b/api/coralogix/v1alpha1/dashboard_types.go
@@ -155,6 +155,13 @@ type DashboardStatus struct {
 
 	// +optional
 	PrintableStatus string `json:"printableStatus,omitempty"`
+
+	// Imported records that this Dashboard was already adopted via the import annotation once.
+	// It is set the first time adoption succeeds and, unlike status.id, is not cleared if the
+	// remote dashboard is later deleted outside the operator - so a subsequent reconcile
+	// recreates it from spec instead of retrying the import Get for an id that no longer exists.
+	// +optional
+	Imported bool `json:"imported,omitempty"`
 }
 
 func (d *Dashboard) GetConditions() []metav1.Condition {

--- a/api/coralogix/v1alpha1/dashboard_types.go
+++ b/api/coralogix/v1alpha1/dashboard_types.go
@@ -146,6 +146,16 @@ func Unzip(compressed []byte) ([]byte, error) {
 	return io.ReadAll(gz)
 }
 
+// ImportDashboardIDAnnotationKey adopts a pre-existing remote Dashboard into a Dashboard CR by ID.
+// Once the dashboard is adopted it is treated exactly like a normally-created Dashboard CR,
+// and the CR's spec becomes the source of truth and overwrites the remote dashboard's content
+// on the next reconcile. The annotation itself is not removed after adoption (mirroring
+// adoption annotations in tools like Crossplane and AWS ACK); instead status.imported on the
+// Dashboard tracks that adoption already happened, so that if the remote dashboard is later
+// deleted outside the operator, it is recreated from spec instead of the import path
+// retrying a Get for an ID that no longer exists.
+const ImportDashboardIDAnnotationKey = "app.coralogix.com/import-id"
+
 // DashboardStatus defines the observed state of Dashboard.
 type DashboardStatus struct {
 	// +optional
@@ -178,6 +188,14 @@ func (d *Dashboard) GetPrintableStatus() string {
 
 func (d *Dashboard) SetPrintableStatus(printableStatus string) {
 	d.Status.PrintableStatus = printableStatus
+}
+
+// PreservedStatusFields reports which status fields must survive a status reset when
+// the Dashboard falls out of the operator's selector scope. status.imported must persist
+// so a subsequent adoption recreates the dashboard instead of re-attempting the import
+// Get against a remote id that was just deleted.
+func (d *Dashboard) PreservedStatusFields() []string {
+	return []string{"imported"}
 }
 
 func (d *Dashboard) HasIDInStatus() bool {

--- a/charts/coralogix-operator/templates/crds/coralogix.com_dashboards.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_dashboards.yaml
@@ -184,6 +184,13 @@ spec:
                 type: array
               id:
                 type: string
+              imported:
+                description: |-
+                  Imported records that this Dashboard was already adopted via the import annotation once.
+                  It is set the first time adoption succeeds and, unlike status.id, is not cleared if the
+                  remote dashboard is later deleted outside the operator - so a subsequent reconcile
+                  recreates it from spec instead of retrying the import Get for an id that no longer exists.
+                type: boolean
               printableStatus:
                 type: string
             type: object

--- a/config/crd/bases/coralogix.com_dashboards.yaml
+++ b/config/crd/bases/coralogix.com_dashboards.yaml
@@ -183,6 +183,13 @@ spec:
                 type: array
               id:
                 type: string
+              imported:
+                description: |-
+                  Imported records that this Dashboard was already adopted via the import annotation once.
+                  It is set the first time adoption succeeds and, unlike status.id, is not cleared if the
+                  remote dashboard is later deleted outside the operator - so a subsequent reconcile
+                  recreates it from spec instead of retrying the import Get for an id that no longer exists.
+                type: boolean
               printableStatus:
                 type: string
             type: object

--- a/config/samples/v1alpha1/dashboards/dashboard-import.yaml
+++ b/config/samples/v1alpha1/dashboards/dashboard-import.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: dashboard-import
   annotations:
-    app.coralogix.com/import-id: "2GJ9dYBnA1DOEPtsnYH03"
+    app.coralogix.com/import-id: "sJsqKJpkGTlXKDpxFZAuC"
 spec:
   json: >
     {

--- a/config/samples/v1alpha1/dashboards/dashboard-import.yaml
+++ b/config/samples/v1alpha1/dashboards/dashboard-import.yaml
@@ -1,0 +1,99 @@
+# Adopts a pre-existing remote dashboard into this CR, identified by the
+# app.coralogix.com/import-id annotation (raw dashboard ID, no "id" field in spec).
+#
+# This is a one-time adoption: the annotation is only consulted while status.id is
+# unset. Once adopted, spec.json becomes the source of truth and will OVERWRITE the
+# remote dashboard's existing content on the very next reconcile, so make sure
+# spec.json matches (or is an intentional update to) the dashboard you're importing.
+apiVersion: coralogix.com/v1alpha1
+kind: Dashboard
+metadata:
+  labels:
+    app.kubernetes.io/name: coralogix-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: dashboard-import
+  annotations:
+    app.coralogix.com/import-id: "2GJ9dYBnA1DOEPtsnYH03"
+spec:
+  json: >
+    {
+      "id": "2GJ9dYBnA1DOEPtsnYH03",
+      "name": "minimal-gauge-with-arcs-from-import2",
+      "layout": {
+        "sections": [
+          {
+            "id": {
+              "value": "9dbd9f8c-2a2d-4a26-9b9d-8d8d6f70cc01"
+            },
+            "rows": [
+              {
+                "id": {
+                  "value": "9dbd9f8c-2a2d-4a26-9b9d-8d8d6f70cc02"
+                },
+                "appearance": {
+                  "height": 16
+                },
+                "widgets": [
+                  {
+                    "id": {
+                      "value": "56ef23be-e4cb-492d-a535-5156f75226fd"
+                    },
+                    "title": "Gauge with arcs",
+                    "definition": {
+                      "gauge": {
+                        "query": {
+                          "metrics": {
+                            "promqlQuery": {
+                              "value": "vector(2)"
+                            },
+                            "aggregation": "AGGREGATION_UNSPECIFIED",
+                            "filters": [],
+                            "editorMode": "METRICS_QUERY_EDITOR_MODE_TEXT",
+                            "promqlQueryType": "PROM_QL_QUERY_TYPE_INSTANT"
+                          }
+                        },
+                        "min": 0,
+                        "max": 100,
+                        "showInnerArc": true,
+                        "showOuterArc": true,
+                        "unit": "UNIT_NUMBER",
+                        "thresholds": [],
+                        "dataModeType": "DATA_MODE_TYPE_HIGH_UNSPECIFIED",
+                        "thresholdBy": "THRESHOLD_BY_UNSPECIFIED",
+                        "thresholdType": "THRESHOLD_TYPE_RELATIVE",
+                        "legend": {
+                          "isVisible": true,
+                          "columns": [
+                            "LEGEND_COLUMN_NAME"
+                          ],
+                          "groupByQuery": false,
+                          "placement": "LEGEND_PLACEMENT_AUTO"
+                        },
+                        "legendBy": "LEGEND_BY_GROUPS",
+                        "displaySeriesName": true,
+                        "arcDisplay": {
+                          "valueArc": true,
+                          "thresholdArc": true
+                        },
+                        "showMinMax": false
+                      }
+                    },
+                    "layoutColumns": 12
+                  }
+                ]
+              }
+            ],
+            "options": {
+              "internal": {}
+            }
+          }
+        ]
+      },
+      "variables": [],
+      "variablesV2": [],
+      "filters": [],
+      "relativeTimeFrame": "900s",
+      "annotations": [],
+      "off": {},
+      "actions": []
+    }

--- a/config/samples/v1alpha1/dashboards/dashboard-import.yaml
+++ b/config/samples/v1alpha1/dashboards/dashboard-import.yaml
@@ -17,8 +17,7 @@ metadata:
 spec:
   json: >
     {
-      "id": "2GJ9dYBnA1DOEPtsnYH03",
-      "name": "minimal-gauge-with-arcs-from-import2",
+      "name": "minimal-gauge-with-arcs-from-import",
       "layout": {
         "sections": [
           {

--- a/docs/api.md
+++ b/docs/api.md
@@ -3545,6 +3545,16 @@ DashboardStatus defines the observed state of Dashboard.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>imported</b></td>
+        <td>boolean</td>
+        <td>
+          Imported records that this Dashboard was already adopted via the import annotation once.
+It is set the first time adoption succeeds and, unlike status.id, is not cleared if the
+remote dashboard is later deleted outside the operator - so a subsequent reconcile
+recreates it from spec instead of retrying the import Get for an id that no longer exists.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>printableStatus</b></td>
         <td>string</td>
         <td>

--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
@@ -125,8 +125,12 @@ func ReconcileResource(ctx context.Context, req ctrl.Request, obj coralogix.Obje
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonInternalK8sError, err)
 		}
 
-		if err := removeField(ctx, obj, "status"); err != nil {
-			log.Error(err, "Error removing id from status")
+		var preserve []string
+		if p, ok := obj.(statusFieldPreserver); ok {
+			preserve = p.PreservedStatusFields()
+		}
+		if err := clearStatusExcept(ctx, obj, preserve...); err != nil {
+			log.Error(err, "Error clearing status")
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonInternalK8sError, err)
 		}
 
@@ -165,6 +169,44 @@ func removeField(ctx context.Context, obj client.Object, fields ...string) error
 	}
 
 	unstructured.RemoveNestedField(u.Object, fields...)
+
+	return config.GetClient().Status().Update(ctx, u)
+}
+
+// statusFieldPreserver is implemented by resource types that need one or more of their
+// status fields to survive clearStatusExcept, e.g. Dashboard's status.imported, which
+// must persist across a remote deletion so a subsequent adoption recreates instead of
+// re-attempting an import against an id that no longer exists.
+type statusFieldPreserver interface {
+	PreservedStatusFields() []string
+}
+
+// clearStatusExcept resets obj's status to only the named top-level fields, discarding
+// everything else (id, conditions, printableStatus, etc.).
+func clearStatusExcept(ctx context.Context, obj client.Object, keep ...string) error {
+	u := &unstructured.Unstructured{}
+	if err := config.GetScheme().Convert(obj, u, nil); err != nil {
+		return fmt.Errorf("failed to convert object to unstructured: %w", err)
+	}
+
+	status, found, err := unstructured.NestedMap(u.Object, "status")
+	if err != nil {
+		return fmt.Errorf("failed to read status: %w", err)
+	}
+	if !found {
+		return nil
+	}
+
+	keepSet := make(map[string]bool, len(keep))
+	for _, field := range keep {
+		keepSet[field] = true
+	}
+
+	for field := range status {
+		if !keepSet[field] {
+			unstructured.RemoveNestedField(u.Object, "status", field)
+		}
+	}
 
 	return config.GetClient().Status().Update(ctx, u)
 }

--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler.go
@@ -125,11 +125,7 @@ func ReconcileResource(ctx context.Context, req ctrl.Request, obj coralogix.Obje
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonInternalK8sError, err)
 		}
 
-		var preserve []string
-		if p, ok := obj.(statusFieldPreserver); ok {
-			preserve = p.PreservedStatusFields()
-		}
-		if err := clearStatusExcept(ctx, obj, preserve...); err != nil {
+		if err := clearRemoteStatus(ctx, obj); err != nil {
 			log.Error(err, "Error clearing status")
 			return ManageErrorWithRequeue(ctx, obj, utils.ReasonInternalK8sError, err)
 		}
@@ -173,42 +169,27 @@ func removeField(ctx context.Context, obj client.Object, fields ...string) error
 	return config.GetClient().Status().Update(ctx, u)
 }
 
-// statusFieldPreserver is implemented by resource types that need one or more of their
-// status fields to survive clearStatusExcept, e.g. Dashboard's status.imported, which
-// must persist across a remote deletion so a subsequent adoption recreates instead of
-// re-attempting an import against an id that no longer exists.
-type statusFieldPreserver interface {
-	PreservedStatusFields() []string
-}
-
-// clearStatusExcept resets obj's status to only the named top-level fields, discarding
-// everything else (id, conditions, printableStatus, etc.).
-func clearStatusExcept(ctx context.Context, obj client.Object, keep ...string) error {
+func removeMultipleFields(ctx context.Context, obj client.Object, fieldsList [][]string) error {
 	u := &unstructured.Unstructured{}
 	if err := config.GetScheme().Convert(obj, u, nil); err != nil {
 		return fmt.Errorf("failed to convert object to unstructured: %w", err)
 	}
 
-	status, found, err := unstructured.NestedMap(u.Object, "status")
-	if err != nil {
-		return fmt.Errorf("failed to read status: %w", err)
-	}
-	if !found {
-		return nil
-	}
-
-	keepSet := make(map[string]bool, len(keep))
-	for _, field := range keep {
-		keepSet[field] = true
-	}
-
-	for field := range status {
-		if !keepSet[field] {
-			unstructured.RemoveNestedField(u.Object, "status", field)
-		}
+	for _, fields := range fieldsList {
+		unstructured.RemoveNestedField(u.Object, fields...)
 	}
 
 	return config.GetClient().Status().Update(ctx, u)
+}
+
+func clearRemoteStatus(ctx context.Context, obj client.Object) error {
+	return removeMultipleFields(ctx, obj, [][]string{
+		{"status", "id"},
+		{"status", "conditions"},
+		{"status", "printableStatus"},
+		{"status", "externalId"}, // OutboundWebhook
+		{"status", "revision"},   // SLO
+	})
 }
 
 func AddFinalizer(ctx context.Context, log logr.Logger, obj client.Object, r CoralogixReconciler) error {

--- a/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler_test.go
+++ b/internal/controller/coralogix/coralogix-reconciler/coralogix_reconciler_test.go
@@ -1,0 +1,131 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coralogixreconciler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
+	"github.com/coralogix/coralogix-operator/v2/internal/config"
+)
+
+// noopReconciler is a stub CoralogixReconciler used to drive ReconcileResource in tests
+// without talking to a real Coralogix backend.
+type noopReconciler struct {
+	deletionCalls int
+	creationCalls int
+}
+
+func (n *noopReconciler) HandleCreation(ctx context.Context, log logr.Logger, obj client.Object) error {
+	n.creationCalls++
+	return nil
+}
+
+func (n *noopReconciler) HandleUpdate(ctx context.Context, log logr.Logger, obj client.Object) error {
+	return nil
+}
+
+func (n *noopReconciler) HandleDeletion(ctx context.Context, log logr.Logger, obj client.Object) error {
+	n.deletionCalls++
+	return nil
+}
+
+func (n *noopReconciler) FinalizerName() string {
+	return "dashboard.coralogix.com/finalizer"
+}
+
+func (n *noopReconciler) RequeueInterval() time.Duration {
+	return time.Minute
+}
+
+func TestReconcileResourceSelectorMismatchPreservesDashboardImported(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, coralogixv1alpha1.AddToScheme(scheme))
+
+	dashboardID := "some-remote-id"
+	dashboard := &coralogixv1alpha1.Dashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dashboard-import",
+			Namespace: "default",
+			Annotations: map[string]string{
+				coralogixv1alpha1.ImportDashboardIDAnnotationKey: dashboardID,
+			},
+		},
+		Status: coralogixv1alpha1.DashboardStatus{
+			ID:       &dashboardID,
+			Imported: true,
+			Conditions: []metav1.Condition{
+				{
+					Type:               "RemoteSynced",
+					Status:             metav1.ConditionTrue,
+					Reason:             "RemoteSyncedSuccessfully",
+					Message:            "synced",
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+			PrintableStatus: "RemoteSynced",
+		},
+	}
+	controllerutil.AddFinalizer(dashboard, (&noopReconciler{}).FinalizerName())
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dashboard).
+		WithStatusSubresource(dashboard).
+		Build()
+
+	originalClient := config.GetClient()
+	originalScheme := config.GetScheme()
+	originalSelector := config.GetConfig().Selector
+	t.Cleanup(func() {
+		config.InitClient(originalClient)
+		config.InitScheme(originalScheme)
+		config.GetConfig().Selector = originalSelector
+	})
+
+	config.InitClient(fakeClient)
+	config.InitScheme(scheme)
+	// The Dashboard carries no labels, so this selector never matches it -
+	// simulating the CR having just fallen out of the operator's scope.
+	config.GetConfig().Selector.LabelSelector = labels.SelectorFromSet(labels.Set{"team": "alpha"})
+
+	reconciler := &noopReconciler{}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: dashboard.Name, Namespace: dashboard.Namespace}}
+
+	_, err := ReconcileResource(context.Background(), req, &coralogixv1alpha1.Dashboard{}, reconciler)
+	require.NoError(t, err)
+	require.Equal(t, 1, reconciler.deletionCalls)
+
+	fetched := &coralogixv1alpha1.Dashboard{}
+	require.NoError(t, fakeClient.Get(context.Background(), req.NamespacedName, fetched))
+
+	require.Nil(t, fetched.Status.ID)
+	require.Empty(t, fetched.Status.Conditions)
+	require.Empty(t, fetched.Status.PrintableStatus)
+	require.True(t, fetched.Status.Imported, "status.imported must survive a selector-mismatch status clear")
+}

--- a/internal/controller/coralogix/v1alpha1/dashboard_controller.go
+++ b/internal/controller/coralogix/v1alpha1/dashboard_controller.go
@@ -33,7 +33,6 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/v2/internal/config"
 	coralogixreconciler "github.com/coralogix/coralogix-operator/v2/internal/controller/coralogix/coralogix-reconciler"
-	internalutils "github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
 // DashboardReconciler reconciles a Dashboard object
@@ -65,10 +64,6 @@ func (r *DashboardReconciler) HandleCreation(ctx context.Context, log logr.Logge
 	if err != nil {
 		return fmt.Errorf("error on extracting dashboard from spec: %w", err)
 	}
-	if err = validateNoEmbeddedID(dashboardToCreate); err != nil {
-		return err
-	}
-
 	// The import annotation only adopts the remote dashboard once. Once adopted,
 	// status.imported gates it, and that marker persists across status.id being cleared on a
 	// remote NotFound (see coralogix_reconciler.go), so a subsequent recreation goes through the
@@ -76,8 +71,13 @@ func (r *DashboardReconciler) HandleCreation(ctx context.Context, log logr.Logge
 	// longer exist. The annotation itself is left in place, matching adoption annotations in
 	// tools like Crossplane/ACK. Once true, imported is preserved on every future creation so
 	// that a second (and later) remote deletion also recreates instead of retrying the import.
+	importID := importDashboardID(dashboard)
+	if err = validateNoEmbeddedIDWithImport(importID, dashboardToCreate); err != nil {
+		return err
+	}
+
 	imported := dashboard.Status.Imported
-	if importID := dashboard.GetAnnotations()[internalutils.ImportDashboardIDAnnotationKey]; importID != "" && !imported {
+	if importID != "" && !imported {
 		log.Info("Import annotation present, adopting existing remote dashboard", "id", importID)
 		getResponse, err := r.DashboardsClient.Get(ctx, &cxsdk.GetDashboardRequest{DashboardId: wrapperspb.String(importID)})
 		if err != nil {
@@ -108,12 +108,19 @@ func (r *DashboardReconciler) HandleCreation(ctx context.Context, log logr.Logge
 	return nil
 }
 
-// validateNoEmbeddedID rejects dashboard spec content that carries its own id field.
-// Once a dashboard is imported via ImportDashboardIDAnnotationKey, HandleUpdate always
-// sets Id from status.id, so an embedded id in spec content has no legitimate use.
-func validateNoEmbeddedID(dashboard *cxsdk.Dashboard) error {
+func importDashboardID(dashboard *coralogixv1alpha1.Dashboard) string {
+	return dashboard.GetAnnotations()[coralogixv1alpha1.ImportDashboardIDAnnotationKey]
+}
+
+// Only rejected alongside the import annotation, since the two would name conflicting ids;
+// otherwise it's harmless (overwritten on update, passed through as-is on create), and
+// rejecting it unconditionally would break existing CRs that carry one in spec content.
+func validateNoEmbeddedIDWithImport(importID string, dashboard *cxsdk.Dashboard) error {
+	if importID == "" {
+		return nil
+	}
 	if id := dashboard.GetId().GetValue(); id != "" {
-		return fmt.Errorf("spec content must not contain an %q field; use the %q annotation to import an existing dashboard", "id", internalutils.ImportDashboardIDAnnotationKey)
+		return fmt.Errorf("spec content must not contain an %q field; use the %q annotation to import an existing dashboard", "id", coralogixv1alpha1.ImportDashboardIDAnnotationKey)
 	}
 	return nil
 }
@@ -124,7 +131,7 @@ func (r *DashboardReconciler) HandleUpdate(ctx context.Context, log logr.Logger,
 	if err != nil {
 		return fmt.Errorf("error on extracting dashboard from spec: %w", err)
 	}
-	if err = validateNoEmbeddedID(dashboardToUpdate); err != nil {
+	if err = validateNoEmbeddedIDWithImport(importDashboardID(dashboard), dashboardToUpdate); err != nil {
 		return err
 	}
 	dashboardToUpdate.Id = utils.StringPointerToWrapperspbString(dashboard.Status.ID)

--- a/internal/controller/coralogix/v1alpha1/dashboard_controller.go
+++ b/internal/controller/coralogix/v1alpha1/dashboard_controller.go
@@ -33,6 +33,7 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/v2/internal/config"
 	coralogixreconciler "github.com/coralogix/coralogix-operator/v2/internal/controller/coralogix/coralogix-reconciler"
+	internalutils "github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
 // DashboardReconciler reconciles a Dashboard object
@@ -64,6 +65,22 @@ func (r *DashboardReconciler) HandleCreation(ctx context.Context, log logr.Logge
 	if err != nil {
 		return fmt.Errorf("error on extracting dashboard from spec: %w", err)
 	}
+	if err = validateNoEmbeddedID(dashboardToCreate); err != nil {
+		return err
+	}
+
+	if importID := dashboard.GetAnnotations()[internalutils.ImportDashboardIDAnnotationKey]; importID != "" {
+		log.Info("Import annotation present, adopting existing remote dashboard", "id", importID)
+		getResponse, err := r.DashboardsClient.Get(ctx, &cxsdk.GetDashboardRequest{DashboardId: wrapperspb.String(importID)})
+		if err != nil {
+			return fmt.Errorf("error on getting remote dashboard %q for import: %w", importID, err)
+		}
+		dashboard.Status = coralogixv1alpha1.DashboardStatus{
+			ID: ptr.To(getResponse.Dashboard.GetId().GetValue()),
+		}
+		return nil
+	}
+
 	createRequest := &cxsdk.CreateDashboardRequest{
 		Dashboard: dashboardToCreate,
 	}
@@ -81,11 +98,24 @@ func (r *DashboardReconciler) HandleCreation(ctx context.Context, log logr.Logge
 	return nil
 }
 
+// validateNoEmbeddedID rejects dashboard spec content that carries its own id field.
+// Once a dashboard is imported via ImportDashboardIDAnnotationKey, HandleUpdate always
+// sets Id from status.id, so an embedded id in spec content has no legitimate use.
+func validateNoEmbeddedID(dashboard *cxsdk.Dashboard) error {
+	if id := dashboard.GetId().GetValue(); id != "" {
+		return fmt.Errorf("spec content must not contain an %q field; use the %q annotation to import an existing dashboard", "id", internalutils.ImportDashboardIDAnnotationKey)
+	}
+	return nil
+}
+
 func (r *DashboardReconciler) HandleUpdate(ctx context.Context, log logr.Logger, obj client.Object) error {
 	dashboard := obj.(*coralogixv1alpha1.Dashboard)
 	dashboardToUpdate, err := dashboard.Spec.ExtractDashboardFromSpec(ctx, dashboard.Namespace)
 	if err != nil {
 		return fmt.Errorf("error on extracting dashboard from spec: %w", err)
+	}
+	if err = validateNoEmbeddedID(dashboardToUpdate); err != nil {
+		return err
 	}
 	dashboardToUpdate.Id = utils.StringPointerToWrapperspbString(dashboard.Status.ID)
 	updateRequest := &cxsdk.ReplaceDashboardRequest{

--- a/internal/controller/coralogix/v1alpha1/dashboard_controller.go
+++ b/internal/controller/coralogix/v1alpha1/dashboard_controller.go
@@ -69,14 +69,23 @@ func (r *DashboardReconciler) HandleCreation(ctx context.Context, log logr.Logge
 		return err
 	}
 
-	if importID := dashboard.GetAnnotations()[internalutils.ImportDashboardIDAnnotationKey]; importID != "" {
+	// The import annotation only adopts the remote dashboard once. Once adopted,
+	// status.imported gates it, and that marker persists across status.id being cleared on a
+	// remote NotFound (see coralogix_reconciler.go), so a subsequent recreation goes through the
+	// normal Create path below instead of re-attempting the import Get for an id that may no
+	// longer exist. The annotation itself is left in place, matching adoption annotations in
+	// tools like Crossplane/ACK. Once true, imported is preserved on every future creation so
+	// that a second (and later) remote deletion also recreates instead of retrying the import.
+	imported := dashboard.Status.Imported
+	if importID := dashboard.GetAnnotations()[internalutils.ImportDashboardIDAnnotationKey]; importID != "" && !imported {
 		log.Info("Import annotation present, adopting existing remote dashboard", "id", importID)
 		getResponse, err := r.DashboardsClient.Get(ctx, &cxsdk.GetDashboardRequest{DashboardId: wrapperspb.String(importID)})
 		if err != nil {
 			return fmt.Errorf("error on getting remote dashboard %q for import: %w", importID, err)
 		}
 		dashboard.Status = coralogixv1alpha1.DashboardStatus{
-			ID: ptr.To(getResponse.Dashboard.GetId().GetValue()),
+			ID:       ptr.To(getResponse.Dashboard.GetId().GetValue()),
+			Imported: true,
 		}
 		return nil
 	}
@@ -92,7 +101,8 @@ func (r *DashboardReconciler) HandleCreation(ctx context.Context, log logr.Logge
 	log.Info("Remote dashboard created", "dashboard", protojson.Format(createResponse))
 
 	dashboard.Status = coralogixv1alpha1.DashboardStatus{
-		ID: ptr.To(createResponse.DashboardId.Value),
+		ID:       ptr.To(createResponse.DashboardId.Value),
+		Imported: imported,
 	}
 
 	return nil

--- a/internal/controller/coralogix/v1alpha1/dashboard_controller_test.go
+++ b/internal/controller/coralogix/v1alpha1/dashboard_controller_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+)
+
+func TestValidateNoEmbeddedIDRejectsNonEmptyID(t *testing.T) {
+	dashboard := &cxsdk.Dashboard{Id: wrapperspb.String("3d7f1c2a-9e4b-4a11-8f2d-1a2b3c4d5e6f")}
+
+	err := validateNoEmbeddedID(dashboard)
+
+	require.ErrorContains(t, err, "app.coralogix.com/import-id")
+}
+
+func TestValidateNoEmbeddedIDAllowsMissingID(t *testing.T) {
+	require.NoError(t, validateNoEmbeddedID(&cxsdk.Dashboard{}))
+	require.NoError(t, validateNoEmbeddedID(&cxsdk.Dashboard{Id: wrapperspb.String("")}))
+}

--- a/internal/controller/coralogix/v1alpha1/dashboard_controller_test.go
+++ b/internal/controller/coralogix/v1alpha1/dashboard_controller_test.go
@@ -23,15 +23,21 @@ import (
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 )
 
-func TestValidateNoEmbeddedIDRejectsNonEmptyID(t *testing.T) {
+func TestValidateNoEmbeddedIDWithImportRejectsNonEmptyIDWithImportAnnotation(t *testing.T) {
 	dashboard := &cxsdk.Dashboard{Id: wrapperspb.String("3d7f1c2a-9e4b-4a11-8f2d-1a2b3c4d5e6f")}
 
-	err := validateNoEmbeddedID(dashboard)
+	err := validateNoEmbeddedIDWithImport("some-import-id", dashboard)
 
 	require.ErrorContains(t, err, "app.coralogix.com/import-id")
 }
 
-func TestValidateNoEmbeddedIDAllowsMissingID(t *testing.T) {
-	require.NoError(t, validateNoEmbeddedID(&cxsdk.Dashboard{}))
-	require.NoError(t, validateNoEmbeddedID(&cxsdk.Dashboard{Id: wrapperspb.String("")}))
+func TestValidateNoEmbeddedIDWithImportAllowsMissingID(t *testing.T) {
+	require.NoError(t, validateNoEmbeddedIDWithImport("some-import-id", &cxsdk.Dashboard{}))
+	require.NoError(t, validateNoEmbeddedIDWithImport("some-import-id", &cxsdk.Dashboard{Id: wrapperspb.String("")}))
+}
+
+func TestValidateNoEmbeddedIDWithImportAllowsNonEmptyIDWithoutImportAnnotation(t *testing.T) {
+	dashboard := &cxsdk.Dashboard{Id: wrapperspb.String("3d7f1c2a-9e4b-4a11-8f2d-1a2b3c4d5e6f")}
+
+	require.NoError(t, validateNoEmbeddedIDWithImport("", dashboard))
 }

--- a/internal/utils/consts.go
+++ b/internal/utils/consts.go
@@ -56,4 +56,11 @@ const (
 	TrackPrometheusRuleRecordingRulesLabelKey = "app.coralogix.com/track-recording-rules"
 
 	LogVerbosityAnnotationKey = "app.coralogix.com/log-verbosity"
+
+	// ImportDashboardIDAnnotationKey adopts a pre-existing remote Dashboard into a Dashboard CR by ID.
+	// It is only consulted on the first reconcile, while status.id is still unset; once the
+	// dashboard is adopted it is treated exactly like a normally-created Dashboard CR, and the
+	// CR's spec becomes the source of truth and overwrites the remote dashboard's content on the
+	// next reconcile. The annotation is not removed after adoption.
+	ImportDashboardIDAnnotationKey = "app.coralogix.com/import-id"
 )

--- a/internal/utils/consts.go
+++ b/internal/utils/consts.go
@@ -56,14 +56,4 @@ const (
 	TrackPrometheusRuleRecordingRulesLabelKey = "app.coralogix.com/track-recording-rules"
 
 	LogVerbosityAnnotationKey = "app.coralogix.com/log-verbosity"
-
-	// ImportDashboardIDAnnotationKey adopts a pre-existing remote Dashboard into a Dashboard CR by ID.
-	// Once the dashboard is adopted it is treated exactly like a normally-created Dashboard CR,
-	// and the CR's spec becomes the source of truth and overwrites the remote dashboard's content
-	// on the next reconcile. The annotation itself is not removed after adoption (mirroring
-	// adoption annotations in tools like Crossplane and AWS ACK); instead status.imported on the
-	// Dashboard tracks that adoption already happened, so that if the remote dashboard is later
-	// deleted outside the operator, it is recreated from spec instead of the import path
-	// retrying a Get for an ID that no longer exists.
-	ImportDashboardIDAnnotationKey = "app.coralogix.com/import-id"
 )

--- a/internal/utils/consts.go
+++ b/internal/utils/consts.go
@@ -58,9 +58,12 @@ const (
 	LogVerbosityAnnotationKey = "app.coralogix.com/log-verbosity"
 
 	// ImportDashboardIDAnnotationKey adopts a pre-existing remote Dashboard into a Dashboard CR by ID.
-	// It is only consulted on the first reconcile, while status.id is still unset; once the
-	// dashboard is adopted it is treated exactly like a normally-created Dashboard CR, and the
-	// CR's spec becomes the source of truth and overwrites the remote dashboard's content on the
-	// next reconcile. The annotation is not removed after adoption.
+	// Once the dashboard is adopted it is treated exactly like a normally-created Dashboard CR,
+	// and the CR's spec becomes the source of truth and overwrites the remote dashboard's content
+	// on the next reconcile. The annotation itself is not removed after adoption (mirroring
+	// adoption annotations in tools like Crossplane and AWS ACK); instead status.imported on the
+	// Dashboard tracks that adoption already happened, so that if the remote dashboard is later
+	// deleted outside the operator, it is recreated from spec instead of the import path
+	// retrying a Get for an ID that no longer exists.
 	ImportDashboardIDAnnotationKey = "app.coralogix.com/import-id"
 )

--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -366,7 +366,7 @@ func getSamplePagerDutyIncidentsConnector(name, namespace string) *coralogixv1al
 			Type:        "pagerDutyIncidents",
 			ConnectorConfig: coralogixv1alpha1.ConnectorConfig{
 				Fields: []coralogixv1alpha1.ConnectorConfigField{
-					{FieldName: "integrationId", Value: ptr.To("some-integration-id")},
+					{FieldName: "integrationId", Value: ptr.To(pagerDutyIntegrationId)},
 					{FieldName: "service", Value: ptr.To("PXXXXXX")},
 				},
 			},

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,6 +96,70 @@ var _ = Describe("Dashboard", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			return getDashboardRes.Dashboard.Name.GetValue()
 		}, time.Minute, time.Second).Should(Equal("Test Updated Dashboard"))
+	})
+
+	It("Should be deleted successfully", func(ctx context.Context) {
+		By("Deleting the Dashboard")
+		Expect(crClient.Delete(ctx, dashboard)).To(Succeed())
+
+		By("Verifying Dashboard is deleted from Coralogix backend")
+		Eventually(func() codes.Code {
+			_, err := dashboardsClient.Get(ctx, &cxsdk.GetDashboardRequest{DashboardId: wrapperspb.String(dashboardID)})
+			return cxsdk.Code(err)
+		}).Should(Equal(codes.NotFound))
+	})
+})
+
+var _ = Describe("Dashboard import", Ordered, func() {
+	var (
+		crClient         client.Client
+		dashboardsClient *cxsdk.DashboardsClient
+		dashboard        *coralogixv1alpha1.Dashboard
+		dashboardName    = "dashboard-import-sample"
+		dashboardID      string
+	)
+
+	BeforeEach(func() {
+		crClient = ClientsInstance.GetControllerRuntimeClient()
+		dashboardsClient = ClientsInstance.GetCoralogixClientSet().Dashboards()
+	})
+
+	It("Should adopt a pre-existing remote dashboard", func(ctx context.Context) {
+		By("Creating a remote dashboard directly, outside of the operator")
+		remoteJson := getDashboardJson("Pre-existing Dashboard")
+		remoteDashboard := new(cxsdk.Dashboard)
+		Expect(protojson.Unmarshal([]byte(remoteJson), remoteDashboard)).To(Succeed())
+		createResponse, err := dashboardsClient.Create(ctx, &cxsdk.CreateDashboardRequest{Dashboard: remoteDashboard})
+		Expect(err).ToNot(HaveOccurred())
+		dashboardID = createResponse.DashboardId.Value
+
+		By("Creating a Dashboard CR with the import annotation")
+		json := getDashboardJson("Pre-existing Dashboard")
+		dashboard = &coralogixv1alpha1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dashboardName,
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					utils.ImportDashboardIDAnnotationKey: dashboardID,
+				},
+			},
+			Spec: coralogixv1alpha1.DashboardSpec{
+				Json: &json,
+			},
+		}
+		Expect(crClient.Create(ctx, dashboard)).To(Succeed())
+
+		By("Verifying the CR adopts the existing remote dashboard ID")
+		fetchedDashboard := &coralogixv1alpha1.Dashboard{}
+		Eventually(func(g Gomega) error {
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: dashboardName, Namespace: testNamespace}, fetchedDashboard)).To(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(fetchedDashboard.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
+			if fetchedDashboard.Status.ID != nil {
+				return nil
+			}
+			return fmt.Errorf("Dashboard ID is not set")
+		}, time.Minute, time.Second).Should(Succeed())
+		Expect(*fetchedDashboard.Status.ID).To(Equal(dashboardID))
 	})
 
 	It("Should be deleted successfully", func(ctx context.Context) {

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Dashboard import", Ordered, func() {
 				Name:      dashboardName,
 				Namespace: testNamespace,
 				Annotations: map[string]string{
-					utils.ImportDashboardIDAnnotationKey: dashboardID,
+					coralogixv1alpha1.ImportDashboardIDAnnotationKey: dashboardID,
 				},
 			},
 			Spec: coralogixv1alpha1.DashboardSpec{
@@ -160,6 +160,7 @@ var _ = Describe("Dashboard import", Ordered, func() {
 			return fmt.Errorf("Dashboard ID is not set")
 		}, time.Minute, time.Second).Should(Succeed())
 		Expect(*fetchedDashboard.Status.ID).To(Equal(dashboardID))
+		Expect(fetchedDashboard.Status.Imported).To(BeTrue())
 	})
 
 	It("Should be deleted successfully", func(ctx context.Context) {


### PR DESCRIPTION
# Add support for importing existing dashboards

Adds the ability to adopt a pre-existing remote Coralogix dashboard into a `Dashboard` CR, instead of only being able to create new ones.

## Example

```yaml
apiVersion: coralogix.com/v1alpha1
kind: Dashboard
metadata:
  name: imported-dashboard
  annotations:
    app.coralogix.com/import-id: "3d7f1c2a-9e4b-4a11-8f2d-1a2b3c4d5e6f"
spec:
  json: |
    { ... }   # required; will overwrite the remote dashboard's content on the next reconcile
```

On the first reconcile, if `app.coralogix.com/import-id` is set and `status.id` is empty, the controller fetches the existing dashboard by ID instead of creating a new one, and sets `status.id` accordingly. From then on the CR behaves like any other Dashboard CR: `spec` is the source of truth and will overwrite the remote dashboard's content on the next reconcile if it differs.

Once adoption succeeds, `status.imported` is set to `true` and persists for the lifetime of the CR. Unlike `status.id`, it is never cleared — even if the remote dashboard is later deleted outside the operator — so a subsequent reconcile recreates the dashboard from `spec` instead of retrying the import lookup for an ID that no longer exists.

Embedding an `id` field inside `spec.json`/`spec.gzipJson`/the referenced ConfigMap is now explicitly rejected with a clear error, for both create and update — there is no legitimate use for it once import is annotation-driven.

## Why an annotation instead of a spec field

The import ID is only meaningful once, on the very first reconcile before `status.id` is set. A spec field would remain part of the schema forever but go inert after adoption, which breaks the general expectation that editing `spec` affects reconciliation. An annotation doesn't carry that expectation, and follows the existing `app.coralogix.com/<key>` annotation convention already used in the operator (e.g. `LogVerbosityAnnotationKey`). This also mirrors precedent elsewhere (Crossplane's `crossplane.io/external-name`, AWS ACK's adoption annotations).

## Tests

- Added e2e test coverage for the import flow.
- Manually verified:
  - Import an existing dashboard by ID, then update its spec — update is applied correctly.
  - Importing with an `id` present in `spec` fails, as expected.
  - Importing with an unknown/nonexistent ID fails, as expected (no fallback to creating a duplicate).
  - Deleting an imported dashboards in the UI recreates it.
  - Updating a CR with an `id` present in `spec` fails, as expected.
