### PR TITLE
Migrate events2metrics from gRPC to rest client

### DIFF
--- a/api/coralogix/utils.go
+++ b/api/coralogix/utils.go
@@ -17,7 +17,6 @@ package coralogix
 import (
 	"fmt"
 
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -27,14 +26,6 @@ func ReverseMap[K, V comparable](m map[K]V) map[V]K {
 		n[v] = k
 	}
 	return n
-}
-
-func StringSliceToWrappedStringSlice(arr []string) []*wrapperspb.StringValue {
-	result := make([]*wrapperspb.StringValue, 0, len(arr))
-	for _, s := range arr {
-		result = append(result, wrapperspb.String(s))
-	}
-	return result
 }
 
 func FloatToQuantity(n float64) resource.Quantity {
@@ -47,25 +38,4 @@ func QuantitiesToFloats32(arr []resource.Quantity) []float32 {
 		result = append(result, float32(q.AsApproximateFloat64()))
 	}
 	return result
-}
-
-func StringPointerToWrapperspbString(s *string) *wrapperspb.StringValue {
-	if s == nil {
-		return nil
-	}
-	return wrapperspb.String(*s)
-}
-
-func WrapperspbStringToStringPointer(s *wrapperspb.StringValue) *string {
-	if s == nil {
-		return nil
-	}
-	return &s.Value
-}
-
-func Int32PointerToWrapperspbInt32(i *int32) *wrapperspb.Int32Value {
-	if i == nil {
-		return nil
-	}
-	return wrapperspb.Int32(*i)
 }

--- a/api/coralogix/v1alpha1/events2metric_types.go
+++ b/api/coralogix/v1alpha1/events2metric_types.go
@@ -15,11 +15,13 @@
 package v1alpha1
 
 import (
-	"google.golang.org/protobuf/types/known/wrapperspb"
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	events2metrics "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
 
 	utils "github.com/coralogix/coralogix-operator/v2/api/coralogix"
 )
@@ -98,14 +100,14 @@ const (
 	AggregationTypeSamples AggregationType = "samples"
 )
 
