### PR TITLE
fix: restrict GITHUB_TOKEN permissions in workflows (11 code scanning alerts) + bump Go to 1.26

### DIFF
--- a/.github/actions/build-operator-image/action.yml
+++ b/.github/actions/build-operator-image/action.yml
@@ -14,8 +14,8 @@ runs:
   using: composite
   steps:
     # The released image builds inside the `golang:` tag in Dockerfile, so read the version from
-    # there rather than from go.mod. go.mod's `go` directive is the module's *minimum* (1.24.0),
-    # which is not what ships: `golang:1.24` resolves to the newest 1.24.x. Taking go.mod at face
+    # there rather than from go.mod. go.mod's `go` directive is the module's *minimum* (1.26.0),
+    # which is not what ships: `golang:1.26` resolves to the newest 1.26.x. Taking go.mod at face
     # value would have CI compile the tested binary with an older patch release than the one the
     # released binary is built with.
     - name: Resolve the Go version the released image is built with

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -14,6 +14,11 @@ on:
     paths-ignore:
       - "charts/**"
 
+# The image is pushed to DockerHub with credentials from secrets.*, never to GHCR, so the
+# workflow token only ever needs to read the repo.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,6 +17,9 @@ on:
       - "docs/**"
       - "**.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in

--- a/.github/workflows/helm-chart-deploy.yml
+++ b/.github/workflows/helm-chart-deploy.yml
@@ -8,6 +8,11 @@ on:
     paths:
       - charts/coralogix-operator/Chart.yaml
 
+# The chart is uploaded to Artifactory with credentials from secrets.*, so the workflow token
+# only ever needs to read the repo.
+permissions:
+  contents: read
+
 env:
   CHART_VERSION: $(yq eval '.version' charts/coralogix-operator/Chart.yaml)
   CHART_NAME: coralogix-operator

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -16,6 +16,9 @@ on:
       - "docs/**"
       - "**.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in

--- a/.github/workflows/helm-sync-check.yaml
+++ b/.github/workflows/helm-sync-check.yaml
@@ -9,6 +9,9 @@ on:
       - main
       - release-*
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/helm-update.yaml
+++ b/.github/workflows/helm-update.yaml
@@ -4,6 +4,12 @@ on:
     tags:
       - "v*"
 
+# peter-evans/create-pull-request pushes the version-bump branch and opens the PR with
+# secrets.GITHUB_TOKEN.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-chart-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -17,6 +17,9 @@ on:
       - "docs/**"
       - "**.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,6 +14,9 @@ on:
     paths-ignore:
       - "charts/**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,6 +12,14 @@ on:
     paths-ignore:
       - "charts/**"
 
+permissions:
+  # seriousben/go-patch-cover-action needs both, one per event type:
+  #   push: its "Save Coverage" step runs `git push origin refs/notes/coverage` to persist the
+  #         coverage baseline that PR runs later diff against.
+  #   pull_request: it creates/updates the patch-coverage comment via the GraphQL API.
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -17,6 +17,9 @@ on:
       - "docs/**"
       - "**.md"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # multi-platform build cross-compiles via GOARCH instead of running the whole Go toolchain
 # under QEMU emulation for each non-native target. The final stage only copies a file, so no
 # emulation is needed there either.
-FROM --platform=${BUILDPLATFORM} golang:1.25 AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coralogix/coralogix-operator/v2
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260806082810-a572d2709b2a


### PR DESCRIPTION
Closes all 11 open code-scanning alerts, which were the same rule — `actions/missing-workflow-permissions`. None of these 10 workflows declared a `permissions` block, so every job ran with the default read/**write** `GITHUB_TOKEN`, including test-only jobs.

Most get `contents: read`. Two genuinely need write, verified against real runs:

- **`unit-tests`** — `go-patch-cover-action` pushes `refs/notes/coverage` on push and comments on PRs. One job serves both events, and permissions can't be event-conditional, so it takes the union.
- **`helm-update`** — `create-pull-request` pushes a branch and opens the PR with `secrets.GITHUB_TOKEN`.

Second commit bumps **Go 1.25 → 1.26** (`go.mod` + `Dockerfile`). 

`actionlint` reports the same findings before and after; `make unit-tests` and lint pass on go1.26.3 with no generated-file drift.

One thing to check before un-drafting: **the go-patch-cover comment should still appear on this PR** — that's the live test of `pull-requests: write`. The push path only runs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
