### PR TITLE
ci: cut PR check time roughly in half, and fix three flaky account-wide e2e specs

### DIFF
--- a/.github/actions/build-operator-image/action.yml
+++ b/.github/actions/build-operator-image/action.yml
@@ -1,0 +1,28 @@
+name: Build operator image
+description: >
+  Builds the controller-manager image for use in the test workflows. The binary is compiled on
+  the runner so that the Go build and module caches are reused across workflow runs, then
+  packaged with Dockerfile.ci. This replaces `make docker-build`, which recompiled every
+  dependency on every run because the Go cache inside the Docker builder stage is discarded.
+
+inputs:
+  image:
+    description: Image reference to tag, e.g. coralogix-operator-image:latest
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache-dependency-path: go.sum
+
+    - name: Build the manager binary
+      shell: bash
+      run: make build-linux
+
+    - name: Build the controller-manager image
+      shell: bash
+      run: docker build -f Dockerfile.ci -t "${{ inputs.image }}" .

--- a/.github/actions/build-operator-image/action.yml
+++ b/.github/actions/build-operator-image/action.yml
@@ -17,7 +17,24 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-        cache-dependency-path: go.sum
+        # The cache is managed below instead. setup-go keys its cache on go.sum alone, so this
+        # job and the unit-tests job shared one entry: whichever saved it first owned the
+        # contents, and since the key never changed it was never refreshed. When unit-tests won
+        # that race the entry held test-binary objects rather than the CGO_ENABLED=0 GOOS=linux
+        # ones needed here, so `go build` recompiled every dependency anyway (~74s).
+        cache: false
+
+    - name: Cache the Go build and module caches
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        # Namespaced so only build-linux writes it, and keyed on go.sum because that is what
+        # decides whether the dependency objects are still valid. Our own packages recompile
+        # incrementally on top, which is fast.
+        key: ${{ runner.os }}-go-image-build-${{ hashFiles('go.sum') }}
+        restore-keys: ${{ runner.os }}-go-image-build-
 
     - name: Build the manager binary
       shell: bash

--- a/.github/actions/build-operator-image/action.yml
+++ b/.github/actions/build-operator-image/action.yml
@@ -13,10 +13,30 @@ inputs:
 runs:
   using: composite
   steps:
+    # The released image builds inside the `golang:` tag in Dockerfile, so read the version from
+    # there rather than from go.mod. go.mod's `go` directive is the module's *minimum* (1.24.0),
+    # which is not what ships: `golang:1.24` resolves to the newest 1.24.x. Taking go.mod at face
+    # value would have CI compile the tested binary with an older patch release than the one the
+    # released binary is built with.
+    - name: Resolve the Go version the released image is built with
+      id: go-version
+      shell: bash
+      run: |
+        version="$(sed -n 's|^FROM .*golang:\([0-9][0-9.]*\).*|\1|p' Dockerfile | head -1)"
+        if [ -z "${version}" ]; then
+          echo "could not read the golang version from Dockerfile" >&2
+          exit 1
+        fi
+        echo "version=${version}" >> "$GITHUB_OUTPUT"
+
     - name: Set up Go
+      id: setup-go
       uses: actions/setup-go@v5
       with:
-        go-version-file: go.mod
+        # Only the minor is pinned in Dockerfile, so check-latest keeps this on the newest patch
+        # of it - the same thing the golang: tag does.
+        go-version: ${{ steps.go-version.outputs.version }}
+        check-latest: true
         # The cache is managed below instead. setup-go keys its cache on go.sum alone, so this
         # job and the unit-tests job shared one entry: whichever saved it first owned the
         # contents, and since the key never changed it was never refreshed. When unit-tests won
@@ -30,11 +50,12 @@ runs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        # Namespaced so only build-linux writes it, and keyed on go.sum because that is what
-        # decides whether the dependency objects are still valid. Our own packages recompile
-        # incrementally on top, which is fast.
-        key: ${{ runner.os }}-go-image-build-${{ hashFiles('go.sum') }}
-        restore-keys: ${{ runner.os }}-go-image-build-
+        # Namespaced so only build-linux writes it, and keyed on the toolchain plus go.sum, which
+        # together decide whether the cached dependency objects are still usable - Go's own cache
+        # keys on compiler version, so a patch bump would otherwise leave dead entries behind.
+        # Our own packages recompile incrementally on top, which is fast.
+        key: ${{ runner.os }}-go-image-build-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('go.sum') }}
+        restore-keys: ${{ runner.os }}-go-image-build-${{ steps.setup-go.outputs.go-version }}-
 
     - name: Build the manager binary
       shell: bash

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         if: ${{ github.repository == 'coralogix/coralogix-operator' && github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -43,18 +43,22 @@ jobs:
         with:
           images: ${{ env.DOCKERHUB_REGISTRY }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
+      # No QEMU: the builder stage is pinned to the build platform and cross-compiles with
+      # GOARCH, and the runtime stage only copies the binary in, so nothing needs emulating.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Build And Push
-        uses: docker/build-push-action@v2.8.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          # Keep the published manifest shape as it was before the action was upgraded;
+          # build-push-action v6 would otherwise attach provenance attestations.
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.DOCKERHUB_REGISTRY }}:${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
   push:
     branches:
       - "main"

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -57,8 +57,10 @@ jobs:
           # Keep the published manifest shape as it was before the action was upgraded;
           # build-push-action v6 would otherwise attach provenance attestations.
           provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No gha layer cache here on purpose: measured at 4.5 minutes of cache export per
+          # run (mode=max has to push the whole multi-GB builder stage), while the only layer
+          # it could ever restore is `go mod download` - the build layer is invalidated by any
+          # source change. Cross-compiling instead of emulating is where the win actually is.
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ env.DOCKERHUB_REGISTRY }}:${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || github.sha }}

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -7,10 +7,18 @@ on:
     branches:
       - main
       - release-*
+  # This job only installs the Helm chart - it never builds or runs the operator, and never
+  # reads config/. So on pull requests it only needs to run when the chart itself changes.
+  # Drift between config/crd/bases and the chart's copies is caught by helm-sync-check.
+  # Pushes to main and release-* stay unfiltered as a safety net.
   pull_request:
     branches:
       - main
       - release-*
+    paths:
+      - "charts/coralogix-operator/**"
+      - "Makefile"
+      - ".github/workflows/crd-validation.yaml"
 permissions:
   contents: read
 

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -13,6 +13,11 @@ on:
       - release-*
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-crds:
     name: Validate CRDs (K8s ${{ matrix.k8s-version }})

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,6 +14,11 @@ on:
       - release-*
     paths-ignore:
       - "charts/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Tests
@@ -32,12 +37,17 @@ jobs:
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build the controller-manager Docker image
-        run: |
-          make docker-build
+        uses: actions/checkout@v4
+      - name: Cache Makefile tool binaries
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
+          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
+      - name: Build the controller-manager image
+        uses: ./.github/actions/build-operator-image
+        with:
+          image: ${{ env.IMG }}
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.4.0
       - name: Load the controller-manager image into Kind

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -19,7 +19,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
+  # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
+  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # it instead.
+  cancel-in-progress: false
 
 jobs:
   tests:
@@ -35,6 +39,8 @@ jobs:
       # settings this job's specs are asserting on. A periodic reconcile lets the operator push
       # its desired state back, the same self-healing the Scope specs rely on.
       IPACCESS_RECONCILE_INTERVAL_SECONDS: 30
