### PR TITLE
chore: prepare 2.6.0 release

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "2.5.0"
+const OperatorVersion = "2.6.0"
 
 var (
 	scheme   = k8sruntime.NewScheme()


### PR DESCRIPTION
Bumps the operator version string from `2.5.0` to `2.6.0` in `cmd/main.go` to prepare the 2.6.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)