### PR TITLE
ci(acceptance-tests): alert Slack when operator tests fail

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -77,3 +77,66 @@ jobs:
         if: always()
         run: |
           scripts/collect-logs.sh
+
+  notify-failure:
+    name: Notify Slack on failure
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    needs:
+      - tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        env:
+          # Slack incoming webhook URL, from the SLACK_CI_WEBHOOK_URL repository secret.
+          # Keep the URL out of both the logs and the process list.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_WEBHOOK_URL }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "::warning::SLACK_CI_WEBHOOK_URL is not set; skipping the Slack notification."
+            exit 0
+          fi
+          umask 077
+          curl_config="$(mktemp)"
+          trap 'rm -f "$curl_config"' EXIT
+          printf 'url = "%s"\n' "$SLACK_WEBHOOK_URL" > "$curl_config"
+          failed_jobs=$(printf '%s' "$NEEDS_JSON" | jq -r '
+            to_entries
+            | map(select(.value.result != "success"))
+            | map("• \(.key): \(.value.result)")
+            | join("\n")
+          ')
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg ref "$REF_NAME" \
+            --arg event "$EVENT_NAME" \
+            --arg url "$RUN_URL" \
+            --arg jobs "$failed_jobs" \
+            '{
+              text: ":rotating_light: Acceptance tests failed",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ":rotating_light: *Acceptance tests failed*\n*Repository:* \($repo)\n*Ref:* \($ref)\n*Trigger:* \($event)\n*Failed jobs:*\n\($jobs)\n<\($url)|View the workflow run>"
+                  }
+                }
+              ]
+            }' \
+            | curl --config "$curl_config" \
+                --fail --silent --show-error \
+                --max-time 30 --retry 3 --retry-connrefused \
+                --header 'Content-Type: application/json' \
+                --data @- \
+                --output /dev/null \
+                --write-out 'Slack responded with HTTP %{http_code}\n'

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -86,3 +86,66 @@ jobs:
         if: always()
         run: |
           scripts/collect-logs.sh
+
+  notify-failure:
+    name: Notify Slack on failure
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    needs:
+      - tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        env:
+          # Slack incoming webhook URL, from the SLACK_CI_WEBHOOK_URL repository secret.
+          # Keep the URL out of both the logs and the process list.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_WEBHOOK_URL }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "::warning::SLACK_CI_WEBHOOK_URL is not set; skipping the Slack notification."
+            exit 0
+          fi
+          umask 077
+          curl_config="$(mktemp)"
+          trap 'rm -f "$curl_config"' EXIT
+          printf 'url = "%s"\n' "$SLACK_WEBHOOK_URL" > "$curl_config"
+          failed_jobs=$(printf '%s' "$NEEDS_JSON" | jq -r '
+            to_entries
+            | map(select(.value.result != "success"))
+            | map("• \(.key): \(.value.result)")
+            | join("\n")
+          ')
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg ref "$REF_NAME" \
+            --arg event "$EVENT_NAME" \
+            --arg url "$RUN_URL" \
+            --arg jobs "$failed_jobs" \
+            '{
+              text: ":rotating_light: Acceptance tests failed",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ":rotating_light: *Acceptance tests failed*\n*Repository:* \($repo)\n*Ref:* \($ref)\n*Trigger:* \($event)\n*Failed jobs:*\n\($jobs)\n<\($url)|View the workflow run>"
+                  }
+                }
+              ]
+            }' \
+            | curl --config "$curl_config" \
+                --fail --silent --show-error \
+                --max-time 30 --retry 3 --retry-connrefused \
+                --header 'Content-Type: application/json' \
+                --data @- \
+                --output /dev/null \
+                --write-out 'Slack responded with HTTP %{http_code}\n'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -67,3 +67,66 @@ jobs:
         if: always()
         run: |
           scripts/collect-logs.sh
