### PR TITLE
Events2metric datasource and aggmetadata fix

### DIFF
--- a/api/coralogix/v1alpha1/events2metric_types.go
+++ b/api/coralogix/v1alpha1/events2metric_types.go
@@ -31,6 +31,9 @@ type Events2MetricSpec struct {
 	// Description of the E2M
 	// +optional
 	Description *string `json:"description,omitempty"`
+	// Data source in <namespace>/<dataset_name> format. If not set, defaults to the standard logs/spans stream.
+	// +optional
+	DataSource *string `json:"dataSource,omitempty"`
 	// Represents the limit of the permutations
 	// +optional
 	PermutationsLimit *int32 `json:"permutationsLimit,omitempty"`
@@ -282,6 +285,7 @@ func (spec *Events2MetricSpec) ExtractCreateE2MRequest() *cxsdk.CreateE2MRequest
 	e2m := &cxsdk.E2MCreateParams{
 		Name:              wrapperspb.String(spec.Name),
 		Description:       utils.StringPointerToWrapperspbString(spec.Description),
+		DataSource:        utils.StringPointerToWrapperspbString(spec.DataSource),
 		PermutationsLimit: utils.Int32PointerToWrapperspbInt32(spec.PermutationsLimit),
 		MetricLabels:      extractE2mMetricLabels(spec.MetricLabels),
 		MetricFields:      extractE2mMetricFields(spec.MetricFields),
@@ -297,6 +301,7 @@ func (spec *Events2MetricSpec) ExtractReplaceE2MRequest() *cxsdk.ReplaceE2MReque
 		E2M: &cxsdk.E2M{
 			Name:         wrapperspb.String(spec.Name),
 			Description:  utils.StringPointerToWrapperspbString(spec.Description),
+			DataSource:   utils.StringPointerToWrapperspbString(spec.DataSource),
 			Permutations: extractE2mPermutations(spec.PermutationsLimit),
 			MetricLabels: extractE2mMetricLabels(spec.MetricLabels),
 			MetricFields: extractE2mMetricFields(spec.MetricFields),

--- a/api/coralogix/v1alpha1/events2metric_types.go
+++ b/api/coralogix/v1alpha1/events2metric_types.go
@@ -72,8 +72,8 @@ type MetricFieldAggregation struct {
 	AggType AggregationType `json:"aggType"`
 	// Target metric field alias name
 	TargetMetricName string `json:"targetMetricName"`
-	// Aggregate metadata, samples or histogram type
-	// Types that are valid to be assigned to AggMetadata: AggregationTypeSamples, AggregationTypeHistogram
+	// Aggregate metadata, samples or histogram type. Only relevant for the samples and histogram
+	// aggregation types; leave both samples and histogram unset for min/max/count/avg/sum.
 	AggMetadata AggregationMetadata `json:"aggMetadata"`
 }
 
@@ -109,7 +109,7 @@ var AggregationTypeSchemaToProto = map[AggregationType]cxsdk.E2MAggregationType{
 }
 
 // AggregationMetadata defines the metadata for aggregation.
-// +kubebuilder:validation:XValidation:rule="has(self.samples) != has(self.histogram)",message="Exactly one of samples or histogram must be set"
+// +kubebuilder:validation:XValidation:rule="!(has(self.samples) && has(self.histogram))",message="At most one of samples or histogram may be set"
 type AggregationMetadata struct {
 	// E2M sample type metadata
 	// +optional

--- a/api/coralogix/v1alpha1/zz_generated.deepcopy.go
+++ b/api/coralogix/v1alpha1/zz_generated.deepcopy.go
@@ -2275,6 +2275,11 @@ func (in *Events2MetricSpec) DeepCopyInto(out *Events2MetricSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DataSource != nil {
+		in, out := &in.DataSource, &out.DataSource
+		*out = new(string)
+		**out = **in
+	}
 	if in.PermutationsLimit != nil {
 		in, out := &in.PermutationsLimit, &out.PermutationsLimit
 		*out = new(int32)

--- a/charts/coralogix-operator/templates/crds/coralogix.com_events2metrics.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_events2metrics.yaml
@@ -51,6 +51,10 @@ spec:
           spec:
             description: Events2MetricSpec defines the desired state of Events2Metric.
             properties:
+              dataSource:
+                description: Data source in <namespace>/<dataset_name> format. If
+                  not set, defaults to the standard logs/spans stream.
+                type: string
               description:
                 description: Description of the E2M
                 type: string

--- a/charts/coralogix-operator/templates/crds/coralogix.com_events2metrics.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_events2metrics.yaml
@@ -68,8 +68,8 @@ spec:
                         properties:
                           aggMetadata:
                             description: |-
-                              Aggregate metadata, samples or histogram type
-                              Types that are valid to be assigned to AggMetadata: AggregationTypeSamples, AggregationTypeHistogram
+                              Aggregate metadata, samples or histogram type. Only relevant for the samples and histogram
+                              aggregation types; leave both samples and histogram unset for min/max/count/avg/sum.
                             properties:
                               histogram:
                                 description: E2M aggregate histogram type metadata
@@ -101,9 +101,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of samples or histogram must be
+                            - message: At most one of samples or histogram may be
                                 set
-                              rule: has(self.samples) != has(self.histogram)
+                              rule: '!(has(self.samples) && has(self.histogram))'
                           aggType:
                             description: Aggregation type
                             enum:

--- a/config/crd/bases/coralogix.com_events2metrics.yaml
+++ b/config/crd/bases/coralogix.com_events2metrics.yaml
@@ -67,8 +67,8 @@ spec:
                         properties:
                           aggMetadata:
                             description: |-
-                              Aggregate metadata, samples or histogram type
-                              Types that are valid to be assigned to AggMetadata: AggregationTypeSamples, AggregationTypeHistogram
+                              Aggregate metadata, samples or histogram type. Only relevant for the samples and histogram
+                              aggregation types; leave both samples and histogram unset for min/max/count/avg/sum.
                             properties:
                               histogram:
                                 description: E2M aggregate histogram type metadata
@@ -100,9 +100,9 @@ spec:
                                 type: object
                             type: object
                             x-kubernetes-validations:
-                            - message: Exactly one of samples or histogram must be
+                            - message: At most one of samples or histogram may be
                                 set
-                              rule: has(self.samples) != has(self.histogram)
+                              rule: '!(has(self.samples) && has(self.histogram))'
                           aggType:
                             description: Aggregation type
                             enum:

--- a/config/crd/bases/coralogix.com_events2metrics.yaml
+++ b/config/crd/bases/coralogix.com_events2metrics.yaml
@@ -50,6 +50,10 @@ spec:
           spec:
             description: Events2MetricSpec defines the desired state of Events2Metric.
             properties:
+              dataSource:
+                description: Data source in <namespace>/<dataset_name> format. If
+                  not set, defaults to the standard logs/spans stream.
+                type: string
               description:
                 description: Description of the E2M
                 type: string

--- a/config/samples/v1alpha1/events2metrics/logs2metric.yaml
+++ b/config/samples/v1alpha1/events2metrics/logs2metric.yaml
@@ -29,6 +29,4 @@ spec:
       aggregations:
         - aggType: "min"
           targetMetricName: "Timestamp"
-          aggMetadata:
-            samples:
-              sampleType: "min"
+          aggMetadata: {}

--- a/config/samples/v1alpha1/events2metrics/logs2metric.yaml
+++ b/config/samples/v1alpha1/events2metrics/logs2metric.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   name: "logs2metric-sample"
   description: "Sample logs2metric"
+  dataSource: "system/poc.error_tracking"
   permutationsLimit: 10000
   metricLabels:
     - targetLabel: "Status"

--- a/docs/api.md
+++ b/docs/api.md
@@ -4780,10 +4780,10 @@ Spans query for spans2metrics E2M
         <td><b><a href="#events2metricspecmetricfieldsindexaggregationsindexaggmetadata">aggMetadata</a></b></td>
         <td>object</td>
         <td>
-          Aggregate metadata, samples or histogram type
-Types that are valid to be assigned to AggMetadata: AggregationTypeSamples, AggregationTypeHistogram<br/>
+          Aggregate metadata, samples or histogram type. Only relevant for the samples and histogram
+aggregation types; leave both samples and histogram unset for min/max/count/avg/sum.<br/>
           <br/>
-            <i>Validations</i>:<li>has(self.samples) != has(self.histogram): Exactly one of samples or histogram must be set</li>
+            <i>Validations</i>:<li>!(has(self.samples) && has(self.histogram)): At most one of samples or histogram may be set</li>
         </td>
         <td>true</td>
       </tr><tr>
@@ -4820,8 +4820,8 @@ Types that are valid to be assigned to AggMetadata: AggregationTypeSamples, Aggr
 
 
 
-Aggregate metadata, samples or histogram type
-Types that are valid to be assigned to AggMetadata: AggregationTypeSamples, AggregationTypeHistogram
+Aggregate metadata, samples or histogram type. Only relevant for the samples and histogram
+aggregation types; leave both samples and histogram unset for min/max/count/avg/sum.
 
 <table>
     <thead>

--- a/docs/api.md
+++ b/docs/api.md
@@ -4533,6 +4533,13 @@ Events2MetricSpec defines the desired state of Events2Metric.
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>dataSource</b></td>
+        <td>string</td>
+        <td>
+          Data source in <namespace>/<dataset_name> format. If not set, defaults to the standard logs/spans stream.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>description</b></td>
         <td>string</td>
         <td>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.24.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260722083645-c4748d25d07c
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39 h1:Ng94C0STKyjwhe0PisPAf72EwfWygiE6VIROidRApsY=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260710130404-1b9d69a25d39/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260722083645-c4748d25d07c h1:DbrOeDCze0AJ5UMrTp5KivXwhbHEPV7HO1f1EUwQWQ4=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260722083645-c4748d25d07c/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/tests/e2e/events2metrics_test.go
+++ b/tests/e2e/events2metrics_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Events2Metric", Ordered, func() {
 			Spec: coralogixv1alpha1.Events2MetricSpec{
 				Name:              e2mName,
 				Description:       ptr.To("e2m from k8s operator"),
+				DataSource:        ptr.To("system/poc.error_tracking"),
 				PermutationsLimit: ptr.To(int32(100)),
 				MetricLabels: []coralogixv1alpha1.MetricLabel{
 					{

--- a/tests/e2e/events2metrics_test.go
+++ b/tests/e2e/events2metrics_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Events2Metric", Ordered, func() {
 			Spec: coralogixv1alpha1.Events2MetricSpec{
 				Name:              e2mName,
 				Description:       ptr.To("e2m from k8s operator"),
-				DataSource:        ptr.To("system/poc.error_tracking"),
+				DataSource:        ptr.To("default/cicd"),
 				PermutationsLimit: ptr.To(int32(100)),
 				MetricLabels: []coralogixv1alpha1.MetricLabel{
 					{

--- a/tests/e2e/events2metrics_test.go
+++ b/tests/e2e/events2metrics_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Events2Metric", Ordered, func() {
 			Spec: coralogixv1alpha1.Events2MetricSpec{
 				Name:              e2mName,
 				Description:       ptr.To("e2m from k8s operator"),
-				DataSource:        ptr.To("default/cicd"),
+				DataSource:        ptr.To("default/logs"),
 				PermutationsLimit: ptr.To(int32(100)),
 				MetricLabels: []coralogixv1alpha1.MetricLabel{
 					{

--- a/tests/e2e/events2metrics_test.go
+++ b/tests/e2e/events2metrics_test.go
@@ -74,11 +74,6 @@ var _ = Describe("Events2Metric", Ordered, func() {
 							{
 								AggType:          coralogixv1alpha1.AggregationTypeMin,
 								TargetMetricName: "min_request_count",
-								AggMetadata: coralogixv1alpha1.AggregationMetadata{
-									Samples: &coralogixv1alpha1.SamplesMetadata{
-										SampleType: coralogixv1alpha1.E2MAggSamplesSampleTypeMin,
-									},
-								},
 							},
 						},
 					},


### PR DESCRIPTION
## Summary
Implements CX-46690 (IAC support template) for `Events2Metric`:
- Adds `spec.dataSource` (`<namespace>/<dataset_name>`) so E2Ms can target a specific dataset instead of only the default logs/spans stream.
- Relaxes the `AggregationMetadata` CRD validation from `has(samples) != has(histogram)` (exactly one required) to `!(has(samples) && has(histogram))` (at most one), since `min`/`max`/`count`/`avg`/`sum` aggregations legitimately use neither — confirmed live against staging, where the API returns these with `"none": {}`.

No breaking changes; both are relaxations/additions.

## Test plan
- [x] Verified locally: kind cluster + operator built from this branch, applied an `Events2Metric` with `dataSource` set and `min`/`max`/`count`/`avg`/`sum` aggregations using bare `aggMetadata: {}` — admitted by the CRD (previously would've been rejected) and reconciled to `RemoteSynced` against a real backend, with `dataSource` confirmed round-tripped via the API.
- [x] `samples`/`histogram` aggregations still validate and reconcile correctly (regression check).
- [x] e2e test updated for the new field/schema.

## Known issue
Currently only the default `dataSource` value (`default/logs`) works against the backend; other datasets are rejected, which is why CI is failing.