+      ARCHIVELOGSTARGET_RECONCILE_INTERVAL_SECONDS: 30
+      ARCHIVEMETRICSTARGET_RECONCILE_INTERVAL_SECONDS: 30
       AWS_REGION: ${{ secrets.AWS_REGION }}
       LOGS_BUCKET: ${{ secrets.LOGS_BUCKET }}
       METRICS_BUCKET: ${{ secrets.METRICS_BUCKET }}
@@ -49,7 +55,6 @@ jobs:
         with:
           path: bin
           key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
-          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
       - name: Build the controller-manager image
         uses: ./.github/actions/build-operator-image
         with:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,6 +14,8 @@ on:
       - release-*
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -31,6 +31,10 @@ jobs:
       CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
       SCOPE_RECONCILE_INTERVAL_SECONDS: 30
       CONNECTOR_RECONCILE_INTERVAL_SECONDS: 30
+      # IPAccess is a company-wide singleton, so a concurrently running e2e job can wipe the
+      # settings this job's specs are asserting on. A periodic reconcile lets the operator push
+      # its desired state back, the same self-healing the Scope specs rely on.
+      IPACCESS_RECONCILE_INTERVAL_SECONDS: 30
       AWS_REGION: ${{ secrets.AWS_REGION }}
       LOGS_BUCKET: ${{ secrets.LOGS_BUCKET }}
       METRICS_BUCKET: ${{ secrets.METRICS_BUCKET }}

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -18,7 +18,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
+  # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
+  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # it instead.
+  cancel-in-progress: false
 
 jobs:
   tests:
@@ -43,7 +47,6 @@ jobs:
         with:
           path: bin
           key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
-          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
       - name: Build the controller-manager image
         uses: ./.github/actions/build-operator-image
         with:
@@ -70,7 +73,9 @@ jobs:
             --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}" \
             --set coralogixOperator.reconcileIntervalSeconds.scope=30 \
             --set coralogixOperator.reconcileIntervalSeconds.connector=30 \
-            --set coralogixOperator.reconcileIntervalSeconds.ipAccess=30
+            --set coralogixOperator.reconcileIntervalSeconds.ipAccess=30 \
+            --set coralogixOperator.reconcileIntervalSeconds.archiveLogsTarget=30 \
+            --set coralogixOperator.reconcileIntervalSeconds.archiveMetricsTarget=30
       - name: Run e2e Tests
         run: |
           make e2e-tests

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -10,6 +10,11 @@ on:
     branches:
       - main
       - release-*
+    # No charts/** here on purpose: this job installs the operator with Helm, so chart changes
+    # are exactly what it needs to cover.
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -10,6 +10,11 @@ on:
     branches:
       - main
       - release-*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Tests
@@ -27,12 +32,17 @@ jobs:
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build the controller-manager Docker image
-        run: |
-          make docker-build IMG=${{ env.IMG_REPO }}:v${{ env.IMG_TAG }}
+        uses: actions/checkout@v4
+      - name: Cache Makefile tool binaries
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
+          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
+      - name: Build the controller-manager image
+        uses: ./.github/actions/build-operator-image
+        with:
+          image: ${{ env.IMG_REPO }}:v${{ env.IMG_TAG }}
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.4.0
       - name: Load the controller-manager image into Kind

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -69,7 +69,8 @@ jobs:
             --set coralogixOperator.image.tag="${{ env.IMG_TAG }}" \
             --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}" \
             --set coralogixOperator.reconcileIntervalSeconds.scope=30 \
-            --set coralogixOperator.reconcileIntervalSeconds.connector=30
+            --set coralogixOperator.reconcileIntervalSeconds.connector=30 \
+            --set coralogixOperator.reconcileIntervalSeconds.ipAccess=30
       - name: Run e2e Tests
         run: |
           make e2e-tests

--- a/.github/workflows/helm-sync-check.yaml
+++ b/.github/workflows/helm-sync-check.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - release-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,7 +19,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
+  # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
+  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # it instead.
+  cancel-in-progress: false
 
 jobs:
   tests:
@@ -37,7 +41,6 @@ jobs:
         with:
           path: bin
           key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
-          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
       - name: Build the controller-manager image
         uses: ./.github/actions/build-operator-image
         with:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,6 +14,8 @@ on:
       - release-*
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,6 +14,11 @@ on:
       - release-*
     paths-ignore:
       - "charts/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: Tests
@@ -24,12 +29,17 @@ jobs:
       CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Build the controller-manager Docker image
-        run: |
-          make docker-build
+        uses: actions/checkout@v4
+      - name: Cache Makefile tool binaries
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
+          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
+      - name: Build the controller-manager image
+        uses: ./.github/actions/build-operator-image
+        with:
+          image: ${{ env.IMG }}
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.4.0
       - name: Load the controller-manager image into Kind

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,6 +14,10 @@ on:
     paths-ignore:
       - "charts/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-docs:
     name: Check generated files

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -9,21 +9,27 @@ on:
       - 'release-*'
     paths-ignore:
       - "charts/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     name: Unit tests
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version-file: go.mod
-    - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.4.0
-    - name: Install CRDs
-      run: |
-        make install
-        make install-prometheus-crds
+        cache-dependency-path: go.sum
+    - name: Cache Makefile tool binaries
+      uses: actions/cache@v4
+      with:
+        path: bin
+        key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
+        restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
     - run: make unit-tests
     - name: Patch Coverage
       uses: seriousben/go-patch-cover-action@v1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
   push:
     branches:
       - 'main'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -31,7 +31,6 @@ jobs:
       with:
         path: bin
         key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
-        restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
     - run: make unit-tests
     - name: Patch Coverage
       uses: seriousben/go-patch-cover-action@v1

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -19,7 +19,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
+  # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
+  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # it instead.
+  cancel-in-progress: false
 
 jobs:
   upgrade-test:
@@ -47,7 +51,6 @@ jobs:
         with:
           path: bin
           key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
-          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
       - name: Create Kind cluster
         uses: helm/kind-action@v1.4.0
       - name: Install Prometheus Operator CRDs
@@ -85,7 +88,9 @@ jobs:
             --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}" \
             --set coralogixOperator.reconcileIntervalSeconds.scope=30 \
             --set coralogixOperator.reconcileIntervalSeconds.connector=30 \
-            --set coralogixOperator.reconcileIntervalSeconds.ipAccess=30
+            --set coralogixOperator.reconcileIntervalSeconds.ipAccess=30 \
+            --set coralogixOperator.reconcileIntervalSeconds.archiveLogsTarget=30 \
+            --set coralogixOperator.reconcileIntervalSeconds.archiveMetricsTarget=30
       - name: Run e2e Tests
         run: |
           make e2e-tests

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
       - release-*
+    # No charts/** here on purpose: this job upgrades into the PR's chart, so chart changes are
+    # exactly what it needs to cover.
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -12,6 +12,10 @@ on:
       - main
       - release-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upgrade-test:
     name: Upgrade Test
@@ -32,9 +36,13 @@ jobs:
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: actions/checkout@v4
+      - name: Cache Makefile tool binaries
+        uses: actions/cache@v4
+        with:
+          path: bin
+          key: ${{ runner.os }}-tools-${{ github.workflow }}-${{ hashFiles('Makefile', 'go.sum') }}
+          restore-keys: ${{ runner.os }}-tools-${{ github.workflow }}-
       - name: Create Kind cluster
         uses: helm/kind-action@v1.4.0
       - name: Install Prometheus Operator CRDs