+
+  notify-failure:
+    name: Notify Slack on failure
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    needs:
+      - tests
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        env:
+          # Slack incoming webhook URL, from the SLACK_CI_WEBHOOK_URL repository secret.
+          # Keep the URL out of both the logs and the process list.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_WEBHOOK_URL }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "::warning::SLACK_CI_WEBHOOK_URL is not set; skipping the Slack notification."
+            exit 0
+          fi
+          umask 077
+          curl_config="$(mktemp)"
+          trap 'rm -f "$curl_config"' EXIT
+          printf 'url = "%s"\n' "$SLACK_WEBHOOK_URL" > "$curl_config"
+          failed_jobs=$(printf '%s' "$NEEDS_JSON" | jq -r '
+            to_entries
+            | map(select(.value.result != "success"))
+            | map("• \(.key): \(.value.result)")
+            | join("\n")
+          ')
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg ref "$REF_NAME" \
+            --arg event "$EVENT_NAME" \
+            --arg url "$RUN_URL" \
+            --arg jobs "$failed_jobs" \
+            '{
+              text: ":rotating_light: Acceptance tests failed",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ":rotating_light: *Acceptance tests failed*\n*Repository:* \($repo)\n*Ref:* \($ref)\n*Trigger:* \($event)\n*Failed jobs:*\n\($jobs)\n<\($url)|View the workflow run>"
+                  }
+                }
+              ]
+            }' \
+            | curl --config "$curl_config" \
+                --fail --silent --show-error \
+                --max-time 30 --retry 3 --retry-connrefused \
+                --header 'Content-Type: application/json' \
+                --data @- \
+                --output /dev/null \
+                --write-out 'Slack responded with HTTP %{http_code}\n'

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -101,3 +101,66 @@ jobs:
         if: always()
         run: |
           scripts/collect-logs.sh
+
+  notify-failure:
+    name: Notify Slack on failure
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    needs:
+      - upgrade-test
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        env:
+          # Slack incoming webhook URL, from the SLACK_CI_WEBHOOK_URL repository secret.
+          # Keep the URL out of both the logs and the process list.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CI_WEBHOOK_URL }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+            echo "::warning::SLACK_CI_WEBHOOK_URL is not set; skipping the Slack notification."
+            exit 0
+          fi
+          umask 077
+          curl_config="$(mktemp)"
+          trap 'rm -f "$curl_config"' EXIT
+          printf 'url = "%s"\n' "$SLACK_WEBHOOK_URL" > "$curl_config"
+          failed_jobs=$(printf '%s' "$NEEDS_JSON" | jq -r '
+            to_entries
+            | map(select(.value.result != "success"))
+            | map("• \(.key): \(.value.result)")
+            | join("\n")
+          ')
+          jq -n \
+            --arg repo "$REPOSITORY" \
+            --arg ref "$REF_NAME" \
+            --arg event "$EVENT_NAME" \
+            --arg url "$RUN_URL" \
+            --arg jobs "$failed_jobs" \
+            '{
+              text: ":rotating_light: Acceptance tests failed",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ":rotating_light: *Acceptance tests failed*\n*Repository:* \($repo)\n*Ref:* \($ref)\n*Trigger:* \($event)\n*Failed jobs:*\n\($jobs)\n<\($url)|View the workflow run>"
+                  }
+                }
+              ]
+            }' \
+            | curl --config "$curl_config" \
+                --fail --silent --show-error \
+                --max-time 30 --retry 3 --retry-connrefused \
+                --header 'Content-Type: application/json' \
+                --data @- \
+                --output /dev/null \
+                --write-out 'Slack responded with HTTP %{http_code}\n'


### PR DESCRIPTION
### Description

Nightly acceptance test failures were silent. You only found them by opening the Actions tab.

This adds a `notify-failure` job to the operator's four scheduled acceptance-test workflows:

- `e2e-tests`
- `helm-e2e-tests`
- `integration-tests`
- `upgrade-test`

If a test job fails or is cancelled, the workflow posts to Slack. It alerts on nightly runs and pushes to `main` or `release-*`. Pull requests stay quiet.

The webhook URL is not in this repo. It comes from a new `SLACK_CI_WEBHOOK_URL` repository secret. `curl` reads it from a `0600` temporary config file, so it stays out of the Actions log and process list. If the secret is missing, the step warns and passes.

### Validation

- Parsed all four workflow files as YAML.
- Ran `git diff --check`.
- Pre-commit secret scan passed.