### PR TITLE
refactor: drop the operator's gRPC dependency

### DIFF
--- a/api/coralogix/v1alpha1/group_types.go
+++ b/api/coralogix/v1alpha1/group_types.go
@@ -94,13 +94,13 @@ type ResourceRef struct {
 
 func (g *Group) ExtractCreateGroupRequest(
 	ctx context.Context,
-	cxClient *cxsdk.ClientSet) (*groups.CreateTeamGroupRequest, error) {
+	usersClient *cxsdk.UsersClient) (*groups.CreateTeamGroupRequest, error) {
 	var groupType *groups.GroupType
 	if g.Spec.GroupType != nil {
 		groupType = groupTypeSchemaToOpenAPI[*g.Spec.GroupType].Ptr()
 	}
 
-	usersIds, err := g.ExtractUsersIDs(ctx, cxClient)
+	usersIds, err := g.ExtractUsersIDs(ctx, usersClient)
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func (g *Group) ExtractCreateGroupRequest(
 }
 
 func (g *Group) ExtractUpdateGroupRequest(
-	ctx context.Context, cxClient *cxsdk.ClientSet) (*groups.UpdateTeamGroupRequest, error) {
+	ctx context.Context, usersClient *cxsdk.UsersClient) (*groups.UpdateTeamGroupRequest, error) {
 	var groupType *groups.GroupType
 	if g.Spec.GroupType != nil {
 		groupType = groupTypeSchemaToOpenAPI[*g.Spec.GroupType].Ptr()
 	}
 
-	usersIds, err := g.ExtractUsersIDs(ctx, cxClient)
+	usersIds, err := g.ExtractUsersIDs(ctx, usersClient)
 	if err != nil {
 		return nil, err
 	}
@@ -180,12 +180,12 @@ func (g *Group) ExtractUpdateGroupRequest(
 	}, nil
 }
 
-func (g *Group) ExtractUsersIDs(ctx context.Context, cxClient *cxsdk.ClientSet) ([]string, error) {
+func (g *Group) ExtractUsersIDs(ctx context.Context, usersClient *cxsdk.UsersClient) ([]string, error) {
 	if g.Spec.Members == nil {
 		return nil, nil
 	}
 
-	users, err := cxClient.Users().List(ctx)
+	users, err := usersClient.List(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "2.4.0"
+const OperatorVersion = "2.5.0"
 
 var (
 	scheme   = k8sruntime.NewScheme()
@@ -132,8 +132,8 @@ func main() {
 	}
 
 	// The SCIM users client is the operator's only remaining consumer of the legacy SDK.
-	// It speaks HTTP (ng-api-http.<domain>/scim/Users), not gRPC, so no gRPC ClientSet
-	// is constructed and the operator never resolves ng-api-grpc.<domain>.
+	// It speaks HTTP (api.<domain>/scim/Users), not gRPC, so no gRPC ClientSet is
+	// constructed and the operator only ever resolves api.<domain>.
 	usersClient := cxsdk.NewUsersClient(cxsdk.NewSDKCallPropertiesCreatorOperator(
 		strings.ToLower(cfg.CoralogixRegionOrDomain),
 		cxsdk.NewAuthContext(cfg.CoralogixApiKey, cfg.CoralogixApiKey),

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -131,8 +131,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	clientSet := cxsdk.NewClientSet(cxsdk.NewSDKCallPropertiesCreatorOperator(
-		strings.ToLower(cfg.CoralogixGrpcUrl),
+	// The SCIM users client is the operator's only remaining consumer of the legacy SDK.
+	// It speaks HTTP (ng-api-http.<domain>/scim/Users), not gRPC, so no gRPC ClientSet
+	// is constructed and the operator never resolves ng-api-grpc.<domain>.
+	usersClient := cxsdk.NewUsersClient(cxsdk.NewSDKCallPropertiesCreatorOperator(
+		strings.ToLower(cfg.CoralogixRegionOrDomain),
 		cxsdk.NewAuthContext(cfg.CoralogixApiKey, cfg.CoralogixApiKey),
 		OperatorVersion))
 
@@ -198,7 +201,7 @@ func main() {
 	}
 	if err = (&v1alpha1controllers.GroupReconciler{
 		GroupsClient: oapiClientSet.Groups(),
-		CXClientSet:  clientSet,
+		UsersClient:  usersClient,
 		Interval:     cfg.ReconcileIntervals[utils.GroupKind],
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Group")
@@ -293,7 +296,7 @@ func main() {
 
 	if err = (&v1alpha1controllers.ArchiveLogsTargetReconciler{
 		ArchiveLogsTargetsClient: oapiClientSet.ArchiveLogs(),
-		ArchiveRetentionsClient:  clientSet.ArchiveRetentions(),
+		ArchiveRetentionsClient:  oapiClientSet.ArchiveRetentions(),
 		Interval:                 cfg.ReconcileIntervals[utils.ArchiveLogsTargetKind],
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ArchiveLogsTarget")
@@ -396,7 +399,7 @@ func main() {
 	monitoring.SetOperatorInfoMetric(
 		runtime.Version(),
 		OperatorVersion,
-		cxsdk.CoralogixGrpcEndpointFromRegion(strings.ToLower(cfg.CoralogixGrpcUrl)),
+		cfg.CoralogixOpenApiUrl,
 	)
 
 	setupLog.Info("starting manager")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.25.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260729141455-fd0f828d882b
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260805125637-c484b4d94209
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.25.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260805125637-c484b4d94209
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260806082810-a572d2709b2a
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260805125637-c484b4d94209 h1:b39LBTWOYI4UHWBx57mS4kc9Cg+30XEtxXrp7cGwOqQ=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260805125637-c484b4d94209/go.mod h1:25jZykZdOnKDW+QCpaE9GiCU0WGOLIXY7ZqbhGJ9AI0=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260806082810-a572d2709b2a h1:ovCwwkhkLl0s66l5Hraju87fiypA9qfLMjqNLarJhY4=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260806082810-a572d2709b2a/go.mod h1:25jZykZdOnKDW+QCpaE9GiCU0WGOLIXY7ZqbhGJ9AI0=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260729141455-fd0f828d882b h1:FooEe+Je4Mxqsy2AHMw0/BXzOKgcfmGOnGNvT8H9/7I=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260729141455-fd0f828d882b/go.mod h1:hC1w7mD+AZhGGw6krKRYEsKst+pYfH6SuUYM001X+tk=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260805125637-c484b4d94209 h1:b39LBTWOYI4UHWBx57mS4kc9Cg+30XEtxXrp7cGwOqQ=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260805125637-c484b4d94209/go.mod h1:25jZykZdOnKDW+QCpaE9GiCU0WGOLIXY7ZqbhGJ9AI0=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,7 @@ var (
 
 type Config struct {
 	CoralogixApiKey             string
-	CoralogixGrpcUrl            string
+	CoralogixRegionOrDomain     string
 	CoralogixOpenApiUrl         string
 	Selector                    Selector
 	ReconcileIntervals          map[string]time.Duration
@@ -101,7 +101,7 @@ func InitConfig(setupLog logr.Logger) *Config {
 		ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 		var err error
-		cfg.CoralogixGrpcUrl, err = getCoralogixGrpcUrl(strings.ToUpper(region), domain)
+		cfg.CoralogixRegionOrDomain, err = getCoralogixRegionOrDomain(strings.ToUpper(region), domain)
 		if err != nil {
 			setupLog.Error(err, "invalid arguments for running operator")
 			os.Exit(1)
@@ -182,7 +182,10 @@ func parseReconcileIntervals(intervals map[string]*string) (map[string]time.Dura
 	return result, nil
 }
 
-func getCoralogixGrpcUrl(region, domain string) (string, error) {
+// getCoralogixRegionOrDomain returns the raw region identifier or custom domain, as
+// provided. The SCIM users client derives its own endpoint from this value; every other
+// client is built from CoralogixOpenApiUrl.
+func getCoralogixRegionOrDomain(region, domain string) (string, error) {
 	if err := validateRegionAndDomain(region, domain); err != nil {
 		return "", err
 	}

--- a/internal/controller/coralogix/v1alpha1/archivelogstarget_controller.go
+++ b/internal/controller/coralogix/v1alpha1/archivelogstarget_controller.go
@@ -23,8 +23,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	cxsdk "github.com/coralogix/coralogix-management-sdk/go"
 	oapicxsdk "github.com/coralogix/coralogix-management-sdk/go/openapi/cxsdk"
+	archiveretentions "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/retentions_service"
 	targets "github.com/coralogix/coralogix-management-sdk/go/openapi/gen/target_service"
 
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
@@ -36,7 +36,7 @@ import (
 // ArchiveLogsTargetReconciler reconciles a ArchiveLogsTarget object
 type ArchiveLogsTargetReconciler struct {
 	ArchiveLogsTargetsClient *targets.TargetServiceAPIService
-	ArchiveRetentionsClient  *cxsdk.ArchiveRetentionsClient
+	ArchiveRetentionsClient  *archiveretentions.RetentionsServiceAPIService
 	Interval                 time.Duration
 }
 
@@ -74,9 +74,9 @@ func (r *ArchiveLogsTargetReconciler) HandleCreation(ctx context.Context, log lo
 	if err != nil {
 		return fmt.Errorf("error on creating remote archivelogstarget: %w", oapicxsdk.NewAPIError(httpResp, err))
 	}
-	_, err = r.ArchiveRetentionsClient.Activate(ctx, &cxsdk.ActivateRetentionsRequest{})
+	_, httpResp, err = r.ArchiveRetentionsClient.RetentionsServiceActivateRetentions(ctx).Execute()
 	if err != nil {
-		return fmt.Errorf("error activating archive retentions: %w", err)
+		return fmt.Errorf("error activating archive retentions: %w", oapicxsdk.NewAPIError(httpResp, err))
 	}
 	log.Info("Remote archivelogstarget created", "response", utils.FormatJSON(createResponse))
 

--- a/internal/controller/coralogix/v1alpha1/group_controller.go
+++ b/internal/controller/coralogix/v1alpha1/group_controller.go
@@ -38,7 +38,7 @@ import (
 // GroupReconciler reconciles a Group object
 type GroupReconciler struct {
 	GroupsClient *groups.TeamGroupsManagementServiceAPIService
-	CXClientSet  *cxsdk.ClientSet
+	UsersClient  *cxsdk.UsersClient
 	Interval     time.Duration
 }
 
@@ -60,7 +60,7 @@ func (r *GroupReconciler) RequeueInterval() time.Duration {
 
 func (r *GroupReconciler) HandleCreation(ctx context.Context, log logr.Logger, obj client.Object) error {
 	group := obj.(*coralogixv1alpha1.Group)
-	createRequest, err := group.ExtractCreateGroupRequest(ctx, r.CXClientSet)
+	createRequest, err := group.ExtractCreateGroupRequest(ctx, r.UsersClient)
 	if err != nil {
 		return fmt.Errorf("error on extracting create request: %w", err)
 	}
@@ -83,7 +83,7 @@ func (r *GroupReconciler) HandleCreation(ctx context.Context, log logr.Logger, o
 
 func (r *GroupReconciler) HandleUpdate(ctx context.Context, log logr.Logger, obj client.Object) error {
 	group := obj.(*coralogixv1alpha1.Group)
-	updateRequest, err := group.ExtractUpdateGroupRequest(ctx, r.CXClientSet)
+	updateRequest, err := group.ExtractUpdateGroupRequest(ctx, r.UsersClient)
 	if err != nil {
 		return fmt.Errorf("error on extracting update request: %w", err)
 	}


### PR DESCRIPTION
## Why

BYOC + FedRAMP tenants behind PrivateLink only have `api.<domain>` published — `ng-api-grpc.<domain>` and `ng-api-http.<domain>` can't be created. The operator derived both from the same `--region`/`--domain` value, so anything on those hosts was unreachable.

After this PR the operator talks to **`api.<domain>` only**.

## Changes

1. **ArchiveLogsTarget → REST.** The last real gRPC call (`cxsdk.ArchiveRetentionsClient.Activate`) now goes through `oapiClientSet.ArchiveRetentions().RetentionsServiceActivateRetentions(...)` — the same REST client TCOLogsPolicies/TCOTracesPolicies already use.
2. **Group → narrow client.** `ClientSet.Users()` was never gRPC (SCIM over HTTP); the controller just held the whole gRPC `ClientSet` to reach it. It now takes a `*cxsdk.UsersClient`, so **no gRPC ClientSet is constructed anywhere** and nobody can reintroduce a gRPC call through it.
3. **SDK bump → coralogix-management-sdk#666** (merged, `a572d270`), which serves SCIM from `api.<domain>` instead of `ng-api-http.<domain>`. This is what removes the last non-`api` host.
4. **Prepare 2.5.0** — `OperatorVersion` bumped to `2.5.0` in `cmd/main.go` (chart intentionally untouched).
5. **Cleanups:** `Config.CoralogixGrpcUrl` → `CoralogixRegionOrDomain` (no user-facing flag/env change — `--region`/`--domain`/`CORALOGIX_REGION`/`CORALOGIX_DOMAIN` all unchanged).
6. ⚠️ **Behavior change:** `operator_info`'s `coralogix_url` label reported the derived gRPC endpoint, which the operator no longer contacts. It now reports `CoralogixOpenApiUrl`. Anything keying on that label value will see it change.

## Verification

`make unit-tests` and `make lint` (0 issues) green. Re-run live against **eu2** on a dedicated kind cluster at this exact commit — 29 controllers started, **zero errors across the whole run**:

- **Archive retentions (the migrated call):** ArchiveLogsTarget create → delete; tenant `isActive` false → true → false, `RemoteSynced`, and zero `error activating archive retentions`. Debug log shows `Creating remote archivelogstarget` → `Remote archivelogstarget created`; the activate call sits between them and returns before status is set, so success implies 2xx.
- **Users / SCIM (now over `api.<domain>`):** Group with `.spec.members` created, updated and deleted. The member resolved on the tenant to `userId 57108c2e-…`, identical to what `api.eu2.coralogix.com/scim/Users` returns for that username.
- **SDK bump is effective:** constructing `NewUsersClient` from the pinned module version (resolved from the proxy, no local replace) yields `https://api.<domain>/scim/Users` for regions, custom domains, and `api.`-prefixed domains alike — re-checked against the merged `a572d270`, whose content is byte-identical to the commit the live run used.
- **Release prep:** `cx_operator_build_info{operator_version="2.5.0", coralogix_url="https://api.eu2.coralogix.com/mgmt/openapi/5"}` — confirms both the version bump and the label change.

Test resources (group, role, scope, archive target) were removed afterwards and verified gone (404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
