### PR TITLE
Stabilize GlobalRouter update test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,10 @@ Use focused unit/envtest coverage for controller behavior, validation, status tr
 
 Use KUTTL or e2e coverage when Kubernetes wiring, CRDs, Helm packaging, or real API behavior is part of the risk.
 
+When a test reads a remote resource, do not depend on the order of items inside a returned list. The API can return
+list elements in any order. Assert on a set or find the element by an identifying field, instead of indexing a fixed
+position.
+
 Before finishing code changes, prefer:
 
 ```bash

--- a/tests/e2e/global_router_test.go
+++ b/tests/e2e/global_router_test.go
@@ -94,11 +94,28 @@ var _ = Describe("GlobalRouter", Ordered, Serial, func() {
 		Expect(crClient.Patch(ctx, modifiedRouter, client.MergeFrom(globalRouter))).To(Succeed())
 
 		By("Verifying GlobalRouter is updated in Coralogix backend")
-		Eventually(func() string {
+		// The backend does not promise to return the rules in spec order, so collect the names and
+		// compare them as a set instead of reading Rules[0]. The expected set comes from the patched
+		// spec, so it also proves the other rules are kept.
+		expectedRuleNames := make([]string, 0, len(modifiedRouter.Spec.Rules))
+		for _, rule := range modifiedRouter.Spec.Rules {
+			expectedRuleNames = append(expectedRuleNames, rule.Name)
+		}
+
+		Eventually(func() ([]string, error) {
 			getRes, err := notificationsClient.GetGlobalRouter(ctx, &cxsdk.GetGlobalRouterRequest{Id: globalRouterID})
-			Expect(err).ToNot(HaveOccurred())
-			return *getRes.GetRouter().Rules[0].Name
-		}, time.Minute, time.Second).Should(Equal(newRuleName))
+			if err != nil {
+				return nil, err
+			}
+			if getRes.GetRouter() == nil {
+				return nil, nil
+			}
+			var ruleNames []string
+			for _, rule := range getRes.GetRouter().Rules {
+				ruleNames = append(ruleNames, ptr.Deref(rule.Name, ""))
+			}
+			return ruleNames, nil
+		}, time.Minute, time.Second).Should(ConsistOf(expectedRuleNames))
 	})
 
 	It("Should be deleted successfully", func(ctx context.Context) {


### PR DESCRIPTION
## The problem

The GlobalRouter fixture has two rules: `first-rule` and `second-rule`.

The test renamed rule number 1, then checked only the first rule in the API answer:

```go
*getRes.GetRouter().Rules[0].Name   // the FIRST rule in the API answer
```

This assumes the first rule in the answer is the rule that was renamed. That is not safe. The API can return the rules in any order.

Most runs the order matched, and the test passed:

```
Rules[0] = updated-rule-1787156517732479919   pass
Rules[1] = second-rule
```

The failing run had the other order:

```
Rules[0] = second-rule                        fail
Rules[1] = updated-rule-1787156517732479919
```

The rename worked. The new name was there, in slot 1. The test kept reading slot 0 for 60 seconds and timed out.

## The fix

Read every rule name and compare the whole group, so the order does not matter:

```go
Should(ConsistOf(expectedRuleNames))   // same members, any order
```

The expected names come from the spec that was just patched. So the check also proves the other rules are kept.

Two smaller repairs in the same block:

- API errors now go back to `Eventually`, so a short network problem retries instead of failing the run.
- The test checks for a nil router and a nil name before reading them, so a partial answer cannot panic.

## AGENTS.md

Added the general rule: a test must not depend on the order of items in a list returned by the API. Assert on a set, or find the element by an identifying field.

## Testing

`go vet ./tests/e2e/` and `gofmt -l` are clean. The e2e suite needs a cluster and real Coralogix access, so it was not run locally. The spec to run is `GlobalRouter Should be updated successfully`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)