@@ -56,8 +64,9 @@ jobs:
             --set secret.data.apiKey="${{ secrets.CORALOGIX_API_KEY }}" \
             --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}"
       - name: Build PR image
-        run: |
-          make docker-build IMG=${{ env.IMG_REPO }}:v${{ env.IMG_TAG }}
+        uses: ./.github/actions/build-operator-image
+        with:
+          image: ${{ env.IMG_REPO }}:v${{ env.IMG_TAG }}
       - name: Load PR image into Kind
         run: |
           kind load docker-image ${{ env.IMG_REPO }}:v${{ env.IMG_TAG }} --name chart-testing

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -84,7 +84,8 @@ jobs:
             --set coralogixOperator.image.tag="${{ env.IMG_TAG }}" \
             --set coralogixOperator.region="${{ secrets.CORALOGIX_REGION }}" \
             --set coralogixOperator.reconcileIntervalSeconds.scope=30 \
-            --set coralogixOperator.reconcileIntervalSeconds.connector=30
+            --set coralogixOperator.reconcileIntervalSeconds.connector=30 \
+            --set coralogixOperator.reconcileIntervalSeconds.ipAccess=30
       - name: Run e2e Tests
         run: |
           make e2e-tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so
 *.dylib
 bin
+dist/
 testbin/*
 Dockerfile.cross
 kubeconfig

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,10 @@ Cluster/API tests:
 
 ```bash
 make integration-tests  # kubectl kuttl test
-make e2e-tests          # go test ./tests/e2e/ -ginkgo.v -v
+make e2e-tests          # ginkgo --procs=4 -v ./tests/e2e/ (override with E2E_PROCS)
 ```
 
-`make unit-tests` uses envtest assets for Kubernetes `1.30.3` and writes `cover.out`. Integration and e2e tests require a Kubernetes cluster and real Coralogix access.
+`make unit-tests` uses envtest assets for Kubernetes `1.30.3` and writes `cover.out`; it no longer needs a running cluster. Integration and e2e tests require a Kubernetes cluster and real Coralogix access.
 
 ## Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ $ export CORALOGIX_REGION="<region>"
 ```sh
 $ make e2e-tests
 ````
+The specs run across 4 processes by default. Set `E2E_PROCS=1` to run them serially, which is
+easier to follow when debugging a single spec.
 
 Running Integration Tests
 ---------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-# Build the manager binary
-FROM golang:1.24 as builder
+# Build the manager binary.
+#
+# --platform=${BUILDPLATFORM} pins this stage to the machine running the build, so that a
+# multi-platform build cross-compiles via GOARCH instead of running the whole Go toolchain
+# under QEMU emulation for each non-native target. The final stage only copies a file, so no
+# emulation is needed there either.
+FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,0 +1,15 @@
+# Packages a manager binary that was already built on the host (see `make build-linux`).
+#
+# CI uses this instead of the multi-stage Dockerfile because a build inside the Dockerfile
+# builder stage cannot reuse the Go build cache between workflow runs, which made every test
+# job pay ~2 minutes to recompile all dependencies from scratch. Building on the runner lets
+# actions/setup-go restore the cache, so the same build takes ~20s.
+#
+# The runtime layer below must stay identical to the final stage of Dockerfile, which is what
+# the released image is built from.
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY dist/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,14 @@ docker-push: ## Push docker image with the manager.
 # To properly provided solutions that supports more than one platform you should use this option.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
-docker-buildx: test ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
+docker-buildx: ## Build and push docker image for the manager for cross-platform support
+	# The Dockerfile now pins its builder stage to --platform=${BUILDPLATFORM} itself, so the
+	# Dockerfile.cross copy this target used to generate is no longer needed. The `test`
+	# prerequisite is also gone: no such target exists, so this recipe could never run.
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross
+	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
 	- docker buildx rm project-v3-builder
-	rm Dockerfile.cross
 
 ##@ Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,12 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	# The Dockerfile now pins its builder stage to --platform=${BUILDPLATFORM} itself, so the
 	# Dockerfile.cross copy this target used to generate is no longer needed. The `test`
 	# prerequisite is also gone: no such target exists, so this recipe could never run.
+	# `-` on create and rm only: create fails when the builder already exists, and rm is
+	# best-effort cleanup. The build itself must propagate its exit code, or this target can
+	# report success without having published anything.
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
+	docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
 	- docker buildx rm project-v3-builder
 
 ##@ Deployment

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,10 @@ lint: golangci-lint
 	$(GOLANGCI_LINT) run
 
 .PHONY: unit-tests
-unit-tests: manifests generate envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./internal/controller/... -coverprofile cover.out
+unit-tests: manifests generate envtest prometheus-crds ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
+	PROMETHEUS_CRDS_DIR="$(PROMETHEUS_CRDS_DIR)" \
+	go test ./internal/controller/... -coverprofile cover.out
 
 ##@ Documentation
 .PHONY: generate-api-docs
@@ -64,6 +66,15 @@ generate-api-docs: crdoc ## Generate API documentation.
 .PHONY: build
 build: generate ## Build manager binary.
 	go build -o bin/manager cmd/main.go
+
+GOARCH ?= amd64
+# Used by CI to build the binary on the runner instead of inside the Dockerfile builder
+# stage, so that the Go build cache can be reused between workflow runs. The image is then
+# assembled from Dockerfile.ci. Deliberately does not depend on `generate`: the generated
+# files are committed and verified by the sanity workflow.
+.PHONY: build-linux
+build-linux: ## Build the manager binary for linux, for packaging into the container image.
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o dist/manager cmd/main.go
 
 .PHONY: run
 run: manifests generate ## Run a controller from your host.
@@ -139,12 +150,15 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 CRDOC ?= $(LOCALBIN)/crdoc
 HELM_DOCS ?= $(LOCALBIN)/helm-docs
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+GINKGO ?= $(LOCALBIN)/ginkgo
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 HELM_DOCS_VERSION ?= v1.14.2
 GOLANGCI_LINT_VERSION ?= v2.1.6
+# Keep the ginkgo CLI on the same version as the library in go.mod.
+GINKGO_VERSION ?= $(shell go list -m -f '{{.Version}}' github.com/onsi/ginkgo/v2)
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -161,6 +175,20 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: ginkgo
+ginkgo: $(GINKGO) ## Download the ginkgo CLI locally if necessary.
+$(GINKGO): $(LOCALBIN)
+	test -s $(LOCALBIN)/ginkgo || GOBIN=$(LOCALBIN) go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
+
+# The unit tests run against envtest, which needs the Prometheus Operator CRDs on disk.
+PROMETHEUS_CRDS_DIR ?= $(LOCALBIN)/prometheus-crds
+PROMETHEUS_CRDS_URL ?= https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/master/example/prometheus-operator-crd-full
+.PHONY: prometheus-crds
+prometheus-crds: ## Download the Prometheus Operator CRDs locally if necessary.
+	@mkdir -p $(PROMETHEUS_CRDS_DIR)
+	test -s $(PROMETHEUS_CRDS_DIR)/prometheusrules.yaml || curl -sSfLo $(PROMETHEUS_CRDS_DIR)/prometheusrules.yaml $(PROMETHEUS_CRDS_URL)/monitoring.coreos.com_prometheusrules.yaml
+	test -s $(PROMETHEUS_CRDS_DIR)/servicemonitors.yaml || curl -sSfLo $(PROMETHEUS_CRDS_DIR)/servicemonitors.yaml $(PROMETHEUS_CRDS_URL)/monitoring.coreos.com_servicemonitors.yaml
 
 .PHONY: crdoc
 crdoc: $(CRDOC) ## Download crdoc locally if necessary.
@@ -181,9 +209,14 @@ $(GOLANGCI_LINT): $(LOCALBIN)
 integration-tests:
 	kubectl kuttl test
 
+# The e2e specs spend nearly all of their time polling the operator and the Coralogix API, so
+# running them across several processes cuts the wall-clock time a long way. Every Describe is
+# Ordered, so the specs inside a container still run in sequence on a single process.
+E2E_PROCS ?= 4
+E2E_TIMEOUT ?= 30m
 .PHONY: e2e-tests
-e2e-tests:
-	go test ./tests/e2e/ -ginkgo.v -v
+e2e-tests: ginkgo
+	$(GINKGO) --procs=$(E2E_PROCS) --timeout=$(E2E_TIMEOUT) -v ./tests/e2e/
 
 .PHONY: helm-sync-check
 helm-sync-check:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,6 +81,8 @@ spec:
         - --scope-reconcile-interval-seconds=${SCOPE_RECONCILE_INTERVAL_SECONDS}
         - --connector-reconcile-interval-seconds=${CONNECTOR_RECONCILE_INTERVAL_SECONDS}
         - --ipaccess-reconcile-interval-seconds=${IPACCESS_RECONCILE_INTERVAL_SECONDS}
+        - --archivelogstarget-reconcile-interval-seconds=${ARCHIVELOGSTARGET_RECONCILE_INTERVAL_SECONDS}
+        - --archivemetricstarget-reconcile-interval-seconds=${ARCHIVEMETRICSTARGET_RECONCILE_INTERVAL_SECONDS}
         name: manager
         image: controller
         imagePullPolicy: IfNotPresent

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -80,6 +80,7 @@ spec:
         - --namespace-selector=${NAMESPACE_SELECTOR}
         - --scope-reconcile-interval-seconds=${SCOPE_RECONCILE_INTERVAL_SECONDS}
         - --connector-reconcile-interval-seconds=${CONNECTOR_RECONCILE_INTERVAL_SECONDS}
+        - --ipaccess-reconcile-interval-seconds=${IPACCESS_RECONCILE_INTERVAL_SECONDS}
         name: manager
         image: controller
         imagePullPolicy: IfNotPresent

--- a/internal/controller/prometheusrule_controller_test.go
+++ b/internal/controller/prometheusrule_controller_test.go
@@ -47,7 +47,7 @@ func setupReconciler(ctx context.Context, t *testing.T) (PrometheusRuleReconcile
 	utilruntime.Must(coralogixv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(coralogixv1beta1.AddToScheme(scheme))
 
-	mgr, _ := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgr, _ := ctrl.NewManager(testCfg, ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
 		Controller: crconfig.Controller{

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// testCfg points at the envtest control plane the tests in this package run against. Using
+// envtest here, like the other controller suites do, means `make unit-tests` no longer needs a
+// Kind cluster to be provisioned first.
+var testCfg *rest.Config
+
+func TestMain(m *testing.M) {
+	// The PrometheusRule controller watches monitoring.coreos.com resources, so envtest needs
+	// the Prometheus Operator CRDs on top of ours. `make prometheus-crds` fetches them.
+	prometheusCRDs := os.Getenv("PROMETHEUS_CRDS_DIR")
+	if prometheusCRDs == "" {
+		prometheusCRDs = filepath.Join("..", "..", "bin", "prometheus-crds")
+	}
+
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			prometheusCRDs,
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start the test environment: %v\n", err)
+		os.Exit(1)
+	}
+	testCfg = cfg
+
+	code := m.Run()
+
+	if err := testEnv.Stop(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop the test environment: %v\n", err)
+	}
+
+	os.Exit(code)
+}

--- a/tests/e2e/aievaluation_test.go
+++ b/tests/e2e/aievaluation_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -1043,7 +1044,45 @@ func newAIEvaluationOpenAPIClientSet() *cxsdk.ClientSet {
 	return cxsdk.NewClientSet(builder.Build())
 }
 
+// Every e2e job running against the same Coralogix account draws from one pool of
+// (application, subsystem, target) slots, and a slot stays taken for as long as some evaluation
+// occupies it. So the pool can be empty simply because a concurrent job is holding the last slot
+// for a few seconds. Retry before giving up, otherwise a whole container's BeforeAll fails.
+var errNoAvailableAIEvaluationTarget = errors.New("no AI application with a subsystem has an available evaluation target")
+
+const (
+	aiEvaluationTargetAttempts = 30
+	aiEvaluationTargetInterval = 4 * time.Second
+)
+
 func firstAvailableAIEvaluationApplication(
+	ctx context.Context,
+	applicationsClient *aiapplications.AIApplicationsServiceAPIService,
+	evaluationsClient *aievaluations.AIEvaluationsServiceAPIService,
+	evaluationType aievaluations.EvaluationType,
+) (aiEvaluationApplicationRef, string, error) {
+	var (
+		ref    aiEvaluationApplicationRef
+		target string
+		err    error
+	)
+
+	for attempt := 0; attempt < aiEvaluationTargetAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(aiEvaluationTargetInterval)
+		}
+
+		ref, target, err = findAvailableAIEvaluationApplication(ctx, applicationsClient, evaluationsClient, evaluationType)
+		// Only an exhausted pool is worth retrying; a real API error will not fix itself.
+		if !errors.Is(err, errNoAvailableAIEvaluationTarget) {
+			return ref, target, err
+		}
+	}
+
+	return aiEvaluationApplicationRef{}, "", err
+}
+
+func findAvailableAIEvaluationApplication(
 	ctx context.Context,
 	applicationsClient *aiapplications.AIApplicationsServiceAPIService,
 	evaluationsClient *aievaluations.AIEvaluationsServiceAPIService,
@@ -1077,7 +1116,7 @@ func firstAvailableAIEvaluationApplication(
 		}
 	}
 
-	return aiEvaluationApplicationRef{}, "", fmt.Errorf("no AI application with a subsystem has an available %s evaluation target", evaluationType)
+	return aiEvaluationApplicationRef{}, "", fmt.Errorf("%w: %s", errNoAvailableAIEvaluationTarget, evaluationType)
 }
 
 func availableAIEvaluationTarget(

--- a/tests/e2e/alert_test.go
+++ b/tests/e2e/alert_test.go
@@ -499,6 +499,16 @@ var _ = Describe("Alert", Ordered, func() {
 		connectorName := fmt.Sprintf("slack-connector-for-alert-gaps-%d", time.Now().Unix())
 		Expect(crClient.Create(ctx, getSampleSlackConnector(connectorName))).To(Succeed())
 
+		// The Alert below cannot reach RemoteSynced until the Connector it references has an ID
+		// to resolve, so wait for that first rather than relying on the Connector winning the
+		// race - under load it does not. Same pattern as the GlobalRouter specs.
+		By("Waiting for the Connector to be synced so its ID can be resolved")
+		Eventually(func(g Gomega) *string {
+			fetchedConnector := &coralogixv1alpha1.Connector{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: connectorName, Namespace: testNamespace}, fetchedConnector)).To(Succeed())
+			return fetchedConnector.Status.Id
+		}, time.Minute, time.Second).ShouldNot(BeNil())
+
 		By("Creating Alert")
 		alertName := "data-sources-alert-gaps"
 		dataSourcesAlert := &coralogixv1beta1.Alert{

--- a/tests/e2e/alert_test.go
+++ b/tests/e2e/alert_test.go
@@ -60,6 +60,21 @@ var _ = Describe("Alert", Ordered, func() {
 		presetName := fmt.Sprintf("slack-preset-for-alert-%d", time.Now().Unix())
 		Expect(crClient.Create(ctx, getSampleSlackPreset(presetName, testNamespace))).To(Succeed())
 
+		// Same reason as in the GlobalRouter specs: the router below references both by name and
+		// needs their IDs resolved, so do not assume they sync before it is created.
+		By("Waiting for the Connector and Preset to be synced so their IDs can be resolved")
+		Eventually(func(g Gomega) *string {
+			fetchedConnector := &coralogixv1alpha1.Connector{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: connectorName, Namespace: testNamespace}, fetchedConnector)).To(Succeed())
+			return fetchedConnector.Status.Id
+		}, time.Minute, time.Second).ShouldNot(BeNil())
+
+		Eventually(func(g Gomega) *string {
+			fetchedPreset := &coralogixv1alpha1.Preset{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: presetName, Namespace: testNamespace}, fetchedPreset)).To(Succeed())
+			return fetchedPreset.Status.Id
+		}, time.Minute, time.Second).ShouldNot(BeNil())
+
 		By("Creating GlobalRouter")
 		globalRouterName := "global-router-for-alert" + gouuid.NewString()
 		globalRouter := getSampleGlobalRouter(globalRouterName, testNamespace, connectorName, presetName)

--- a/tests/e2e/archivelogstarget_test.go
+++ b/tests/e2e/archivelogstarget_test.go
@@ -85,7 +85,7 @@ var _ = Describe("ArchiveLogsTarget", Ordered, func() {
 			g.Expect(archiveLogsTarget.Target.GetArchiveSpec().IsActive).To(BeTrue())
 			g.Expect(archiveLogsTarget.Target.GetS3().Bucket).To(Equal(logsBucket))
 			g.Expect(archiveLogsTarget.Target.GetS3().Region).To(Equal(&awsRegion))
-		}, time.Minute, time.Second).Should(Succeed())
+		}, accountWideBackendTimeout, time.Second).Should(Succeed())
 	})
 
 	It("Should be deactivated successfully", func(ctx context.Context) {
@@ -97,7 +97,7 @@ var _ = Describe("ArchiveLogsTarget", Ordered, func() {
 			storageTarget, err := archiveLogsClient.Get(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(storageTarget.Target.GetArchiveSpec().IsActive).To(BeFalse())
-		}, time.Minute, time.Second).Should(Succeed(), "Storage target should be deactivated in Coralogix backend")
+		}, accountWideBackendTimeout, time.Second).Should(Succeed(), "Storage target should be deactivated in Coralogix backend")
 	})
 
 })

--- a/tests/e2e/archivemetricstarget_test.go
+++ b/tests/e2e/archivemetricstarget_test.go
@@ -93,7 +93,7 @@ var _ = Describe("ArchiveMetricsTarget", Ordered, func() {
 			g.Expect(archiveMetricsTarget.TenantConfig.Disabled).To(BeFalse())
 			g.Expect(archiveMetricsTarget.TenantConfig.GetS3().Bucket).To(Equal(metricsBucket))
 			g.Expect(archiveMetricsTarget.TenantConfig.GetS3().Region).To(Equal(awsRegion))
-		}, time.Minute, time.Second).Should(Succeed())
+		}, accountWideBackendTimeout, time.Second).Should(Succeed())
 	})
 
 	It("Should be deactivated successfully", func(ctx context.Context) {
@@ -105,7 +105,7 @@ var _ = Describe("ArchiveMetricsTarget", Ordered, func() {
 			getTenantConfigResponse, err := archiveMetricsClient.Get(ctx)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(getTenantConfigResponse.TenantConfig.Disabled).To(BeTrue())
-		}, time.Minute, time.Second).Should(Succeed(), "Storage target should be deactivated in Coralogix backend")
+		}, accountWideBackendTimeout, time.Second).Should(Succeed(), "Storage target should be deactivated in Coralogix backend")
 	})
 
 })

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -36,7 +36,9 @@ func TestE2E(t *testing.T) {
 	RunSpecs(t, "Coralogix operator E2E test suite")
 }
 
-var _ = BeforeSuite(func(ctx context.Context) {
+// initClients has to run on every Ginkgo process, since each one is a separate OS process
+// with its own copy of ClientsInstance.
+func initClients() {
 	region := strings.ToLower(os.Getenv("CORALOGIX_REGION"))
 	apiKey := os.Getenv("CORALOGIX_API_KEY")
 
@@ -44,7 +46,10 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	ClientsInstance.InitCoralogixClientSet(region, apiKey, apiKey)
 	Expect(ClientsInstance.InitControllerRuntimeClient()).To(Succeed())
 	Expect(ClientsInstance.InitK8sClient()).To(Succeed())
+}
 
+var _ = SynchronizedBeforeSuite(func(ctx context.Context) []byte {
+	initClients()
 	k8sClient := ClientsInstance.GetK8sClient()
 
 	By("Creating test namespace")
@@ -70,17 +75,22 @@ var _ = BeforeSuite(func(ctx context.Context) {
 		}
 		return false
 	}, time.Minute, time.Second).Should(BeTrue())
+
+	return nil
+}, func(_ context.Context, _ []byte) {
+	initClients()
 })
 
-var _ = AfterSuite(func(ctx context.Context) {
+var _ = SynchronizedAfterSuite(func() {}, func(ctx context.Context) {
 	By("Deleting test namespace")
 	k8sClient := ClientsInstance.GetK8sClient()
 	Expect(k8sClient.CoreV1().Namespaces().Delete(ctx, testNamespace, metav1.DeleteOptions{})).To(Succeed())
+
+	// The namespace only disappears once the operator has removed the finalizer from every
+	// resource in it, which means the remote Coralogix resources are already cleaned up by
+	// the time this returns.
 	Eventually(func() bool {
 		_, err := k8sClient.CoreV1().Namespaces().Get(ctx, testNamespace, metav1.GetOptions{})
 		return errors.IsNotFound(err)
-	}, time.Minute, time.Second).Should(BeTrue())
-
-	By("Giving the operator some time to clean up")
-	time.Sleep(30 * time.Second)
+	}, 3*time.Minute, time.Second).Should(BeTrue())
 })

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -31,6 +31,14 @@ import (
 
 const testNamespace = "coralogix-e2e-test"
 
+// accountWideBackendTimeout is for assertions on Coralogix objects that belong to the whole
+// account or tenant rather than to this cluster - company IP access settings, archive targets and
+// the like. Several e2e jobs run this suite against one account at a time, so another job can
+// overwrite or clear such an object while a spec is asserting on it. The owning operator pushes
+// its desired state back on its next reconcile (the specs that need this have a
+// <KIND>_RECONCILE_INTERVAL_SECONDS set in CI), so allow enough time for that to land.
+const accountWideBackendTimeout = 3 * time.Minute
+
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Coralogix operator E2E test suite")

--- a/tests/e2e/global_router_test.go
+++ b/tests/e2e/global_router_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
-var _ = Describe("GlobalRouter", Ordered, func() {
+// Serial: both GlobalRouter containers route notifications for the whole account, so they must
+// not run at the same time as each other when the suite runs with -procs > 1.
+var _ = Describe("GlobalRouter", Ordered, Serial, func() {
 	var (
 		crClient            client.Client
 		notificationsClient *cxsdk.NotificationsClient
@@ -152,7 +154,7 @@ func getSampleGlobalRouter(globalRouterName, testNamespace, slackConnectorName, 
 }
 
 // NC gap fields: GlobalRouter disabled flag and per-entity-type fallbackTargets.
-var _ = Describe("GlobalRouter with disabled and fallbackTargets", Ordered, func() {
+var _ = Describe("GlobalRouter with disabled and fallbackTargets", Ordered, Serial, func() {
 	var (
 		crClient            client.Client
 		notificationsClient *cxsdk.NotificationsClient

--- a/tests/e2e/global_router_test.go
+++ b/tests/e2e/global_router_test.go
@@ -45,6 +45,22 @@ var _ = Describe("GlobalRouter", Ordered, Serial, func() {
 		presetName := fmt.Sprintf("slack-preset-for-global-router-%d", time.Now().Unix())
 		Expect(crClient.Create(ctx, getSampleSlackPreset(presetName, testNamespace))).To(Succeed())
 
+		// The GlobalRouter's rules reference both by name, and it cannot reach RemoteSynced until
+		// each has an ID to resolve. Wait for them rather than relying on them winning that race -
+		// under load they do not. The fallbackTargets spec below already does this.
+		By("Waiting for the Connector and Preset to be synced so their IDs can be resolved")
+		Eventually(func(g Gomega) *string {
+			fetchedConnector := &coralogixv1alpha1.Connector{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: connectorName, Namespace: testNamespace}, fetchedConnector)).To(Succeed())
+			return fetchedConnector.Status.Id
+		}, time.Minute, time.Second).ShouldNot(BeNil())
+
+		Eventually(func(g Gomega) *string {
+			fetchedPreset := &coralogixv1alpha1.Preset{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: presetName, Namespace: testNamespace}, fetchedPreset)).To(Succeed())
+			return fetchedPreset.Status.Id
+		}, time.Minute, time.Second).ShouldNot(BeNil())
+
 		By("Creating GlobalRouter")
 		globalRouterName := "global-router-sample" + gouuid.NewString()
 		globalRouter = getSampleGlobalRouter(globalRouterName, testNamespace, connectorName, presetName)

--- a/tests/e2e/ip_access_test.go
+++ b/tests/e2e/ip_access_test.go
@@ -33,7 +33,9 @@ import (
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
-var _ = Describe("IPAccess", func() {
+// Ordered: the create/update/delete specs below share ipAccessCR and ipAccessID, so they must
+// stay on one process and in sequence when the suite runs with -procs > 1.
+var _ = Describe("IPAccess", Ordered, func() {
 	var (
 		crClient       client.Client
 		ipAccessClient *ipaccess.IPAccessServiceAPIService

--- a/tests/e2e/ip_access_test.go
+++ b/tests/e2e/ip_access_test.go
@@ -33,6 +33,13 @@ import (
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
+// The company IP access settings are a single account-wide object, so any other e2e job running
+// against the same Coralogix account can overwrite or clear them mid-spec - the create step here
+// starts by deleting them outright. Allow enough time for the operator's periodic reconcile
+// (IPACCESS_RECONCILE_INTERVAL_SECONDS, 30s in CI) to push this job's desired state back before
+// giving up on a backend assertion.
+const ipAccessBackendTimeout = 3 * time.Minute
+
 // Ordered: the create/update/delete specs below share ipAccessCR and ipAccessID, so they must
 // stay on one process and in sequence when the suite runs with -procs > 1.
 var _ = Describe("IPAccess", Ordered, func() {
@@ -109,7 +116,7 @@ var _ = Describe("IPAccess", Ordered, func() {
 				}
 			}
 			g.Expect(found).To(BeTrue(), "VPN rule should be present in backend")
-		}, time.Minute, time.Second).Should(Succeed())
+		}, ipAccessBackendTimeout, time.Second).Should(Succeed())
 	})
 
 	It("Should be updated successfully", func(ctx context.Context) {
@@ -134,7 +141,7 @@ var _ = Describe("IPAccess", Ordered, func() {
 				}
 			}
 			g.Expect(found).To(BeTrue(), "Updated Office Network rule should be present in backend")
-		}, time.Minute, time.Second).Should(Succeed())
+		}, ipAccessBackendTimeout, time.Second).Should(Succeed())
 	})
 
 	It("Should be deleted successfully", func(ctx context.Context) {
@@ -147,6 +154,6 @@ var _ = Describe("IPAccess", Ordered, func() {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(res.Settings.IpAccess).ToNot(BeNil())
 			g.Expect(*res.Settings.IpAccess).To(BeEmpty())
-		}, time.Minute, time.Second).Should(Succeed())
+		}, ipAccessBackendTimeout, time.Second).Should(Succeed())
 	})
 })

--- a/tests/e2e/ip_access_test.go
+++ b/tests/e2e/ip_access_test.go
@@ -33,13 +33,6 @@ import (
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
-// The company IP access settings are a single account-wide object, so any other e2e job running
-// against the same Coralogix account can overwrite or clear them mid-spec - the create step here
-// starts by deleting them outright. Allow enough time for the operator's periodic reconcile
-// (IPACCESS_RECONCILE_INTERVAL_SECONDS, 30s in CI) to push this job's desired state back before
-// giving up on a backend assertion.
-const ipAccessBackendTimeout = 3 * time.Minute
-
 // Ordered: the create/update/delete specs below share ipAccessCR and ipAccessID, so they must
 // stay on one process and in sequence when the suite runs with -procs > 1.
 var _ = Describe("IPAccess", Ordered, func() {
@@ -116,7 +109,7 @@ var _ = Describe("IPAccess", Ordered, func() {
 				}
 			}
 			g.Expect(found).To(BeTrue(), "VPN rule should be present in backend")
-		}, ipAccessBackendTimeout, time.Second).Should(Succeed())
+		}, accountWideBackendTimeout, time.Second).Should(Succeed())
 	})
 
 	It("Should be updated successfully", func(ctx context.Context) {
@@ -141,7 +134,7 @@ var _ = Describe("IPAccess", Ordered, func() {
 				}
 			}
 			g.Expect(found).To(BeTrue(), "Updated Office Network rule should be present in backend")
-		}, ipAccessBackendTimeout, time.Second).Should(Succeed())
+		}, accountWideBackendTimeout, time.Second).Should(Succeed())
 	})
 
 	It("Should be deleted successfully", func(ctx context.Context) {
@@ -154,6 +147,6 @@ var _ = Describe("IPAccess", Ordered, func() {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(res.Settings.IpAccess).ToNot(BeNil())
 			g.Expect(*res.Settings.IpAccess).To(BeEmpty())
-		}, ipAccessBackendTimeout, time.Second).Should(Succeed())
+		}, accountWideBackendTimeout, time.Second).Should(Succeed())
 	})
 })

--- a/tests/e2e/scope_test.go
+++ b/tests/e2e/scope_test.go
@@ -95,8 +95,17 @@ var _ = Describe("Scope", Ordered, func() {
 	It("After deleted from Coralogix backend directly, it should be recreated based on configured interval",
 		func(ctx context.Context) {
 			By("Deleting the Scope from Coralogix backend")
-			_, err := scopesClient.Delete(ctx, &cxsdk.DeleteScopeRequest{Id: scopeID})
-			Expect(err).ToNot(HaveOccurred())
+			// Scopes are team-wide, so another e2e job running against the same Coralogix
+			// account can have this call rejected with InvalidArgument ("Some of the requested
+			// value are in conflict") while it is mutating the team's scopes. That is transient,
+			// so retry; a NotFound means an earlier attempt already took effect.
+			Eventually(func(g Gomega) {
+				_, err := scopesClient.Delete(ctx, &cxsdk.DeleteScopeRequest{Id: scopeID})
+				if err != nil && cxsdk.Code(err) == codes.NotFound {
+					return
+				}
+				g.Expect(err).ToNot(HaveOccurred())
+			}, time.Minute, 2*time.Second).Should(Succeed())
 
 			By("Verifying Scope is populated with a new ID after configured interval")
 			var newScopeID string


### PR DESCRIPTION
This does two things: it cuts the wall-clock time of the PR checks, and it fixes three e2e specs that were flaky before this branch existed.

**No test coverage is removed.** Every job still runs the full e2e suite on every PR. Nothing is skipped, sampled, gated or moved to nightly.

## Why the checks were slow

Step timings from #541, before any of this:

| Step | Time |
|---|---|
| Build the controller-manager Docker image | 120s |
| Create Kind cluster | 44s |
| Deploy the controller-manager | 37s |
| **Run e2e tests** | **394s** |

Four dominant costs:

1. **The e2e suite ran its 165 specs serially.** Nearly every spec is an `Eventually(..., time.Minute, time.Second)` poll waiting on the reconciler and the Coralogix API — I/O-wait, not CPU.
2. **The image was rebuilt from scratch in five jobs per PR.** The Go build cache inside the Dockerfile builder stage is discarded between runs, and `go build -a` forced a rebuild of every dependency on top of that.
3. **The release container build emulated arm64.** `Dockerfile`'s builder stage had no `--platform`, so for `linux/arm64` buildx ran the entire Go toolchain under QEMU.
4. **Only `container.yaml` had a `concurrency` group,** so superseded runs kept occupying runners — #541 had four overlapping runs inside 30 minutes.

## Measured results

All numbers are real runs: "before" from #541, "after" from this branch.

| Metric | Before | After | Change |
|---|---|---|---|
| **Build Container** job | 17m37s – 28m35s | **3m53s** | −78% to −86% |
| **unit-tests** job | 3m30s | **1m04s** | −70% |
| **integration-tests** job | 3m33s | **1m27s** | −59% |
| **e2e-tests** job | 10m08s | **4m50s** | −52% |
| **upgrade-test** job | 10m01s | **4m54s** | −51% |
| **helm-e2e-tests** job | 9m12s | **4m35s** | −50% |
| e2e suite runtime | 394s | **~110–130s** | −67% to −72% |
| `make unit-tests` | 130s | **36s** | −72% |
| Cluster setup for unit-tests (Kind + apply CRDs) | 54s | **0s** | setup no longer needed, tests unchanged |
| Deploy the controller-manager | 37s | **15s** | −59% |

The `Build Container` range is three pre-change runs whose `Build And Push` step took 1695s, 1021s and 1664s; the same step is now 216s.

## Speed changes

**The e2e suite runs in parallel.** `make e2e-tests` now uses the ginkgo CLI with `--procs` (`E2E_PROCS`, default 4) instead of `go test`, which cannot run specs in parallel at all. Two changes were needed to make that safe:

- `BeforeSuite`/`AfterSuite` became `SynchronizedBeforeSuite`/`SynchronizedAfterSuite`. Otherwise every process would try to create the shared test namespace and processes 2..N would fail with `AlreadyExists`.
- `IPAccess` is now `Ordered` and both `GlobalRouter` containers are `Serial` — see the test section.

The 30s sleep at the end of the suite is gone: the namespace only finishes deleting once the operator has cleared the finalizer on every resource in it, so the remote resources are already gone by the time the `Eventually` returns. That `Eventually` gets 3 minutes instead of 1, since more resources are now torn down at once.

**Test-image builds reuse the Go cache.** A `build-operator-image` composite action compiles the binary on the runner — where `actions/setup-go` can restore the module and build caches across runs — and packages it with a new `Dockerfile.ci`, whose runtime layer is identical to the final stage of `Dockerfile`. Building inside the Dockerfile builder stage can never reuse that cache between runs.

Building on the runner does mean the toolchain comes from `setup-go` rather than the `golang:` image, so the action reads the version out of `Dockerfile` and sets `check-latest`. `go.mod`'s `go` directive is the module's *minimum* (`1.24.0`), not what ships — `golang:1.24` resolves to the newest 1.24.x — so keying on go.mod would have CI compile the tested binary with an older patch release than the released one. What ships stays the single source of truth; CI logs confirm it resolves `go1.24.13`, matching the image. Thanks @markshleifer-coralogix for catching this.

That needed a second fix to actually pay off. `setup-go` keys its cache on `go.sum` alone, so the four image-building jobs and `unit-tests` all shared one entry: whichever saved it first owned the contents, and because the key never changed it was never refreshed. With `unit-tests` as the writer the entry held test-binary objects rather than the `CGO_ENABLED=0 GOOS=linux` ones needed here, so `go build` recompiled every dependency anyway — 74s of a ~100s step, despite the logs reporting a cache hit. The action now manages a cache under a key only `build-linux` writes.

**The release container cross-compiles instead of emulating.** `FROM --platform=${BUILDPLATFORM} golang:1.24 AS builder` — the stage already declared `TARGETOS`/`TARGETARCH` and passed `GOARCH`, so it was written to cross-compile but was never pinned to the build platform. `setup-qemu-action` is dropped since nothing needs emulating now; the runtime stage only copies the binary in. Build logs confirm the change: the stage is now `[linux/amd64->arm64 builder]` rather than `[linux/arm64 builder]`, and both platforms compile in parallel at ~193s each.

I also tried a `type=gha` layer cache here and **removed it again**: it cost 4.5 minutes of cache export per run (`mode=max` has to push the whole multi-GB builder stage) while the only layer it could ever restore is `go mod download`, since any source change invalidates the build layer. Measured, not assumed.

**Superseded runs are cancelled.** `concurrency` groups added to `e2e-tests`, `helm-e2e-tests`, `integration-tests`, `upgrade-test`, `unit-tests`, `sanity`, `crd-validation` and `helm-sync-check`. Deliberately not added to the release/automation workflows (`helm-chart-deploy`, `helm-update`, `link-issue-on-merge`, `dispatch-event-on-docs-change`), where cancelling mid-flight is not safe.

**Tool binaries are cached.** `bin/` (controller-gen, setup-envtest, ginkgo, envtest assets) is cached per workflow, keyed on `Makefile` + `go.sum`. Previously every run recompiled controller-gen and setup-envtest from source. This is also what took `Deploy the controller-manager` from 37s to 15s — kustomize no longer downloads each time.

**`make unit-tests` no longer needs a Kind cluster.** To be clear up front: **no unit test was removed, skipped or changed** — only the cluster provisioning around them.

`internal/controller` was the only package calling `ctrl.GetConfigOrDie()`, and that one call is why the workflow provisioned a Kind cluster and applied CRDs into it (49s + 5s). The other two suites, `internal/controller/coralogix/v1alpha1` and `.../v1beta1`, already ran on envtest and never needed a cluster. That package now matches them: a `TestMain` starts envtest, and `ctrl.GetConfigOrDie()` becomes the envtest `rest.Config`. CRDs are still installed, via `CRDDirectoryPaths` over `config/crd/bases` plus the two Prometheus Operator CRDs that `make prometheus-crds` fetches.

The whole diff under `internal/` is a one-line change in `prometheusrule_controller_test.go` and a new `suite_test.go` containing only `TestMain`. Test function count is identical, and the coverage bot on this PR reports 12.4% before and 12.4% after.

The one real difference: envtest runs a real `kube-apiserver` and `etcd` but not the kube-controller-manager or scheduler, so there is no pod scheduling and none of the built-in controllers. These tests do CRUD on CRs and drive the reconciler directly, so that is not in play — and it is already what the other two suites in this repo depend on. Bonus: `make unit-tests` now runs on a laptop with no cluster.

**Workflows only run when they can be affected.** `crd-validation` creates a Kind cluster, runs `helm install ./charts/coralogix-operator` and counts CRDs against the chart's own templates — it never builds or runs the operator and never reads `config/`. It is a chart test, so on pull requests it now runs only for the chart, the `Makefile` (which supplies `install-prometheus-crds`) and its own workflow file. On a Go-only PR that is 9 matrix jobs which could not have told us anything — the chart they validate is byte-identical to the one on `main`. A PR that does touch the chart still gets all 9. Drift between `config/crd/bases` and the chart's copies is already caught by `helm-sync-check`, which triggers on `config/**`. Separately, `docs/**` and `**.md` are now ignored by the e2e, helm-e2e, integration, upgrade, unit-tests and container workflows, so a docs-only PR runs `sanity` and CodeQL only. `sanity` itself keeps running on everything — it regenerates `docs/api.md` and the chart README and is the guard against hand-edited generated files. `helm-e2e-tests` and `upgrade-test` still do **not** ignore `charts/**`, since both install the operator through Helm.

Filters are applied to `pull_request` only. Pushes to `main`/`release-*` stay unfiltered as a safety net, and path filters on tag pushes can silently skip a release build.

Also bumped `actions/checkout` v2/v2.4.0/v3 → v4, `actions/setup-go` v4 → v5, and in `container.yaml` `login-action` v1 → v3, `setup-buildx-action` v1 → v3, `build-push-action` v2.8.0 → v6 (the old versions predate the options used here). `provenance: false` keeps the published manifest the same shape it had under v2.

## Test fixes

These are correctness fixes, not speed work. Four e2e jobs run the full suite per PR, all against **one shared Coralogix account**, and several specs act on objects that are account-wide rather than per-cluster — so they break when another job touches the same object at the wrong moment. All of these have been seen failing on unrelated PRs (#541 is currently red on two of them), so they are pre-existing; parallelism only changes when the windows overlap.

- **`IPAccess` is now `Ordered`.** Its create/update/delete specs share `ipAccessCR` and `ipAccessID`, and without `Ordered` Ginkgo distributed them across processes, so update and delete ran before create had populated that state. This was a real bug that parallelism exposed.
- **`IPAccess` tolerates an external wipe.** The company IP access settings are a single account-wide object and the create spec begins by deleting them outright, so a concurrent job can clear what this job is asserting on. `IPACCESS_RECONCILE_INTERVAL_SECONDS=30` is now wired through both deploy paths (matching what Scope and Connector already do) so the operator pushes its desired state back, and the backend assertions get 3 minutes for that reconcile to land.
- **`Scope` retries a transient conflict.** Deleting a scope directly can be rejected with `InvalidArgument: Some of the requested value are in conflict` while another job mutates the team's scopes — the failure on #541 was a 0.2s rejection, not a timeout. It now retries, treating `NotFound` as an earlier attempt having succeeded.
- **`AIEvaluation` waits for a free slot.** `firstAvailableAIEvaluationApplication` needs an (application, subsystem, target) slot that no evaluation currently occupies, and that pool is account-wide, so a concurrent job holding the last slot failed a whole container's `BeforeAll`. It now retries for up to 2 minutes, but only when the pool is exhausted — a real API error will not fix itself.
- **Archive targets get the same treatment**, after `ArchiveMetricsTarget` failed exactly as `IPAccess` had: the archive configuration is tenant-wide, so a concurrent job disabling or repointing it breaks an assertion here. Both kinds get a 30s reconcile interval and use the shared `accountWideBackendTimeout`.
- Both `GlobalRouter` containers are marked `Serial`: they configure account-wide notification routing and previously only ever ran one after the other.
- **Dependencies are awaited before what references them.** Several specs created a Connector and/or Preset and then immediately created an Alert or GlobalRouter referencing them by name, before waiting for `RemoteSynced`. The referencing resource cannot sync until each dependency has an ID to resolve, so those specs were relying on the dependency winning that race — it does on a quiet API and does not under four parallel processes. This is a latent ordering bug rather than account contention, and it accounted for two of the failures seen here.

  Every site that creates a Connector or Preset and then references it was audited:

  | Site | State |
  |---|---|
  | `global_router_test.go:42,46` | fixed |
  | `global_router_test.go:192` | already waited — the pattern the others now follow |
  | `alert_test.go:57,61` | fixed |
  | `alert_test.go:515` | fixed |
  | `connector_test.go` ×4 | no wait needed; they assert on the connector itself |
- **Cancelled runs no longer leak resources.** The four API-backed workflows use `cancel-in-progress: false`. Cancelling them killed the Kind cluster before finalizers ran, so remote resources leaked into the shared account — the cancellation was actively feeding the flakiness above. The cheap workflows still cancel, since they create nothing remote.

### Known limitation

Two distinct causes were at work, and they should not be conflated.

The **ordering bugs** (missing `Ordered`, missing dependency waits) are now fixed at every site, verified by audit rather than by waiting for the next red run. Those were always latent; parallel load is only what surfaced them.

The **account contention** is different: hardening specs one at a time raises the odds without making them deterministic. Across eight runs on this branch the red spec moved around — `IPAccess`, `Scope`, `ArchiveMetricsTarget`, `Alert`, `GlobalRouter` — because roughly seven spec groups act on account-wide objects while four jobs exercise all of them at once. Two runs were green on all 24 checks.

Two assertions cannot be fixed in test code at all: the `IPAccess` delete spec asserts the company settings are **empty**, and the TCO policy specs assert exact company-wide counts. Neither can hold while another job may have just created its own resources.

The real fix is a dedicated Coralogix account per CI job, or one job owning the account-wide specs. That is an infrastructure decision, so it is not in this PR — but it is the reason this suite is flaky today, independently of anything here, and it deserves a follow-up ticket. A scheduled reaper for resources orphaned by lost runners (timeouts and infrastructure failures, which `cancel-in-progress: false` does not cover) belongs in the same ticket.

## Verified

Locally:
- `make unit-tests` passes with no cluster running; coverage unchanged at 67.2% for `internal/controller`.
- `go build ./...`, `go vet`, `gofmt` clean.
- `ginkgo --dry-run ./tests/e2e/` — 165 specs, spec tree and the Synchronized nodes validate.
- All workflow and action YAML parses.
- The new reconcile flags render on both deploy paths — `--ipaccess-reconcile-interval-seconds=30`, `--archivelogstarget-...`, `--archivemetricstarget-...` via `kustomize build | envsubst`, and the `-<kind>-reconcile-interval-seconds=30` equivalents via `helm template`.

In CI: **all 24 checks green** — all three `Tests` jobs, both `Upgrade Test` matrix jobs, `Unit tests`, all 9 `Validate CRDs` jobs, `Build Container`, CodeQL, linter and sanity.

I could not run the e2e specs locally (no Coralogix credentials), so CI on this PR is their only real exercise. The container image builds were likewise not run locally — no Docker daemon available — and were verified from the CI build logs instead.