-var AggregationTypeSchemaToProto = map[AggregationType]cxsdk.E2MAggregationType{
-	AggregationTypeMin:       cxsdk.E2MAggregationTypeMin,
-	AggregationTypeMax:       cxsdk.E2MAggregationTypeMax,
-	AggregationTypeCount:     cxsdk.E2MAggregationTypeCount,
-	AggregationTypeAvg:       cxsdk.E2MAggregationTypeAvg,
-	AggregationTypeSum:       cxsdk.E2MAggregationTypeSum,
-	AggregationTypeHistogram: cxsdk.E2MAggregationTypeHistogram,
-	AggregationTypeSamples:   cxsdk.E2MAggregationTypeSamples,
+var AggregationTypeSchemaToOpenAPI = map[AggregationType]events2metrics.AggType{
+	AggregationTypeMin:       events2metrics.AGGTYPE_AGG_TYPE_MIN,
+	AggregationTypeMax:       events2metrics.AGGTYPE_AGG_TYPE_MAX,
+	AggregationTypeCount:     events2metrics.AGGTYPE_AGG_TYPE_COUNT,
+	AggregationTypeAvg:       events2metrics.AGGTYPE_AGG_TYPE_AVG,
+	AggregationTypeSum:       events2metrics.AGGTYPE_AGG_TYPE_SUM,
+	AggregationTypeHistogram: events2metrics.AGGTYPE_AGG_TYPE_HISTOGRAM,
+	AggregationTypeSamples:   events2metrics.AGGTYPE_AGG_TYPE_SAMPLES,
 }
 
 // AggregationMetadata defines the metadata for aggregation.
@@ -133,9 +135,9 @@ const (
 	E2MAggSamplesSampleTypeMax E2MAggSampleType = "max"
 )
 
-var E2MAggSamplesSampleTypeSchemaToProto = map[E2MAggSampleType]cxsdk.E2MAggSampleType{
-	E2MAggSamplesSampleTypeMin: cxsdk.E2MAggSampleTypeMin,
-	E2MAggSamplesSampleTypeMax: cxsdk.E2MAggSampleTypeMax,
+var E2MAggSamplesSampleTypeSchemaToOpenAPI = map[E2MAggSampleType]events2metrics.SampleType{
+	E2MAggSamplesSampleTypeMin: events2metrics.SAMPLETYPE_SAMPLE_TYPE_MIN,
+	E2MAggSamplesSampleTypeMax: events2metrics.SAMPLETYPE_SAMPLE_TYPE_MAX,
 }
 
 // HistogramMetadata defines the metadata for histogram aggregation.
@@ -212,13 +214,13 @@ const (
 	L2MSeverityCritical L2MSeverity = "critical"
 )
 
-var L2MSeveritySchemaToProto = map[L2MSeverity]cxsdk.L2MSeverity{
-	L2MSeverityDebug:    cxsdk.L2MSeverityDebug,
-	L2MSeverityVerbose:  cxsdk.L2MSeverityVerbose,
-	L2MSeverityInfo:     cxsdk.L2MSeverityInfo,
-	L2MSeverityWarning:  cxsdk.L2MSeverityWarning,
-	L2MSeverityError:    cxsdk.L2MSeverityError,
-	L2MSeverityCritical: cxsdk.L2MSeverityCritical,
+var L2MSeveritySchemaToOpenAPI = map[L2MSeverity]events2metrics.Logs2metricsV2Severity{
+	L2MSeverityDebug:    events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_DEBUG,
+	L2MSeverityVerbose:  events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_VERBOSE,
+	L2MSeverityInfo:     events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_INFO,
+	L2MSeverityWarning:  events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_WARNING,
+	L2MSeverityError:    events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_ERROR,
+	L2MSeverityCritical: events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_CRITICAL,
 }
 
 // Events2MetricStatus defines the observed state of Events2Metric.
@@ -281,166 +283,197 @@ func init() {
 	SchemeBuilder.Register(&Events2Metric{}, &Events2MetricList{})
 }
 
-func (spec *Events2MetricSpec) ExtractCreateE2MRequest() *cxsdk.CreateE2MRequest {
-	e2m := &cxsdk.E2MCreateParams{
-		Name:              wrapperspb.String(spec.Name),
-		Description:       utils.StringPointerToWrapperspbString(spec.Description),
-		DataSource:        utils.StringPointerToWrapperspbString(spec.DataSource),
-		PermutationsLimit: utils.Int32PointerToWrapperspbInt32(spec.PermutationsLimit),
+func (spec *Events2MetricSpec) ExtractCreateE2MRequest() (*events2metrics.E2MCreateParams, error) {
+	metricFields, err := extractE2mMetricFields(spec.MetricFields)
+	if err != nil {
+		return nil, err
+	}
+
+	e2m := &events2metrics.E2MCreateParams{
+		Name:              spec.Name,
+		Description:       spec.Description,
+		DataSource:        spec.DataSource,
+		PermutationsLimit: spec.PermutationsLimit,
 		MetricLabels:      extractE2mMetricLabels(spec.MetricLabels),
-		MetricFields:      extractE2mMetricFields(spec.MetricFields),
+		MetricFields:      metricFields,
 	}
-	e2m = expandE2MQuery(e2m, spec.Query)
-	return &cxsdk.CreateE2MRequest{
-		E2M: e2m,
+	if err := expandCreateE2MQuery(e2m, spec.Query); err != nil {
+		return nil, err
 	}
+	return e2m, nil
 }
 
-func (spec *Events2MetricSpec) ExtractReplaceE2MRequest() *cxsdk.ReplaceE2MRequest {
-	e2m := &cxsdk.ReplaceE2MRequest{
-		E2M: &cxsdk.E2M{
-			Name:         wrapperspb.String(spec.Name),
-			Description:  utils.StringPointerToWrapperspbString(spec.Description),
-			DataSource:   utils.StringPointerToWrapperspbString(spec.DataSource),
-			Permutations: extractE2mPermutations(spec.PermutationsLimit),
-			MetricLabels: extractE2mMetricLabels(spec.MetricLabels),
-			MetricFields: extractE2mMetricFields(spec.MetricFields),
-		},
+func (spec *Events2MetricSpec) ExtractReplaceE2MRequest(id string) (*events2metrics.E2M1, error) {
+	metricFields, err := extractE2mMetricFields(spec.MetricFields)
+	if err != nil {
+		return nil, err
 	}
-	e2m.E2M = expandUpdateE2MQuery(e2m.E2M, spec.Query)
-	return e2m
+
+	e2m := &events2metrics.E2M1{
+		Id:           &id,
+		Name:         spec.Name,
+		Description:  emptyStringIfNil(spec.Description),
+		DataSource:   spec.DataSource,
+		Permutations: extractE2mPermutations(spec.PermutationsLimit),
+		MetricLabels: extractE2mMetricLabels(spec.MetricLabels),
+		MetricFields: metricFields,
+	}
+	if err := expandReplaceE2MQuery(e2m, spec.Query); err != nil {
+		return nil, err
+	}
+	return e2m, nil
 }
 
-func extractE2mPermutations(permutations *int32) *cxsdk.E2MPermutations {
+// emptyStringIfNil coerces a nil *string to "". Used only on replace for
+// description: omit keeps the previous value, and min_length: 0 allows "".
+// Create leaves description nil. lucene, dataSource, and alias clear on omit
+// (dataSource/alias also have min_length: 1, so "" is invalid for them).
+func emptyStringIfNil(s *string) *string {
+	if s != nil {
+		return s
+	}
+	return ptr.To("")
+}
+
+func extractE2mPermutations(permutations *int32) *events2metrics.E2MPermutations {
 	if permutations == nil {
 		return nil
 	}
-	return &cxsdk.E2MPermutations{
+	return &events2metrics.E2MPermutations{
 		Limit: *permutations,
 	}
 }
 
-func expandE2MQuery(e2m *cxsdk.E2MCreateParams, query E2MQuery) *cxsdk.E2MCreateParams {
+func expandCreateE2MQuery(e2m *events2metrics.E2MCreateParams, query E2MQuery) error {
 	if spans := query.Spans; spans != nil {
-		e2m.Query = &cxsdk.E2MCreateParamsSpansQuery{
-			SpansQuery: &cxsdk.S2MSpansQuery{
-				Lucene:                 utils.StringPointerToWrapperspbString(spans.Lucene),
-				ApplicationnameFilters: utils.StringSliceToWrappedStringSlice(spans.ApplicationNameFilters),
-				SubsystemnameFilters:   utils.StringSliceToWrappedStringSlice(spans.SubsystemNameFilters),
-				ActionFilters:          utils.StringSliceToWrappedStringSlice(spans.ActionFilters),
-				ServiceFilters:         utils.StringSliceToWrappedStringSlice(spans.ServiceFilters),
-			},
+		e2m.Type = events2metrics.E2MTYPE_E2_M_TYPE_SPANS2_METRICS.Ptr()
+		e2m.SpansQuery = &events2metrics.V2SpansQuery{
+			Lucene:                 spans.Lucene,
+			ApplicationnameFilters: spans.ApplicationNameFilters,
+			SubsystemnameFilters:   spans.SubsystemNameFilters,
+			ActionFilters:          spans.ActionFilters,
+			ServiceFilters:         spans.ServiceFilters,
 		}
-		e2m.Type = cxsdk.E2MTypeSpans2Metrics
-	} else if logs := query.Logs; logs != nil {
-		e2m.Query = &cxsdk.E2MCreateParamsLogsQuery{
-			LogsQuery: &cxsdk.L2MLogsQuery{
-				Lucene:                 utils.StringPointerToWrapperspbString(logs.Lucene),
-				Alias:                  utils.StringPointerToWrapperspbString(logs.Alias),
-				ApplicationnameFilters: utils.StringSliceToWrappedStringSlice(logs.ApplicationNameFilters),
-				SubsystemnameFilters:   utils.StringSliceToWrappedStringSlice(logs.SubsystemNameFilters),
-				SeverityFilters:        expandL2MSeverityFilters(logs.SeverityFilters),
-			},
-		}
-		e2m.Type = cxsdk.E2MTypeLogs2Metrics
+		return nil
 	}
-
-	return e2m
+	if logs := query.Logs; logs != nil {
+		e2m.Type = events2metrics.E2MTYPE_E2_M_TYPE_LOGS2_METRICS.Ptr()
+		e2m.LogsQuery = &events2metrics.V2LogsQuery{
+			Lucene:                 logs.Lucene,
+			Alias:                  logs.Alias,
+			ApplicationnameFilters: logs.ApplicationNameFilters,
+			SubsystemnameFilters:   logs.SubsystemNameFilters,
+			SeverityFilters:        expandL2MSeverityFilters(logs.SeverityFilters),
+		}
+		return nil
+	}
+	return fmt.Errorf("exactly one of query.spans or query.logs must be set")
 }
 
-func expandUpdateE2MQuery(e2m *cxsdk.E2M, query E2MQuery) *cxsdk.E2M {
+func expandReplaceE2MQuery(e2m *events2metrics.E2M1, query E2MQuery) error {
 	if spans := query.Spans; spans != nil {
-		e2m.Query = &cxsdk.E2MSpansQuery{
-			SpansQuery: &cxsdk.S2MSpansQuery{
-				Lucene:                 utils.StringPointerToWrapperspbString(spans.Lucene),
-				ApplicationnameFilters: utils.StringSliceToWrappedStringSlice(spans.ApplicationNameFilters),
-				SubsystemnameFilters:   utils.StringSliceToWrappedStringSlice(spans.SubsystemNameFilters),
-				ActionFilters:          utils.StringSliceToWrappedStringSlice(spans.ActionFilters),
-				ServiceFilters:         utils.StringSliceToWrappedStringSlice(spans.ServiceFilters),
-			},
+		e2m.Type = events2metrics.E2MTYPE_E2_M_TYPE_SPANS2_METRICS
+		e2m.SpansQuery = &events2metrics.V2SpansQuery{
+			Lucene:                 spans.Lucene,
+			ApplicationnameFilters: spans.ApplicationNameFilters,
+			SubsystemnameFilters:   spans.SubsystemNameFilters,
+			ActionFilters:          spans.ActionFilters,
+			ServiceFilters:         spans.ServiceFilters,
 		}
-		e2m.Type = cxsdk.E2MTypeSpans2Metrics
-	} else if logs := query.Logs; logs != nil {
-		e2m.Query = &cxsdk.E2MLogsQuery{
-			LogsQuery: &cxsdk.L2MLogsQuery{
-				Lucene:                 utils.StringPointerToWrapperspbString(logs.Lucene),
-				Alias:                  utils.StringPointerToWrapperspbString(logs.Alias),
-				ApplicationnameFilters: utils.StringSliceToWrappedStringSlice(logs.ApplicationNameFilters),
-				SubsystemnameFilters:   utils.StringSliceToWrappedStringSlice(logs.SubsystemNameFilters),
-				SeverityFilters:        expandL2MSeverityFilters(logs.SeverityFilters),
-			},
-		}
-		e2m.Type = cxsdk.E2MTypeLogs2Metrics
+		return nil
 	}
-
-	return e2m
+	if logs := query.Logs; logs != nil {
+		e2m.Type = events2metrics.E2MTYPE_E2_M_TYPE_LOGS2_METRICS
+		e2m.LogsQuery = &events2metrics.V2LogsQuery{
+			Lucene:                 logs.Lucene,
+			Alias:                  logs.Alias,
+			ApplicationnameFilters: logs.ApplicationNameFilters,
+			SubsystemnameFilters:   logs.SubsystemNameFilters,
+			SeverityFilters:        expandL2MSeverityFilters(logs.SeverityFilters),
+		}
+		return nil
+	}
+	return fmt.Errorf("exactly one of query.spans or query.logs must be set")
 }
 
-func expandL2MSeverityFilters(severityFilters []L2MSeverity) []cxsdk.L2MSeverity {
+func expandL2MSeverityFilters(severityFilters []L2MSeverity) []events2metrics.Logs2metricsV2Severity {
 	if severityFilters == nil {
 		return nil
 	}
-	expanded := make([]cxsdk.L2MSeverity, 0, len(severityFilters))
+	expanded := make([]events2metrics.Logs2metricsV2Severity, 0, len(severityFilters))
 	for _, severity := range severityFilters {
-		if protoSeverity, ok := L2MSeveritySchemaToProto[severity]; ok {
-			expanded = append(expanded, protoSeverity)
+		if apiSeverity, ok := L2MSeveritySchemaToOpenAPI[severity]; ok {
+			expanded = append(expanded, apiSeverity)
 		}
 	}
 	return expanded
 }
 
-func extractE2mMetricLabels(labels []MetricLabel) []*cxsdk.MetricLabel {
-	metricLabels := make([]*cxsdk.MetricLabel, 0, len(labels))
+func extractE2mMetricLabels(labels []MetricLabel) []events2metrics.MetricLabel {
+	metricLabels := make([]events2metrics.MetricLabel, 0, len(labels))
 	for _, label := range labels {
-		metricLabels = append(metricLabels, &cxsdk.MetricLabel{
-			TargetLabel: wrapperspb.String(label.TargetLabel),
-			SourceField: wrapperspb.String(label.SourceField),
+		metricLabels = append(metricLabels, events2metrics.MetricLabel{
+			TargetLabel: label.TargetLabel,
+			SourceField: label.SourceField,
 		})
 	}
 	return metricLabels
 }
 
-func extractE2mMetricFields(fields []MetricField) []*cxsdk.MetricField {
-	metricFields := make([]*cxsdk.MetricField, 0, len(fields))
+func extractE2mMetricFields(fields []MetricField) ([]events2metrics.V2MetricField, error) {
+	metricFields := make([]events2metrics.V2MetricField, 0, len(fields))
 	for _, field := range fields {
-		metricField := &cxsdk.MetricField{
-			TargetBaseMetricName: wrapperspb.String(field.TargetBaseMetricName),
-			SourceField:          wrapperspb.String(field.SourceField),
-			Aggregations:         extractE2mAggregations(field.Aggregations),
+		aggregations, err := extractE2mAggregations(field.Aggregations)
+		if err != nil {
+			return nil, err
 		}
-		metricFields = append(metricFields, metricField)
+		metricFields = append(metricFields, events2metrics.V2MetricField{
+			TargetBaseMetricName: field.TargetBaseMetricName,
+			SourceField:          field.SourceField,
+			Aggregations:         aggregations,
+		})
 	}
-	return metricFields
+	return metricFields, nil
 }
 
-func extractE2mAggregations(aggregations []MetricFieldAggregation) []*cxsdk.E2MAggregation {
-	metricAggregations := make([]*cxsdk.E2MAggregation, 0, len(aggregations))
+func extractE2mAggregations(aggregations []MetricFieldAggregation) ([]events2metrics.V2Aggregation, error) {
+	// Always emit a non-nil slice so OpenAPI required "aggregations" serializes as [] not null.
+	metricAggregations := make([]events2metrics.V2Aggregation, 0, len(aggregations))
 	for _, aggregation := range aggregations {
-		metricAggregation := &cxsdk.E2MAggregation{
-			Enabled:          aggregation.Enabled,
-			AggType:          AggregationTypeSchemaToProto[aggregation.AggType],
-			TargetMetricName: aggregation.TargetMetricName,
+		aggType, ok := AggregationTypeSchemaToOpenAPI[aggregation.AggType]
+		if !ok {
+			return nil, fmt.Errorf("unsupported aggregation type %q", aggregation.AggType)
 		}
-		metricAggregation = expandE2MAggMetadata(metricAggregation, aggregation.AggMetadata)
+		enabled := aggregation.Enabled
+		targetMetricName := aggregation.TargetMetricName
+		metricAggregation := events2metrics.V2Aggregation{
+			Enabled:          &enabled,
+			AggType:          aggType.Ptr(),
+			TargetMetricName: &targetMetricName,
+		}
+		if err := expandE2MAggMetadata(&metricAggregation, aggregation.AggMetadata); err != nil {
+			return nil, err
+		}
 		metricAggregations = append(metricAggregations, metricAggregation)
 	}
-	return metricAggregations
+	return metricAggregations, nil
 }
 
-func expandE2MAggMetadata(metricAggregation *cxsdk.E2MAggregation, metadata AggregationMetadata) *cxsdk.E2MAggregation {
+func expandE2MAggMetadata(metricAggregation *events2metrics.V2Aggregation, metadata AggregationMetadata) error {
 	if metadata.Samples != nil {
-		metricAggregation.AggMetadata = &cxsdk.E2MAggregationSamples{
-			Samples: &cxsdk.E2MAggSamples{
-				SampleType: E2MAggSamplesSampleTypeSchemaToProto[metadata.Samples.SampleType],
-			},
+		sampleType, ok := E2MAggSamplesSampleTypeSchemaToOpenAPI[metadata.Samples.SampleType]
+		if !ok {
+			return fmt.Errorf("unsupported sample type %q", metadata.Samples.SampleType)
 		}
-	} else if metadata.Histogram != nil {
-		metricAggregation.AggMetadata = &cxsdk.E2MAggregationHistogram{
-			Histogram: &cxsdk.E2MAggHistogram{
-				Buckets: utils.QuantitiesToFloats32(metadata.Histogram.Buckets),
-			},
+		metricAggregation.Samples = &events2metrics.E2MAggSamples{
+			SampleType: sampleType.Ptr(),
+		}
+		return nil
+	}
+	if metadata.Histogram != nil {
+		metricAggregation.Histogram = &events2metrics.E2MAggHistogram{
+			Buckets: utils.QuantitiesToFloats32(metadata.Histogram.Buckets),
 		}
 	}
-
-	return metricAggregation
+	return nil
 }

--- a/api/coralogix/v1alpha1/events2metric_types_test.go
+++ b/api/coralogix/v1alpha1/events2metric_types_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026 Coralogix Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+
+	events2metrics "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
+)
+
+func TestExtractCreateE2MRequestLogsWireShape(t *testing.T) {
+	spec := Events2MetricSpec{
+		Name:              "logs-e2m",
+		Description:       ptr.To("desc"),
+		DataSource:        ptr.To("default/logs"),
+		PermutationsLimit: ptr.To(int32(100)),
+		MetricLabels: []MetricLabel{
+			{TargetLabel: "status", SourceField: "status"},
+		},
+		MetricFields: []MetricField{
+			{
+				TargetBaseMetricName: "request_count",
+				SourceField:          "request_count",
+				Aggregations: []MetricFieldAggregation{
+					{
+						Enabled:          true,
+						AggType:          AggregationTypeMin,
+						TargetMetricName: "min_request_count",
+					},
+					{
+						Enabled:          false,
+						AggType:          AggregationTypeMax,
+						TargetMetricName: "max_request_count",
+					},
+					{
+						Enabled:          true,
+						AggType:          AggregationTypeCount,
+						TargetMetricName: "count_request_count",
+					},
+					{
+						Enabled:          true,
+						AggType:          AggregationTypeAvg,
+						TargetMetricName: "avg_request_count",
+					},
+					{
+						Enabled:          true,
+						AggType:          AggregationTypeSum,
+						TargetMetricName: "sum_request_count",
+					},
+				},
+			},
+		},
+		Query: E2MQuery{
+			Logs: &E2MQueryLogs{
+				Lucene:                 ptr.To("status:200"),
+				Alias:                  ptr.To("e2m-logs"),
+				ApplicationNameFilters: []string{"app"},
+				SubsystemNameFilters:   []string{"sub"},
+				SeverityFilters:        []L2MSeverity{L2MSeverityError, L2MSeverityCritical},
+			},
+		},
+	}
+
+	got, err := spec.ExtractCreateE2MRequest()
+	require.NoError(t, err)
+
+	require.Equal(t, "logs-e2m", got.Name)
+	require.Equal(t, ptr.To("desc"), got.Description)
+	require.Equal(t, ptr.To("default/logs"), got.DataSource)
+	require.Equal(t, ptr.To(int32(100)), got.PermutationsLimit)
+	require.Equal(t, events2metrics.E2MTYPE_E2_M_TYPE_LOGS2_METRICS.Ptr(), got.Type)
+	require.Nil(t, got.SpansQuery)
+	require.NotNil(t, got.LogsQuery)
+	require.Equal(t, ptr.To("status:200"), got.LogsQuery.Lucene)
+	require.Equal(t, ptr.To("e2m-logs"), got.LogsQuery.Alias)
+	require.Equal(t, []string{"app"}, got.LogsQuery.ApplicationnameFilters)
+	require.Equal(t, []string{"sub"}, got.LogsQuery.SubsystemnameFilters)
+	require.Equal(t, []events2metrics.Logs2metricsV2Severity{
+		events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_ERROR,
+		events2metrics.LOGS2METRICSV2SEVERITY_SEVERITY_CRITICAL,
+	}, got.LogsQuery.SeverityFilters)
+
+	require.Len(t, got.MetricLabels, 1)
+	require.Equal(t, "status", got.MetricLabels[0].TargetLabel)
+	require.Equal(t, "status", got.MetricLabels[0].SourceField)
+
+	require.Len(t, got.MetricFields, 1)
+	require.Equal(t, "request_count", got.MetricFields[0].TargetBaseMetricName)
+	require.Len(t, got.MetricFields[0].Aggregations, 5)
+
+	for _, agg := range got.MetricFields[0].Aggregations {
+		require.NotNil(t, agg.Enabled)
+		require.NotNil(t, agg.AggType)
+		require.NotNil(t, agg.TargetMetricName)
+		require.Nil(t, agg.Samples)
+		require.Nil(t, agg.Histogram)
+		require.Nil(t, agg.None)
+	}
+	require.True(t, *got.MetricFields[0].Aggregations[0].Enabled)
+	require.False(t, *got.MetricFields[0].Aggregations[1].Enabled)
+	require.Equal(t, events2metrics.AGGTYPE_AGG_TYPE_MIN, *got.MetricFields[0].Aggregations[0].AggType)
+	require.Equal(t, events2metrics.AGGTYPE_AGG_TYPE_MAX, *got.MetricFields[0].Aggregations[1].AggType)
+}
+
+func TestExtractCreateE2MRequestSpansWireShape(t *testing.T) {
+	spec := Events2MetricSpec{
+		Name: "spans-e2m",
+		MetricFields: []MetricField{
+			{
+				TargetBaseMetricName: "duration",
+				SourceField:          "duration",
+				Aggregations: []MetricFieldAggregation{
+					{
+						Enabled:          true,
+						AggType:          AggregationTypeMin,
+						TargetMetricName: "min_duration",
+					},
+				},
+			},
+		},
+		Query: E2MQuery{
+			Spans: &E2MQuerySpans{
+				Lucene:                 ptr.To("service:nginx"),
+				ApplicationNameFilters: []string{"app"},
+				SubsystemNameFilters:   []string{"sub"},
+				ActionFilters:          []string{"GET"},
+				ServiceFilters:         []string{"nginx"},
+			},
+		},
+	}
+
+	got, err := spec.ExtractCreateE2MRequest()
+	require.NoError(t, err)
+	require.Equal(t, events2metrics.E2MTYPE_E2_M_TYPE_SPANS2_METRICS.Ptr(), got.Type)
+	require.Nil(t, got.LogsQuery)
+	require.NotNil(t, got.SpansQuery)
+	require.Equal(t, ptr.To("service:nginx"), got.SpansQuery.Lucene)
+	require.Equal(t, []string{"app"}, got.SpansQuery.ApplicationnameFilters)
+	require.Equal(t, []string{"sub"}, got.SpansQuery.SubsystemnameFilters)
+	require.Equal(t, []string{"GET"}, got.SpansQuery.ActionFilters)
+	require.Equal(t, []string{"nginx"}, got.SpansQuery.ServiceFilters)
+}
+
+func TestExtractCreateE2MRequestSamplesAndHistogram(t *testing.T) {
+	spec := Events2MetricSpec{
+		Name: "agg-meta-e2m",
+		MetricFields: []MetricField{
+			{
+				TargetBaseMetricName: "latency",
+				SourceField:          "latency",
+				Aggregations: []MetricFieldAggregation{
+					{
+						Enabled:          true,
+						AggType:          AggregationTypeSamples,
+						TargetMetricName: "samples_latency",
+						AggMetadata: AggregationMetadata{
+							Samples: &SamplesMetadata{SampleType: E2MAggSamplesSampleTypeMax},
+						},
+					},
+					{
+						Enabled:          true,
+						AggType:          AggregationTypeHistogram,
+						TargetMetricName: "histogram_latency",
+						AggMetadata: AggregationMetadata{
+							Histogram: &HistogramMetadata{
+								Buckets: []resource.Quantity{
+									resource.MustParse("0.1"),
+									resource.MustParse("5.5"),
+									resource.MustParse("100"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Query: E2MQuery{
+			Logs: &E2MQueryLogs{},
+		},
+	}
+
+	got, err := spec.ExtractCreateE2MRequest()
+	require.NoError(t, err)
+	require.Len(t, got.MetricFields[0].Aggregations, 2)
+
+	samples := got.MetricFields[0].Aggregations[0]
+	require.Equal(t, events2metrics.AGGTYPE_AGG_TYPE_SAMPLES, *samples.AggType)
+	require.NotNil(t, samples.Samples)
+	require.Equal(t, events2metrics.SAMPLETYPE_SAMPLE_TYPE_MAX, *samples.Samples.SampleType)
+	require.Nil(t, samples.Histogram)
+	require.Nil(t, samples.None)
+
+	histogram := got.MetricFields[0].Aggregations[1]
+	require.Equal(t, events2metrics.AGGTYPE_AGG_TYPE_HISTOGRAM, *histogram.AggType)
+	require.NotNil(t, histogram.Histogram)
+	require.Equal(t, []float32{0.1, 5.5, 100}, histogram.Histogram.Buckets)
+	require.Nil(t, histogram.Samples)
+	require.Nil(t, histogram.None)
+}
+
+func TestExtractCreateE2MRequestEmptyAggregationsIsEmptySlice(t *testing.T) {
+	spec := Events2MetricSpec{
+		Name: "empty-aggs",
+		MetricFields: []MetricField{
+			{
+				TargetBaseMetricName: "field",
+				SourceField:          "field",
+			},
+		},
+		Query: E2MQuery{Logs: &E2MQueryLogs{}},
+	}
+
+	got, err := spec.ExtractCreateE2MRequest()
+	require.NoError(t, err)
+	require.NotNil(t, got.MetricFields[0].Aggregations)
+	require.Empty(t, got.MetricFields[0].Aggregations)
+
+	payload, err := json.Marshal(got.MetricFields[0])
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(payload, &raw))
+	aggs, ok := raw["aggregations"].([]any)
+	require.True(t, ok, "aggregations must be present as a JSON array, got %#v", raw["aggregations"])
+	require.Empty(t, aggs)
+}
+
+func TestExtractCreateAndReplaceOmitOptionalFields(t *testing.T) {
+	spec := Events2MetricSpec{
+		Name: "omit-optionals",
+		Query: E2MQuery{
+			Logs: &E2MQueryLogs{},
+		},
+	}
+
+	create, err := spec.ExtractCreateE2MRequest()
+	require.NoError(t, err)
+	require.Nil(t, create.Description)
+	require.Nil(t, create.DataSource)
+	require.Nil(t, create.PermutationsLimit)
+	require.Nil(t, create.LogsQuery.Lucene)
+	require.Nil(t, create.LogsQuery.Alias)
+
+	createPayload, err := json.Marshal(create)
+	require.NoError(t, err)
+	var createRaw map[string]any
+	require.NoError(t, json.Unmarshal(createPayload, &createRaw))
+	_, hasPermutationsLimit := createRaw["permutationsLimit"]
+	require.False(t, hasPermutationsLimit)
+	_, hasDescription := createRaw["description"]
+	require.False(t, hasDescription)
+	_, hasDataSource := createRaw["dataSource"]
+	require.False(t, hasDataSource)
+
+	replace, err := spec.ExtractReplaceE2MRequest("11111111-1111-1111-1111-111111111111")
+	require.NoError(t, err)
+	require.Equal(t, ptr.To("11111111-1111-1111-1111-111111111111"), replace.Id)
+	require.Equal(t, ptr.To(""), replace.Description)
+	require.Nil(t, replace.DataSource)
+	require.Nil(t, replace.LogsQuery.Lucene)
+	require.Nil(t, replace.LogsQuery.Alias)
+	require.Nil(t, replace.Permutations)
+
+	replacePayload, err := json.Marshal(replace)
+	require.NoError(t, err)
+	var replaceRaw map[string]any
+	require.NoError(t, json.Unmarshal(replacePayload, &replaceRaw))
+	_, hasPermutations := replaceRaw["permutations"]
+	require.False(t, hasPermutations)
+	require.Equal(t, "", replaceRaw["description"])
+	_, hasDataSource = replaceRaw["dataSource"]
+	require.False(t, hasDataSource)
+	logsQuery, ok := replaceRaw["logsQuery"].(map[string]any)
+	require.True(t, ok)
+	_, hasLucene := logsQuery["lucene"]
+	require.False(t, hasLucene)
+	_, hasAlias := logsQuery["alias"]
+	require.False(t, hasAlias)
+
+	spansSpec := Events2MetricSpec{
+		Name: "omit-optionals-spans",
+		Query: E2MQuery{
+			Spans: &E2MQuerySpans{},
+		},
+	}
+	spansReplace, err := spansSpec.ExtractReplaceE2MRequest("11111111-1111-1111-1111-111111111111")
+	require.NoError(t, err)
+	require.Nil(t, spansReplace.SpansQuery.Lucene)
+}
+
+func TestExtractReplaceE2MRequestPresenceRules(t *testing.T) {
+	spec := Events2MetricSpec{
+		Name:              "replace-e2m",
+		Description:       ptr.To("updated"),
+		DataSource:        ptr.To("default/logs"),
+		PermutationsLimit: ptr.To(int32(42)),
+		MetricFields: []MetricField{
+			{
+				TargetBaseMetricName: "field",
+				SourceField:          "field",
+				Aggregations: []MetricFieldAggregation{
+					{
+						Enabled:          false,
+						AggType:          AggregationTypeSum,
+						TargetMetricName: "sum_field",
+					},
+				},
+			},
+		},
+		Query: E2MQuery{
+			Logs: &E2MQueryLogs{
+				Lucene: ptr.To("status:500"),
+				Alias:  ptr.To("alias"),
+			},
+		},
+	}
+
+	got, err := spec.ExtractReplaceE2MRequest("22222222-2222-2222-2222-222222222222")
+	require.NoError(t, err)
+	require.Equal(t, "replace-e2m", got.Name)
+	require.Equal(t, events2metrics.E2MTYPE_E2_M_TYPE_LOGS2_METRICS, got.Type)
+	require.Equal(t, ptr.To("updated"), got.Description)
+	require.Equal(t, ptr.To("default/logs"), got.DataSource)
+	require.NotNil(t, got.Permutations)
+	require.Equal(t, int32(42), got.Permutations.Limit)
+	require.False(t, got.Permutations.HasExceededLimit)
+	require.False(t, *got.MetricFields[0].Aggregations[0].Enabled)
+	require.Equal(t, ptr.To("status:500"), got.LogsQuery.Lucene)
+	require.Equal(t, ptr.To("alias"), got.LogsQuery.Alias)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -315,7 +315,7 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&v1alpha1controllers.Events2MetricReconciler{
-		E2MClient: clientSet.Events2Metrics(),
+		E2MClient: oapiClientSet.Events2Metrics(),
 		Interval:  cfg.ReconcileIntervals[utils.Events2MetricKind],
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Events2Metric")

--- a/config/samples/v1alpha1/events2metrics/spans2metric.yaml
+++ b/config/samples/v1alpha1/events2metrics/spans2metric.yaml
@@ -25,3 +25,10 @@ spec:
         - "filter:equals:GET"
       serviceFilters:
         - "filter:equals:nginx"
+  metricFields:
+    - targetBaseMetricName: "duration"
+      sourceField: "duration"
+      aggregations:
+        - aggType: "min"
+          targetMetricName: "min_duration"
+          aggMetadata: {}

--- a/internal/controller/coralogix/v1alpha1/events2metric_controller.go
+++ b/internal/controller/coralogix/v1alpha1/events2metric_controller.go
@@ -19,24 +19,23 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/coralogix/coralogix-operator/v2/internal/config"
 	"github.com/go-logr/logr"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/encoding/protojson"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	events2metrics "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
 
-	utils "github.com/coralogix/coralogix-operator/v2/api/coralogix"
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
+	"github.com/coralogix/coralogix-operator/v2/internal/config"
 	coralogixreconciler "github.com/coralogix/coralogix-operator/v2/internal/controller/coralogix/coralogix-reconciler"
+	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
 // Events2MetricReconciler reconciles a Events2Metric object
 type Events2MetricReconciler struct {
+	E2MClient *events2metrics.Events2MetricsServiceAPIService
 	Interval  time.Duration
-	E2MClient *cxsdk.Events2MetricsClient
 }
 
 // +kubebuilder:rbac:groups=coralogix.com,resources=events2metrics,verbs=get;list;watch;create;update;patch;delete
@@ -57,17 +56,27 @@ func (r *Events2MetricReconciler) FinalizerName() string {
 
 func (r *Events2MetricReconciler) HandleCreation(ctx context.Context, log logr.Logger, obj client.Object) error {
 	e2m := obj.(*coralogixv1alpha1.Events2Metric)
-	createRequest := e2m.Spec.ExtractCreateE2MRequest()
-
-	log.Info("Creating remote E2M", "E2M", protojson.Format(createRequest))
-	createResponse, err := r.E2MClient.Create(ctx, createRequest)
+	createRequest, err := e2m.Spec.ExtractCreateE2MRequest()
 	if err != nil {
-		return fmt.Errorf("error on creating remote E2M: %w", err)
+		return fmt.Errorf("error on extracting create request: %w", err)
 	}
-	log.Info("Remote E2M created", "response", protojson.Format(createResponse))
+
+	log.Info("Creating remote E2M", "E2M", utils.FormatJSON(createRequest))
+	createResponse, httpResp, err := r.E2MClient.
+		Events2MetricServiceCreateE2M(ctx).
+		E2MCreateParams(*createRequest).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("error on creating remote E2M: %w", cxsdk.NewAPIError(httpResp, err))
+	}
+	log.Info("Remote E2M created", "response", utils.FormatJSON(createResponse))
+
+	if createResponse == nil || createResponse.E2m == nil || createResponse.E2m.Id == nil || *createResponse.E2m.Id == "" {
+		return fmt.Errorf("error on creating remote E2M: empty id in response")
+	}
 
 	e2m.Status = coralogixv1alpha1.Events2MetricStatus{
-		Id: utils.WrapperspbStringToStringPointer(createResponse.E2M.Id),
+		Id: createResponse.E2m.Id,
 	}
 
 	return nil
@@ -75,31 +84,42 @@ func (r *Events2MetricReconciler) HandleCreation(ctx context.Context, log logr.L
 
 func (r *Events2MetricReconciler) HandleUpdate(ctx context.Context, log logr.Logger, obj client.Object) error {
 	e2m := obj.(*coralogixv1alpha1.Events2Metric)
-	updateRequest := e2m.Spec.ExtractReplaceE2MRequest()
-	updateRequest.E2M.Id = utils.StringPointerToWrapperspbString(e2m.Status.Id)
-
-	log.Info("Updating remote E2M", "E2M", protojson.Format(updateRequest))
-	updateResponse, err := r.E2MClient.Replace(ctx, updateRequest)
+	updateRequest, err := e2m.Spec.ExtractReplaceE2MRequest(*e2m.Status.Id)
 	if err != nil {
-		return err
+		return fmt.Errorf("error on extracting replace request: %w", err)
 	}
-	log.Info("Remote E2M updated", "E2M", protojson.Format(updateResponse))
+
+	log.Info("Updating remote E2M", "E2M", utils.FormatJSON(updateRequest))
+	updateResponse, httpResp, err := r.E2MClient.
+		Events2MetricServiceReplaceE2M(ctx).
+		E2M1(*updateRequest).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("error on updating remote E2M: %w", cxsdk.NewAPIError(httpResp, err))
+	}
+	log.Info("Remote E2M updated", "E2M", utils.FormatJSON(updateResponse))
 
 	return nil
 }
 
 func (r *Events2MetricReconciler) HandleDeletion(ctx context.Context, log logr.Logger, obj client.Object) error {
 	e2m := obj.(*coralogixv1alpha1.Events2Metric)
-	log.Info("Deleting E2M from remote system", "id", *e2m.Status.Id)
-	_, err := r.E2MClient.Delete(ctx,
-		&cxsdk.DeleteE2MRequest{
-			Id: utils.StringPointerToWrapperspbString(e2m.Status.Id),
-		})
-	if err != nil && cxsdk.Code(err) != codes.NotFound {
-		log.Error(err, "Error deleting remote E2M", "id", *e2m.Status.Id)
-		return fmt.Errorf("error deleting remote E2M %s: %w", *e2m.Status.Id, err)
+	if e2m.Status.Id == nil || *e2m.Status.Id == "" {
+		log.Info("No ID in status, nothing to delete remotely")
+		return nil
 	}
-	log.Info("E2M deleted from remote system", "id", *e2m.Status.Id)
+	id := *e2m.Status.Id
+	log.Info("Deleting E2M from remote system", "id", id)
+	_, httpResp, err := r.E2MClient.
+		Events2MetricServiceDeleteE2M(ctx, id).
+		Execute()
+	if err != nil {
+		if apiErr := cxsdk.NewAPIError(httpResp, err); !cxsdk.IsNotFound(apiErr) {
+			log.Error(err, "Error deleting remote E2M", "id", id)
+			return fmt.Errorf("error deleting remote E2M %s: %w", id, apiErr)
+		}
+	}
+	log.Info("E2M deleted from remote system", "id", id)
 	return nil
 }
 

--- a/tests/e2e/aicustomevaluation_test.go
+++ b/tests/e2e/aicustomevaluation_test.go
@@ -49,7 +49,7 @@ var _ = Describe("AICustomEvaluation", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -191,7 +191,7 @@ var _ = Describe("AICustomEvaluation minimal", Ordered, func() {
 
 	BeforeAll(func() {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		aiEvaluations = newAIEvaluationOpenAPIClientSet().AIEvaluations()
+		aiEvaluations = newOpenAPIClientSet().AIEvaluations()
 		aiCustomEvaluation = newAICustomEvaluation(
 			resourceName,
 			"minimal-policy",
@@ -248,7 +248,7 @@ var _ = Describe("AICustomEvaluation application resolution", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 
 		var err error

--- a/tests/e2e/aievaluation_test.go
+++ b/tests/e2e/aievaluation_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -63,7 +62,7 @@ var _ = Describe("AIEvaluation PII", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -175,7 +174,7 @@ var _ = Describe("AIEvaluation Allowed Topics", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -287,7 +286,7 @@ var _ = Describe("AIEvaluation Competition", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -449,7 +448,7 @@ var _ = Describe("AIEvaluation Language Mismatch", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -559,7 +558,7 @@ var _ = Describe("AIEvaluation Prompt Injection", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -671,7 +670,7 @@ var _ = Describe("AIEvaluation Restricted Topics", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -781,7 +780,7 @@ var _ = Describe("AIEvaluation Sexism", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -935,7 +934,7 @@ var _ = Describe("AIEvaluation Toxicity", Ordered, func() {
 
 	BeforeAll(func(ctx context.Context) {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		clientSet := newAIEvaluationOpenAPIClientSet()
+		clientSet := newOpenAPIClientSet()
 		aiApplications = clientSet.AIApplications()
 		aiEvaluations = clientSet.AIEvaluations()
 
@@ -1032,16 +1031,6 @@ var _ = Describe("AIEvaluation Toxicity", Ordered, func() {
 type aiEvaluationApplicationRef struct {
 	application string
 	subsystem   string
-}
-
-func newAIEvaluationOpenAPIClientSet() *cxsdk.ClientSet {
-	builder := cxsdk.NewConfigBuilder().WithAPIKeyEnv()
-	if domain := os.Getenv("CORALOGIX_DOMAIN"); domain != "" {
-		builder = builder.WithDomain(domain)
-	} else {
-		builder = builder.WithRegionEnv()
-	}
-	return cxsdk.NewClientSet(builder.Build())
 }
 
 // Every e2e job running against the same Coralogix account draws from one pool of
@@ -1176,7 +1165,7 @@ func describeEmptyConfigAIEvaluation(
 
 		BeforeAll(func(ctx context.Context) {
 			crClient = ClientsInstance.GetControllerRuntimeClient()
-			clientSet := newAIEvaluationOpenAPIClientSet()
+			clientSet := newOpenAPIClientSet()
 			aiApplications = clientSet.AIApplications()
 			aiEvaluations = clientSet.AIEvaluations()
 
@@ -1295,7 +1284,7 @@ func describeStringSetConfigAIEvaluation(
 
 		BeforeAll(func(ctx context.Context) {
 			crClient = ClientsInstance.GetControllerRuntimeClient()
-			clientSet := newAIEvaluationOpenAPIClientSet()
+			clientSet := newOpenAPIClientSet()
 			aiApplications = clientSet.AIApplications()
 			aiEvaluations = clientSet.AIEvaluations()
 

--- a/tests/e2e/client.go
+++ b/tests/e2e/client.go
@@ -15,6 +15,8 @@
 package e2e
 
 import (
+	"os"
+
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	prometheusv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"k8s.io/client-go/kubernetes"
@@ -22,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	openapicxsdk "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
 
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
 	coralogixv1beta1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1beta1"
@@ -90,4 +93,16 @@ func (c *Clients) GetControllerRuntimeClient() client.Client {
 
 func (c *Clients) GetK8sClient() *kubernetes.Clientset {
 	return c.K8sClient
+}
+
+// newOpenAPIClientSet builds an OpenAPI SDK client from CORALOGIX_API_KEY and
+// either CORALOGIX_DOMAIN or CORALOGIX_REGION.
+func newOpenAPIClientSet() *openapicxsdk.ClientSet {
+	builder := openapicxsdk.NewConfigBuilder().WithAPIKeyEnv()
+	if domain := os.Getenv("CORALOGIX_DOMAIN"); domain != "" {
+		builder = builder.WithDomain(domain)
+	} else {
+		builder = builder.WithRegionEnv()
+	}
+	return openapicxsdk.NewClientSet(builder.Build())
 }

--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -48,7 +47,7 @@ var _ = Describe("Dashboard", Ordered, func() {
 
 	BeforeEach(func() {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		dashboardsClient = newDashboardOpenAPIClientSet().Dashboards()
+		dashboardsClient = newOpenAPIClientSet().Dashboards()
 	})
 
 	It("Should be created successfully", func(ctx context.Context) {
@@ -135,7 +134,7 @@ var _ = Describe("Dashboard import", Ordered, func() {
 
 	BeforeEach(func() {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		dashboardsClient = newDashboardOpenAPIClientSet().Dashboards()
+		dashboardsClient = newOpenAPIClientSet().Dashboards()
 	})
 
 	It("Should adopt a pre-existing remote dashboard", func(ctx context.Context) {
@@ -196,16 +195,6 @@ var _ = Describe("Dashboard import", Ordered, func() {
 		}, time.Minute, time.Second).Should(Equal(http.StatusNotFound))
 	})
 })
-
-func newDashboardOpenAPIClientSet() *cxsdk.ClientSet {
-	builder := cxsdk.NewConfigBuilder().WithAPIKeyEnv()
-	if domain := os.Getenv("CORALOGIX_DOMAIN"); domain != "" {
-		builder = builder.WithDomain(domain)
-	} else {
-		builder = builder.WithRegionEnv()
-	}
-	return cxsdk.NewClientSet(builder.Build())
-}
 
 // getDashboardJson carries arcDisplay, showMinMax and layoutColumns deliberately: those
 // three fields are missing from the proto the gRPC client used, so they double as the

--- a/tests/e2e/events2metrics_test.go
+++ b/tests/e2e/events2metrics_test.go
@@ -16,40 +16,54 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
+	"github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	events2metrics "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/events2metrics_service"
 
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
 
+func uniqueE2MMetricName(prefix string) string {
+	return fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+}
+
 var _ = Describe("Events2Metric", Ordered, func() {
 	var (
 		crClient  client.Client
-		e2mClient *cxsdk.Events2MetricsClient
+		e2mClient *events2metrics.Events2MetricsServiceAPIService
 		e2mID     string
 		e2m       *coralogixv1alpha1.Events2Metric
+		baseName  string
+		e2mName   string
 	)
 
 	BeforeAll(func() {
 		crClient = ClientsInstance.GetControllerRuntimeClient()
-		e2mClient = ClientsInstance.GetCoralogixClientSet().Events2Metrics()
+		e2mClient = newOpenAPIClientSet().Events2Metrics()
+		baseName = uniqueE2MMetricName("request_count")
+		e2mName = fmt.Sprintf("logs2metric-%d", time.Now().UnixNano())
+		// Register in BeforeAll so cleanup runs after the Ordered container, not after the create It.
+		DeferCleanup(func(ctx context.Context) {
+			_ = crClient.Delete(ctx, &coralogixv1alpha1.Events2Metric{
+				ObjectMeta: metav1.ObjectMeta{Name: e2mName, Namespace: testNamespace},
+			})
+		})
 	})
 
 	It("Should be created successfully", func(ctx context.Context) {
 		By("Creating E2M")
-		e2mName := "logs2metric"
 		e2m = &coralogixv1alpha1.Events2Metric{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      e2mName,
@@ -68,7 +82,7 @@ var _ = Describe("Events2Metric", Ordered, func() {
 				},
 				MetricFields: []coralogixv1alpha1.MetricField{
 					{
-						TargetBaseMetricName: "request_count",
+						TargetBaseMetricName: baseName,
 						SourceField:          "request_count",
 						Aggregations: []coralogixv1alpha1.MetricFieldAggregation{
 							{
@@ -96,37 +110,131 @@ var _ = Describe("Events2Metric", Ordered, func() {
 		fetchedE2M := &coralogixv1alpha1.Events2Metric{}
 		Eventually(func(g Gomega) {
 			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: e2mName, Namespace: testNamespace}, fetchedE2M)).To(Succeed())
-
 			g.Expect(meta.IsStatusConditionTrue(fetchedE2M.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
-
 			g.Expect(fetchedE2M.Status.PrintableStatus).To(Equal("RemoteSynced"))
-
 			g.Expect(fetchedE2M.Status.Id).ToNot(BeNil())
-
 			e2mID = *fetchedE2M.Status.Id
-
 		}, time.Minute, time.Second).Should(Succeed())
 
 		By("Verifying E2M exists in Coralogix backend")
-		Eventually(func() error {
-			_, err := e2mClient.Get(ctx, &cxsdk.GetE2MRequest{Id: wrapperspb.String(e2mID)})
-			return err
+		Eventually(func(g Gomega) {
+			getE2mRes, _, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(getE2mRes.E2m).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.Description).ToNot(BeNil())
+			g.Expect(*getE2mRes.E2m.Description).To(Equal("e2m from k8s operator"))
+			g.Expect(getE2mRes.E2m.DataSource).ToNot(BeNil())
+			g.Expect(*getE2mRes.E2m.DataSource).To(Equal("default/logs"))
+			g.Expect(getE2mRes.E2m.Permutations).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.Permutations.Limit).To(Equal(int32(100)))
+			g.Expect(getE2mRes.E2m.LogsQuery).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.LogsQuery.Lucene).ToNot(BeNil())
+			g.Expect(*getE2mRes.E2m.LogsQuery.Lucene).To(Equal("status:200 AND request_count:[* TO *]"))
 		}, time.Minute, time.Second).Should(Succeed())
 	})
 
 	It("Should be updated successfully", func(ctx context.Context) {
-		By("Patching the E2M")
-		newE2MName := "updated-logs2metric"
+		By("Patching the E2M beyond rename")
+		// Account-wide E2M names must be unique; leftovers from interrupted runs collide on a fixed name.
+		newE2MName := fmt.Sprintf("updated-logs2metric-%d", time.Now().UnixNano())
 		modifiedE2M := e2m.DeepCopy()
 		modifiedE2M.Spec.Name = newE2MName
+		modifiedE2M.Spec.Description = ptr.To("updated description")
+		modifiedE2M.Spec.PermutationsLimit = ptr.To(int32(250))
+		modifiedE2M.Spec.MetricLabels = []coralogixv1alpha1.MetricLabel{
+			{TargetLabel: "status", SourceField: "status"},
+			{TargetLabel: "method", SourceField: "method"},
+		}
+		modifiedE2M.Spec.MetricFields = []coralogixv1alpha1.MetricField{
+			{
+				TargetBaseMetricName: baseName,
+				SourceField:          "request_count",
+				Aggregations: []coralogixv1alpha1.MetricFieldAggregation{
+					{
+						Enabled:          true,
+						AggType:          coralogixv1alpha1.AggregationTypeMin,
+						TargetMetricName: "min_request_count",
+					},
+					{
+						Enabled:          false,
+						AggType:          coralogixv1alpha1.AggregationTypeMax,
+						TargetMetricName: "max_request_count",
+					},
+				},
+			},
+		}
 		Expect(crClient.Patch(ctx, modifiedE2M, client.MergeFrom(e2m))).To(Succeed())
+		e2m = modifiedE2M
 
 		By("Verifying E2M is updated in Coralogix backend")
-		Eventually(func() *wrapperspb.StringValue {
-			getE2mRes, err := e2mClient.Get(ctx, &cxsdk.GetE2MRequest{Id: wrapperspb.String(e2mID)})
-			Expect(err).ToNot(HaveOccurred())
-			return getE2mRes.GetE2M().GetName()
-		}, time.Minute, time.Second).Should(Equal(wrapperspb.String(newE2MName)))
+		Eventually(func(g Gomega) {
+			getE2mRes, _, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(getE2mRes.E2m).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.Name).To(Equal(newE2MName))
+			g.Expect(getE2mRes.E2m.Description).ToNot(BeNil())
+			g.Expect(*getE2mRes.E2m.Description).To(Equal("updated description"))
+			g.Expect(getE2mRes.E2m.Permutations).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.Permutations.Limit).To(Equal(int32(250)))
+			g.Expect(getE2mRes.E2m.MetricLabels).To(HaveLen(2))
+			g.Expect(getE2mRes.E2m.MetricFields).To(HaveLen(1))
+			// API expands each field into a full aggregation set; do not assert exact length.
+			g.Expect(getE2mRes.E2m.MetricFields[0].Aggregations).ToNot(BeEmpty())
+
+			disabledMaxFound := false
+			for _, agg := range getE2mRes.E2m.MetricFields[0].Aggregations {
+				if agg.AggType != nil && *agg.AggType == events2metrics.AGGTYPE_AGG_TYPE_MAX &&
+					agg.Enabled != nil && !*agg.Enabled {
+					disabledMaxFound = true
+				}
+			}
+			g.Expect(disabledMaxFound).To(BeTrue())
+		}, time.Minute, time.Second).Should(Succeed())
+	})
+
+	It("Should clear optional fields successfully", func(ctx context.Context) {
+		By("Clearing optional string fields and permutationsLimit")
+		fetched := &coralogixv1alpha1.Events2Metric{}
+		Expect(crClient.Get(ctx, types.NamespacedName{Name: e2m.Name, Namespace: testNamespace}, fetched)).To(Succeed())
+		fetched.Spec.Description = nil
+		fetched.Spec.DataSource = nil
+		fetched.Spec.PermutationsLimit = nil
+		Expect(fetched.Spec.Query.Logs).ToNot(BeNil())
+		fetched.Spec.Query.Logs.Lucene = nil
+		fetched.Spec.Query.Logs.Alias = nil
+		Expect(crClient.Update(ctx, fetched)).To(Succeed())
+		e2m = fetched
+
+		By("Verifying replace succeeds and optional fields are cleared or omitted remotely")
+		Eventually(func(g Gomega) {
+			current := &coralogixv1alpha1.Events2Metric{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: e2m.Name, Namespace: testNamespace}, current)).To(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(current.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
+			g.Expect(current.Spec.Description).To(BeNil())
+			g.Expect(current.Spec.DataSource).To(BeNil())
+			g.Expect(current.Spec.PermutationsLimit).To(BeNil())
+			g.Expect(current.Spec.Query.Logs).ToNot(BeNil())
+			g.Expect(current.Spec.Query.Logs.Lucene).To(BeNil())
+			g.Expect(current.Spec.Query.Logs.Alias).To(BeNil())
+
+			getE2mRes, _, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(getE2mRes.E2m).ToNot(BeNil())
+			if getE2mRes.E2m.Description != nil {
+				g.Expect(*getE2mRes.E2m.Description).To(BeEmpty())
+			}
+			if getE2mRes.E2m.DataSource != nil {
+				g.Expect(*getE2mRes.E2m.DataSource).To(BeEmpty())
+			}
+			// Replace omits permutations when Spec.PermutationsLimit is nil.
+			// The API resets the limit to its default (30000), not the prior value.
+			g.Expect(getE2mRes.E2m.Permutations).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.Permutations.Limit).To(Equal(int32(30000)))
+			g.Expect(getE2mRes.E2m.LogsQuery).ToNot(BeNil())
+			if getE2mRes.E2m.LogsQuery.Lucene != nil {
+				g.Expect(*getE2mRes.E2m.LogsQuery.Lucene).To(BeEmpty())
+			}
+		}, time.Minute, time.Second).Should(Succeed())
 	})
 
 	It("Should be deleted successfully", func(ctx context.Context) {
@@ -134,9 +242,212 @@ var _ = Describe("Events2Metric", Ordered, func() {
 		Expect(crClient.Delete(ctx, e2m)).To(Succeed())
 
 		By("Verifying E2M is deleted from Coralogix backend")
-		Eventually(func() codes.Code {
-			_, err := e2mClient.Get(ctx, &cxsdk.GetE2MRequest{Id: wrapperspb.String(e2mID)})
-			return cxsdk.Code(err)
-		}, time.Minute, time.Second).Should(Equal(codes.NotFound))
+		Eventually(func(g Gomega) {
+			_, httpResp, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(cxsdk.IsNotFound(cxsdk.NewAPIError(httpResp, err))).To(BeTrue())
+		}, time.Minute, time.Second).Should(Succeed())
+	})
+})
+
+var _ = Describe("Events2Metric spans samples histogram", Ordered, func() {
+	var (
+		crClient  client.Client
+		e2mClient *events2metrics.Events2MetricsServiceAPIService
+		e2mName   string
+	)
+
+	BeforeAll(func() {
+		crClient = ClientsInstance.GetControllerRuntimeClient()
+		e2mClient = newOpenAPIClientSet().Events2Metrics()
+		e2mName = fmt.Sprintf("spans2metric-%d", time.Now().UnixNano())
+		DeferCleanup(func(ctx context.Context) {
+			_ = crClient.Delete(ctx, &coralogixv1alpha1.Events2Metric{
+				ObjectMeta: metav1.ObjectMeta{Name: e2mName, Namespace: testNamespace},
+			})
+		})
+	})
+
+	It("Should create update and delete a spans E2M with samples and histogram aggregations", func(ctx context.Context) {
+		durationMetric := uniqueE2MMetricName("span_duration")
+		samplesMetric := uniqueE2MMetricName("span_samples")
+		histogramMetric := uniqueE2MMetricName("span_histogram")
+
+		e2m := &coralogixv1alpha1.Events2Metric{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      e2mName,
+				Namespace: testNamespace,
+			},
+			Spec: coralogixv1alpha1.Events2MetricSpec{
+				Name:              e2mName,
+				Description:       ptr.To("spans e2m from k8s operator"),
+				PermutationsLimit: ptr.To(int32(50)),
+				MetricFields: []coralogixv1alpha1.MetricField{
+					{
+						TargetBaseMetricName: durationMetric,
+						SourceField:          "duration",
+						Aggregations: []coralogixv1alpha1.MetricFieldAggregation{
+							{
+								Enabled:          true,
+								AggType:          coralogixv1alpha1.AggregationTypeMin,
+								TargetMetricName: "min_duration",
+							},
+						},
+					},
+					{
+						TargetBaseMetricName: samplesMetric,
+						SourceField:          "duration",
+						Aggregations: []coralogixv1alpha1.MetricFieldAggregation{
+							{
+								Enabled:          true,
+								AggType:          coralogixv1alpha1.AggregationTypeSamples,
+								TargetMetricName: "samples_duration",
+								AggMetadata: coralogixv1alpha1.AggregationMetadata{
+									Samples: &coralogixv1alpha1.SamplesMetadata{
+										SampleType: coralogixv1alpha1.E2MAggSamplesSampleTypeMax,
+									},
+								},
+							},
+						},
+					},
+					{
+						TargetBaseMetricName: histogramMetric,
+						SourceField:          "duration",
+						Aggregations: []coralogixv1alpha1.MetricFieldAggregation{
+							{
+								Enabled:          true,
+								AggType:          coralogixv1alpha1.AggregationTypeHistogram,
+								TargetMetricName: "histogram_duration",
+								AggMetadata: coralogixv1alpha1.AggregationMetadata{
+									Histogram: &coralogixv1alpha1.HistogramMetadata{
+										Buckets: []resource.Quantity{
+											resource.MustParse("0.1"),
+											resource.MustParse("5.5"),
+											resource.MustParse("100"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Query: coralogixv1alpha1.E2MQuery{
+					Spans: &coralogixv1alpha1.E2MQuerySpans{
+						Lucene:                 ptr.To("service:nginx"),
+						ApplicationNameFilters: []string{"test-app"},
+						SubsystemNameFilters:   []string{"test-subsystem"},
+						ActionFilters:          []string{"GET"},
+						ServiceFilters:         []string{"nginx"},
+					},
+				},
+			},
+		}
+
+		Expect(crClient.Create(ctx, e2m)).To(Succeed())
+
+		var e2mID string
+		Eventually(func(g Gomega) {
+			fetched := &coralogixv1alpha1.Events2Metric{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: e2mName, Namespace: testNamespace}, fetched)).To(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(fetched.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
+			g.Expect(fetched.Status.Id).ToNot(BeNil())
+			e2mID = *fetched.Status.Id
+		}, time.Minute, time.Second).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			getE2mRes, _, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(getE2mRes.E2m).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.Type).To(Equal(events2metrics.E2MTYPE_E2_M_TYPE_SPANS2_METRICS))
+			g.Expect(getE2mRes.E2m.Description).ToNot(BeNil())
+			g.Expect(*getE2mRes.E2m.Description).To(Equal("spans e2m from k8s operator"))
+			g.Expect(getE2mRes.E2m.SpansQuery).ToNot(BeNil())
+			g.Expect(getE2mRes.E2m.SpansQuery.Lucene).ToNot(BeNil())
+			g.Expect(*getE2mRes.E2m.SpansQuery.Lucene).To(Equal("service:nginx"))
+			g.Expect(getE2mRes.E2m.MetricFields).To(HaveLen(3))
+
+			// The API expands each metric field into a full aggregation set (default
+			// histogram has empty buckets) and may rewrite targetMetricName (e.g. to
+			// cx_bucket). Match by TargetBaseMetricName + AggType instead.
+			var foundSamples, foundHistogram bool
+			for _, field := range getE2mRes.E2m.MetricFields {
+				for _, agg := range field.Aggregations {
+					if agg.AggType == nil {
+						continue
+					}
+					switch {
+					case field.TargetBaseMetricName == samplesMetric &&
+						*agg.AggType == events2metrics.AGGTYPE_AGG_TYPE_SAMPLES:
+						foundSamples = true
+						g.Expect(agg.Samples).ToNot(BeNil())
+						g.Expect(agg.Samples.SampleType).ToNot(BeNil())
+						g.Expect(*agg.Samples.SampleType).To(Equal(events2metrics.SAMPLETYPE_SAMPLE_TYPE_MAX))
+					case field.TargetBaseMetricName == histogramMetric &&
+						*agg.AggType == events2metrics.AGGTYPE_AGG_TYPE_HISTOGRAM:
+						foundHistogram = true
+						g.Expect(agg.Histogram).ToNot(BeNil())
+						g.Expect(agg.Histogram.Buckets).To(Equal([]float32{0.1, 5.5, 100}))
+					}
+				}
+			}
+			g.Expect(foundSamples).To(BeTrue())
+			g.Expect(foundHistogram).To(BeTrue())
+		}, time.Minute, time.Second).Should(Succeed())
+
+		By("Updating spans description")
+		modified := e2m.DeepCopy()
+		modified.Spec.Description = ptr.To("updated spans e2m")
+		Expect(crClient.Patch(ctx, modified, client.MergeFrom(e2m))).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			getE2mRes, _, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(getE2mRes.E2m.Description).ToNot(BeNil())
+			g.Expect(*getE2mRes.E2m.Description).To(Equal("updated spans e2m"))
+		}, time.Minute, time.Second).Should(Succeed())
+
+		By("Clearing optional spans string fields")
+		fetched := &coralogixv1alpha1.Events2Metric{}
+		Expect(crClient.Get(ctx, types.NamespacedName{Name: e2mName, Namespace: testNamespace}, fetched)).To(Succeed())
+		fetched.Spec.Description = nil
+		Expect(fetched.Spec.Query.Spans).ToNot(BeNil())
+		fetched.Spec.Query.Spans.Lucene = nil
+		Expect(crClient.Update(ctx, fetched)).To(Succeed())
+		modified = fetched
+
+		Eventually(func(g Gomega) {
+			current := &coralogixv1alpha1.Events2Metric{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: e2mName, Namespace: testNamespace}, current)).To(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(current.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
+			g.Expect(current.Spec.Description).To(BeNil())
+			g.Expect(current.Spec.Query.Spans).ToNot(BeNil())
+			g.Expect(current.Spec.Query.Spans.Lucene).To(BeNil())
+
+			getE2mRes, _, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(getE2mRes.E2m).ToNot(BeNil())
+			if getE2mRes.E2m.Description != nil {
+				g.Expect(*getE2mRes.E2m.Description).To(BeEmpty())
+			}
+			g.Expect(getE2mRes.E2m.SpansQuery).ToNot(BeNil())
+			if getE2mRes.E2m.SpansQuery.Lucene != nil {
+				g.Expect(*getE2mRes.E2m.SpansQuery.Lucene).To(BeEmpty())
+			}
+		}, time.Minute, time.Second).Should(Succeed())
+
+		By("Deleting the E2M")
+		Expect(crClient.Delete(ctx, modified)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := crClient.Get(ctx, types.NamespacedName{Name: e2mName, Namespace: testNamespace}, &coralogixv1alpha1.Events2Metric{})
+			g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+			g.Expect(err).To(HaveOccurred())
+		}, time.Minute, time.Second).Should(Succeed())
+
+		By("Verifying E2M is deleted from Coralogix backend")
+		Eventually(func(g Gomega) {
+			_, httpResp, err := e2mClient.Events2MetricServiceGetE2M(ctx, e2mID).Execute()
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(cxsdk.IsNotFound(cxsdk.NewAPIError(httpResp, err))).To(BeTrue())
+		}, time.Minute, time.Second).Should(Succeed())
 	})
 })


### PR DESCRIPTION
## Summary

Migrate the `Events2Metric` controller from the gRPC SDK client to the OpenAPI REST client. Conversion now builds OpenAPI request models instead of protobuf wrappers. The CRD schema is unchanged.

## Backward compatibility

- Existing `Events2Metric` manifests keep the same fields and values. No CRD breaking change.
- Create/update/delete still go through the shared reconciler. Status `id` and `RemoteSynced` behavior are unchanged.
- Replace presence semantics are unchanged for users:
  - Omitting `description` still clears the remote value. REST omit would keep the old value, so the operator sends `""` on replace (implementation detail only).
  - Omitting `lucene` / `dataSource` / `alias` still clears them remotely.
  - Omitting `permutationsLimit` still omits it on replace; the API still resets the limit to its default (`30000`).

## E2E coverage

- Logs path: create, update (name, description, labels, aggregations), clear optional fields, delete; asserts remote state over REST.
- Spans path: create/update/clear/delete with `samples` and `histogram` aggregations and bucket metadata.
- Unique resource/metric names to avoid account-wide collisions; cleanup via `DeferCleanup`.
- Unit tests cover create/replace request wire shape for logs and spans.
