### PR TITLE
fix: make `priority` required on TCO policy targets

### DIFF
--- a/api/coralogix/v1alpha1/tcologspolicies_types.go
+++ b/api/coralogix/v1alpha1/tcologspolicies_types.go
@@ -45,7 +45,7 @@ type TCOLogsPolicy struct {
 	Description *string `json:"description,omitempty"`
 
 	// +kubebuilder:validation:Enum=block;high;medium;low
-	// The policy priority. Required when targets is not set, or when targets do not specify their own priorities.
+	// The policy priority. Required when targets is not set. Mutually exclusive with targets, which carry their own per-target priorities.
 	// +optional
 	Priority *string `json:"priority,omitempty"`
 
@@ -126,9 +126,8 @@ type TCOPolicyTarget struct {
 	Dataspace *string `json:"dataspace,omitempty"`
 
 	// +kubebuilder:validation:Enum=block;high;low;medium
-	// +optional
-	// Per-target priority. Mutually exclusive with a policy-level priority.
-	Priority *string `json:"priority,omitempty"`
+	// Per-target priority. Required on every target. Mutually exclusive with the policy-level priority.
+	Priority string `json:"priority"`
 
 	// +optional
 	// Dynamic quota-based priority override for this target.
@@ -303,14 +302,12 @@ func expandTCOPolicyTargets(retentionsByName map[string]string, targets []TCOPol
 			errs = errors.Join(errs, err)
 			continue
 		}
+		priority := PrioritySchemaToOpenAPI[target.Priority]
 		t := tcopolicies.V1Target{
 			Dataset:          &target.Dataset,
 			Dataspace:        target.Dataspace,
+			Priority:         &priority,
 			ArchiveRetention: archiveRetention,
-		}
-		if target.Priority != nil {
-			priority := PrioritySchemaToOpenAPI[*target.Priority]
-			t.Priority = &priority
 		}
 		if target.PriorityOverride != nil {
 			t.PriorityOverride = expandTCOPolicyPriorityOverride(target.PriorityOverride)

--- a/api/coralogix/v1alpha1/tcologspolicies_types.go
+++ b/api/coralogix/v1alpha1/tcologspolicies_types.go
@@ -68,8 +68,8 @@ type TCOLogsPolicy struct {
 	// +optional
 	Subsystems *TCOPolicyRule `json:"subsystems,omitempty"`
 
-	// Targets defines the datasets to route matched data to, each with its own priority.
-	// When set, overrides or supplements the policy-level priority.
+	// Targets defines the datasets to route matched data to, each with its own required priority.
+	// Setting targets requires omitting the policy-level priority; the two are mutually exclusive.
 	// +optional
 	Targets []TCOPolicyTarget `json:"targets,omitempty"`
 }

--- a/api/coralogix/v1alpha1/zz_generated.deepcopy.go
+++ b/api/coralogix/v1alpha1/zz_generated.deepcopy.go
@@ -5466,11 +5466,6 @@ func (in *TCOPolicyTarget) DeepCopyInto(out *TCOPolicyTarget) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Priority != nil {
-		in, out := &in.Priority, &out.Priority
-		*out = new(string)
-		**out = **in
-	}
 	if in.PriorityOverride != nil {
 		in, out := &in.PriorityOverride, &out.PriorityOverride
 		*out = new(TCOPolicyPriorityOverride)

--- a/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
@@ -110,7 +110,8 @@ spec:
                       type: string
                     priority:
                       description: The policy priority. Required when targets is not
-                        set, or when targets do not specify their own priorities.
+                        set. Mutually exclusive with targets, which carry their own
+                        per-target priorities.
                       enum:
                       - block
                       - high
@@ -186,8 +187,8 @@ spec:
                             maxLength: 50
                             type: string
                           priority:
-                            description: Per-target priority. Mutually exclusive with
-                              a policy-level priority.
+                            description: Per-target priority. Required on every target.
+                              Mutually exclusive with the policy-level priority.
                             enum:
                             - block
                             - high
@@ -232,6 +233,7 @@ spec:
                             type: object
                         required:
                         - dataset
+                        - priority
                         type: object
                       type: array
                   required:

--- a/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_tcologspolicies.yaml
@@ -156,8 +156,8 @@ spec:
                       type: object
                     targets:
                       description: |-
-                        Targets defines the datasets to route matched data to, each with its own priority.
-                        When set, overrides or supplements the policy-level priority.
+                        Targets defines the datasets to route matched data to, each with its own required priority.
+                        Setting targets requires omitting the policy-level priority; the two are mutually exclusive.
                       items:
                         description: TCOPolicyTarget defines a dataset destination
                           with its own priority for matched log data.

--- a/config/crd/bases/coralogix.com_tcologspolicies.yaml
+++ b/config/crd/bases/coralogix.com_tcologspolicies.yaml
@@ -155,8 +155,8 @@ spec:
                       type: object
                     targets:
                       description: |-
-                        Targets defines the datasets to route matched data to, each with its own priority.
-                        When set, overrides or supplements the policy-level priority.
+                        Targets defines the datasets to route matched data to, each with its own required priority.
+                        Setting targets requires omitting the policy-level priority; the two are mutually exclusive.
                       items:
                         description: TCOPolicyTarget defines a dataset destination
                           with its own priority for matched log data.

--- a/config/crd/bases/coralogix.com_tcologspolicies.yaml
+++ b/config/crd/bases/coralogix.com_tcologspolicies.yaml
@@ -109,7 +109,8 @@ spec:
                       type: string
                     priority:
                       description: The policy priority. Required when targets is not
-                        set, or when targets do not specify their own priorities.
+                        set. Mutually exclusive with targets, which carry their own
+                        per-target priorities.
                       enum:
                       - block
                       - high
@@ -185,8 +186,8 @@ spec:
                             maxLength: 50
                             type: string
                           priority:
-                            description: Per-target priority. Mutually exclusive with
-                              a policy-level priority.
+                            description: Per-target priority. Required on every target.
+                              Mutually exclusive with the policy-level priority.
                             enum:
                             - block
                             - high
@@ -231,6 +232,7 @@ spec:
                             type: object
                         required:
                         - dataset
+                        - priority
                         type: object
                       type: array
                   required:

--- a/docs/api.md
+++ b/docs/api.md
@@ -10885,7 +10885,7 @@ A TCO policy for logs.
         <td><b>priority</b></td>
         <td>enum</td>
         <td>
-          The policy priority. Required when targets is not set, or when targets do not specify their own priorities.<br/>
+          The policy priority. Required when targets is not set. Mutually exclusive with targets, which carry their own per-target priorities.<br/>
           <br/>
             <i>Enum</i>: block, high, medium, low<br/>
         </td>
@@ -11059,6 +11059,15 @@ TCOPolicyTarget defines a dataset destination with its own priority for matched 
         </td>
         <td>true</td>
       </tr><tr>
+        <td><b>priority</b></td>
+        <td>enum</td>
+        <td>
+          Per-target priority. Required on every target. Mutually exclusive with the policy-level priority.<br/>
+          <br/>
+            <i>Enum</i>: block, high, low, medium<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
         <td><b><a href="#tcologspoliciesspecpoliciesindextargetsindexarchiveretention">archiveRetention</a></b></td>
         <td>object</td>
         <td>
@@ -11070,15 +11079,6 @@ TCOPolicyTarget defines a dataset destination with its own priority for matched 
         <td>string</td>
         <td>
           The dataspace within the dataset.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>priority</b></td>
-        <td>enum</td>
-        <td>
-          Per-target priority. Mutually exclusive with a policy-level priority.<br/>
-          <br/>
-            <i>Enum</i>: block, high, low, medium<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/api.md
+++ b/docs/api.md
@@ -10901,8 +10901,8 @@ A TCO policy for logs.
         <td><b><a href="#tcologspoliciesspecpoliciesindextargetsindex">targets</a></b></td>
         <td>[]object</td>
         <td>
-          Targets defines the datasets to route matched data to, each with its own priority.
-When set, overrides or supplements the policy-level priority.<br/>
+          Targets defines the datasets to route matched data to, each with its own required priority.
+Setting targets requires omitting the policy-level priority; the two are mutually exclusive.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/internal/controller/coralogix/v1alpha1/tcologspolicies_validation_test.go
+++ b/internal/controller/coralogix/v1alpha1/tcologspolicies_validation_test.go
@@ -93,7 +93,7 @@ var _ = Describe("TCOLogsPolicies validation", func() {
 					Severities: []coralogixv1alpha1.TCOPolicySeverity{"info"},
 					Targets: []coralogixv1alpha1.TCOPolicyTarget{{
 						Dataset:  "",
-						Priority: ptr.To("low"),
+						Priority: "low",
 					}},
 				}},
 			},
@@ -115,7 +115,7 @@ var _ = Describe("TCOLogsPolicies validation", func() {
 					Severities: []coralogixv1alpha1.TCOPolicySeverity{"info"},
 					Targets: []coralogixv1alpha1.TCOPolicyTarget{{
 						Dataset:  "myDataset",
-						Priority: ptr.To("low"),
+						Priority: "low",
 					}},
 				}},
 			},
@@ -135,8 +135,8 @@ var _ = Describe("TCOLogsPolicies validation", func() {
 					Name:       "targets-own-priority",
 					Severities: []coralogixv1alpha1.TCOPolicySeverity{"info"},
 					Targets: []coralogixv1alpha1.TCOPolicyTarget{
-						{Dataset: "ds1", Priority: ptr.To("low")},
-						{Dataset: "ds2", Priority: ptr.To("medium")},
+						{Dataset: "ds1", Priority: "low"},
+						{Dataset: "ds2", Priority: "medium"},
 					},
 				}},
 			},
@@ -145,16 +145,15 @@ var _ = Describe("TCOLogsPolicies validation", func() {
 		Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
 	})
 
-	It("should accept a policy with a top-level priority and targets that have no per-target priority", func(ctx context.Context) {
+	It("should reject a target with no priority", func(ctx context.Context) {
 		policy := &coralogixv1alpha1.TCOLogsPolicies{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "top-level-priority-with-targets",
+				Name:      "target-without-priority",
 				Namespace: "default",
 			},
 			Spec: coralogixv1alpha1.TCOLogsPoliciesSpec{
 				Policies: []coralogixv1alpha1.TCOLogsPolicy{{
-					Name:       "inherited-priority",
-					Priority:   ptr.To("low"),
+					Name:       "missing-target-priority",
 					Severities: []coralogixv1alpha1.TCOPolicySeverity{"info"},
 					Targets: []coralogixv1alpha1.TCOPolicyTarget{{
 						Dataset: "myDataset",
@@ -162,8 +161,9 @@ var _ = Describe("TCOLogsPolicies validation", func() {
 				}},
 			},
 		}
-		Expect(k8sClient.Create(ctx, policy)).To(Succeed())
-		Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+		err := k8sClient.Create(ctx, policy)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec.policies[0].targets[0].priority"))
 	})
 
 	// resource.Quantity for DailyQuotaPercentage (supports fractional values)
@@ -179,7 +179,7 @@ var _ = Describe("TCOLogsPolicies validation", func() {
 					Severities: []coralogixv1alpha1.TCOPolicySeverity{"info"},
 					Targets: []coralogixv1alpha1.TCOPolicyTarget{{
 						Dataset:  "myDataset",
-						Priority: ptr.To("low"),
+						Priority: "low",
 						PriorityOverride: &coralogixv1alpha1.TCOPolicyPriorityOverride{
 							QuotaBased: &coralogixv1alpha1.TCOPolicyQuotaBased{
 								UsageTiers: []coralogixv1alpha1.TCOPolicyUsageTier{{

--- a/tests/e2e/tco_logs_policies_test.go
+++ b/tests/e2e/tco_logs_policies_test.go
@@ -129,12 +129,12 @@ var _ = Describe("TCOLogsPolicies", Serial, func() {
 							{
 								Dataset:   "myDataset",
 								Dataspace: ptr.To("default"),
-								Priority:  ptr.To("low"),
+								Priority:  "low",
 							},
 							{
 								Dataset:   "myDataset2",
 								Dataspace: ptr.To("default"),
-								Priority:  ptr.To("medium"),
+								Priority:  "medium",
 							},
 						},
 					},


### PR DESCRIPTION
## What

Makes `priority` required on every `TCOLogsPolicies` target.

Follow-up to #545 (CX-51353), which modelled `TCOPolicyTarget.Priority` as optional (`*string`, `+optional`) on the assumption that a priority-less target would inherit the policy-level priority. Based on our feedback, the backend has changed and now rejects that shape.

**Not a breaking change** — targets support has not been released yet.

## Why — live API verification

Probed against EU2 (`PUT /dataplans/log-policies/v1`). Every probe was cleaned up afterwards; the tenant was restored to `{"policies":[]}`.

| Request | Result |
|---|---|
| policy `priority: MEDIUM` + target with no `priority` | **400** `Target "logs": a priority is required on every target.` |
| target `priority: PRIORITY_TYPE_UNSPECIFIED` | **400** same error — `UNSPECIFIED` counts as unset |
| target with only `priorityOverride`, no `priority` | **400** same error — an override does **not** satisfy it |
| 2 targets, one missing `priority` | **400** `Target "logs2": a priority is required on every target.` |
| policy priority omitted **or** `UNSPECIFIED` + every target priced | **200** ✅ |
| policy `priority` set, no targets | **200** ✅ |
| no priority anywhere | **400** `A priority is required: set the policy priority (or a quota-based priority override), or provide targets that each specify a priority.` |
| target with both `priority` and `priorityOverride` | **200** ✅ — these two are *not* mutually exclusive at target level |

## Changes

- `TCOPolicyTarget.Priority`: `*string` + `+optional` → required `string`.
- `expandTCOPolicyTargets` maps the priority unconditionally instead of behind a nil guard, matching how the already-required `TCOPolicyUsageTier.Priority` is handled.
- Policy-level `Priority` doc comment corrected — it no longer claims targets can inherit it.
- Regenerated: DeepCopy, `config/crd/bases`, `docs/api.md`, and the Helm chart CRD (synced by hand; `diff` against the base shows only the two `{{- if .Values.crds.create }}` guard lines). `priority` now joins `dataset` in `targets[].required`.
- The unit test asserting *"policy priority + priority-less targets is accepted"* becomes a rejection test — that combination is now always a 400, per the mutual-exclusion rule above.
- `config/samples/.../example-tco-logs-policies.yaml` needed no change; it already prices every target.

## Scope note

The backend enforces a **second** rule: policy-level and per-target priority are mutually exclusive. This PR deliberately does **not** add CEL admission validation for it — violations reach the API and surface as `RemoteSynced=False` with the backend message. Happy to add the guard in a follow-up if we'd rather fail at admission time.

## Testing

- `make unit-tests` — all packages pass. The v1alpha1 envtest suite ran 49/49; verified the new rejection spec actually executes rather than passing vacuously.
- `make lint` — 0 issues. `go vet ./api/... ./internal/... ./tests/...` clean.
- Live end-to-end against EU2: replayed the full sample YAML exactly as the updated `extractCreateLogPolicyRequest` serialises it (all four policies, archive-retention IDs resolved). HTTP 200, and `fourth policy with targets` came back with `myDataset/LOW` and `archiveDataset/LOW` + quota override. Tenant cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
