### PR TITLE
ci: only run workflows on pull requests that can affect them

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
   push:
     branches:
       - "main"

--- a/.github/workflows/crd-validation.yaml
+++ b/.github/workflows/crd-validation.yaml
@@ -7,10 +7,18 @@ on:
     branches:
       - main
       - release-*
+  # This job only installs the Helm chart - it never builds or runs the operator, and never
+  # reads config/. So on pull requests it only needs to run when the chart itself changes.
+  # Drift between config/crd/bases and the chart's copies is caught by helm-sync-check.
+  # Pushes to main and release-* stay unfiltered as a safety net.
   pull_request:
     branches:
       - main
       - release-*
+    paths:
+      - "charts/coralogix-operator/**"
+      - "Makefile"
+      - ".github/workflows/crd-validation.yaml"
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -14,6 +14,8 @@ on:
       - release-*
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -10,6 +10,11 @@ on:
     branches:
       - main
       - release-*
+    # No charts/** here on purpose: this job installs the operator with Helm, so chart changes
+    # are exactly what it needs to cover.
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,6 +14,8 @@ on:
       - release-*
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
 jobs:
   tests:
     name: Tests

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths-ignore:
       - "charts/**"
+      - "docs/**"
+      - "**.md"
   push:
     branches:
       - 'main'

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
       - release-*
+    # No charts/** here on purpose: this job upgrades into the PR's chart, so chart changes are
+    # exactly what it needs to cover.
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
 
 jobs:
   upgrade-test:


### PR DESCRIPTION
## Why

Every PR runs every check, regardless of what it touches. Two cases pay for work that cannot tell us anything.

**crd-validation — 9 matrix jobs, ~1m15s each, on every PR.** Reading what it actually does: create a Kind cluster, `helm install ./charts/coralogix-operator`, then compare the installed `*.coralogix.com` CRD count against the files in `charts/coralogix-operator/templates/crds`. It never builds the image, never runs the operator, and never reads `config/`. It is a **chart** test, so a Go-only PR learns nothing from it.

**Docs-only PRs run the whole cluster suite** — e2e, helm-e2e, integration, upgrade-test ×2 and the container build, for a change to a Markdown file.

## What changed

**crd-validation** now uses a `paths` allowlist on `pull_request`:

```yaml
paths:
  - "charts/coralogix-operator/**"
  - "Makefile"                              # supplies install-prometheus-crds
  - ".github/workflows/crd-validation.yaml"
```

Drift between `config/crd/bases` and the chart's copies is already caught by `helm-sync-check`, which triggers on `config/**` and `charts/**` — so a change to `api/**` that regenerates CRDs still gets caught there, and lands in `charts/**` once `make helm-update-crds` runs, which re-triggers crd-validation.

(`paths` and `paths-ignore` cannot both be set on the same event, hence an allowlist rather than adding to an ignore list.)

**`docs/**` and `**.md` added to `paths-ignore`** on `e2e-tests`, `helm-e2e-tests`, `integration-tests`, `upgrade-test`, `unit-tests` and `container`. `paths-ignore` only skips when *every* changed file matches, so a PR touching both docs and Go code still runs everything.

Two deliberate non-changes:

- **`sanity` keeps running on everything.** It regenerates `docs/api.md` and the chart README and is what catches hand-edits to generated files, so filtering out `docs/**` there would remove the guard. It is also only ~40s.
- **`helm-e2e-tests` and `upgrade-test` still do not ignore `charts/**`**, since both install the operator through Helm — chart changes are exactly what they cover. Only `e2e-tests` (kustomize-based) ignores the chart, as it did before.

**Filters are on `pull_request` only.** Pushes to `main`/`release-*` stay unfiltered as a safety net, and I did not add path filters to any tag trigger — they can silently skip a release build. Worth noting `container.yaml` already has `paths-ignore` on a `push` trigger that includes `tags: v*`; I left that as-is, but it may deserve a separate look.

## Effect

A typical Go-only PR drops 9 crd-validation jobs. A docs-only PR drops everything except `sanity` and CodeQL.

## Safety

`main` has no required status checks configured (`required_status_checks.checks` and `.contexts` are both empty), so a skipped workflow cannot leave a PR stuck waiting on a check that will never report. That is the usual hazard with path filters and it does not apply here — but it is worth re-checking if required checks are ever turned on.

## Verified

All workflow YAML parses. The behaviour itself is only observable once merged, since path filters are evaluated from the workflow file on the PR's base for `pull_request` events.

## Related

Stacked conceptually on #542 (which speeds up the jobs themselves) but independent of it — no file overlap in the `on:` blocks beyond what is shown here, so either can merge first. If #542 merges first, this branch may need a trivial rebase where both touch the same `on:` blocks.