### PR TITLE
feat: add eventBridge Notification Center connector type (CX-54943)

### DIFF
--- a/api/coralogix/v1alpha1/connector_types.go
+++ b/api/coralogix/v1alpha1/connector_types.go
@@ -36,8 +36,8 @@ type ConnectorSpec struct {
 	// Description is the description of the connector.
 	Description string `json:"description"`
 
-	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, or microsoftTeams.
-	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;serviceNow;microsoftTeams
+	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.
+	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;serviceNow;microsoftTeams;eventBridge
 	Type string `json:"type"`
 
 	// ConnectorConfig is the configuration of the connector.
@@ -127,6 +127,7 @@ var (
 		"email":              connectors.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
 		"serviceNow":         connectors.NOTIFICATIONCENTERCONNECTORTYPE_SERVICE_NOW,
 		"microsoftTeams":     connectors.NOTIFICATIONCENTERCONNECTORTYPE_MICROSOFT_TEAMS,
+		"eventBridge":        connectors.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE,
 	}
 	schemaToOpenApiEntityType = map[string]connectors.NotificationCenterEntityType{
 		"alerts": connectors.NOTIFICATIONCENTERENTITYTYPE_ALERTS,

--- a/api/coralogix/v1alpha1/notification_center_gaps_test.go
+++ b/api/coralogix/v1alpha1/notification_center_gaps_test.go
@@ -161,6 +161,52 @@ func TestConnectorExtractMicrosoftTeams(t *testing.T) {
 	}
 }
 
+func TestConnectorExtractEventBridge(t *testing.T) {
+	value := "integration-id"
+	connector := &Connector{
+		Spec: ConnectorSpec{
+			Name:        "c",
+			Description: "d",
+			Type:        "eventBridge",
+			ConnectorConfig: ConnectorConfig{
+				Fields: []ConnectorConfigField{
+					{FieldName: "integrationId", Value: &value},
+				},
+			},
+		},
+	}
+
+	got, err := connector.ExtractConnector(context.Background())
+	if err != nil {
+		t.Fatalf("ExtractConnector returned error: %v", err)
+	}
+	if got.Type == nil || *got.Type != connectors.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE {
+		t.Fatalf("Type = %v, want EVENTBRIDGE", got.Type)
+	}
+}
+
+func TestPresetExtractEventBridge(t *testing.T) {
+	preset := &Preset{
+		Spec: PresetSpec{
+			Name:          "p",
+			Description:   "d",
+			ConnectorType: "eventBridge",
+			EntityType:    "cases",
+		},
+	}
+
+	got, err := preset.ExtractPreset()
+	if err != nil {
+		t.Fatalf("ExtractPreset returned error: %v", err)
+	}
+	if got.ConnectorType == nil || *got.ConnectorType != presets.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE {
+		t.Fatalf("ConnectorType = %v, want EVENTBRIDGE", got.ConnectorType)
+	}
+	if got.EntityType == nil || *got.EntityType != presets.NOTIFICATIONCENTERENTITYTYPE_CASES {
+		t.Fatalf("EntityType = %v, want CASES", got.EntityType)
+	}
+}
+
 // GlobalRouter supports disabled, fallbackTargets, and CASES routing-rule entity type.
 func TestGlobalRouterExtractDisabledFallbackTargetsAndCases(t *testing.T) {
 	disabled := true

--- a/api/coralogix/v1alpha1/preset_types.go
+++ b/api/coralogix/v1alpha1/preset_types.go
@@ -36,8 +36,8 @@ type PresetSpec struct {
 	// +optional
 	ParentId *string `json:"parentId,omitempty"`
 
-	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, or microsoftTeams.
-	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;microsoftTeams
+	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.
+	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;microsoftTeams;eventBridge
 	ConnectorType string `json:"connectorType"`
 
 	// EntityType is the entity type for the preset. Can be one of alerts or cases.
@@ -137,6 +137,7 @@ var (
 		"pagerDutyIncidents": presets.NOTIFICATIONCENTERCONNECTORTYPE_PAGERDUTY_INCIDENTS,
 		"email":              presets.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
 		"microsoftTeams":     presets.NOTIFICATIONCENTERCONNECTORTYPE_MICROSOFT_TEAMS,
+		"eventBridge":        presets.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE,
 	}
 	schemaToOpenApiPresetsEntityType = map[string]presets.NotificationCenterEntityType{
 		"alerts": presets.NOTIFICATIONCENTERENTITYTYPE_ALERTS,

--- a/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
@@ -150,7 +150,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  or microsoftTeams.
+                  microsoftTeams, or eventBridge.
                 enum:
                 - slack
                 - genericHttps
@@ -159,6 +159,7 @@ spec:
                 - email
                 - serviceNow
                 - microsoftTeams
+                - eventBridge
                 type: string
             required:
             - connectorConfig

--- a/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
@@ -123,8 +123,8 @@ spec:
                 type: array
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
-                  of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, or
-                  microsoftTeams.
+                  of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
+                  or eventBridge.
                 enum:
                 - slack
                 - genericHttps
@@ -132,6 +132,7 @@ spec:
                 - pagerDutyIncidents
                 - email
                 - microsoftTeams
+                - eventBridge
                 type: string
               description:
                 description: Description is the description of the preset.

--- a/config/crd/bases/coralogix.com_connectors.yaml
+++ b/config/crd/bases/coralogix.com_connectors.yaml
@@ -149,7 +149,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  or microsoftTeams.
+                  microsoftTeams, or eventBridge.
                 enum:
                 - slack
                 - genericHttps
@@ -158,6 +158,7 @@ spec:
                 - email
                 - serviceNow
                 - microsoftTeams
+                - eventBridge
                 type: string
             required:
             - connectorConfig

--- a/config/crd/bases/coralogix.com_presets.yaml
+++ b/config/crd/bases/coralogix.com_presets.yaml
@@ -122,8 +122,8 @@ spec:
                 type: array
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
-                  of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, or
-                  microsoftTeams.
+                  of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
+                  or eventBridge.
                 enum:
                 - slack
                 - genericHttps
@@ -131,6 +131,7 @@ spec:
                 - pagerDutyIncidents
                 - email
                 - microsoftTeams
+                - eventBridge
                 type: string
               description:
                 description: Description is the description of the preset.

--- a/config/samples/v1alpha1/connectors/eventbridge.yaml
+++ b/config/samples/v1alpha1/connectors/eventbridge.yaml
@@ -1,0 +1,18 @@
+apiVersion: coralogix.com/v1alpha1
+kind: Connector
+metadata:
+  labels:
+    app.kubernetes.io/name: coralogix-operator
+    app.kubernetes.io/instance: connector-sample
+    app.kubernetes.io/part-of: coralogix-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: coralogix-operator
+  name: eventbridge-sample
+spec:
+  name: eventbridge-sample
+  description: This is a sample EventBridge connector
+  type: eventBridge
+  connectorConfig:
+    fields:
+      - fieldName: integrationId
+        value: some-integration-id

--- a/docs/api.md
+++ b/docs/api.md
@@ -10173,9 +10173,9 @@ See also https://coralogix.com/docs/user-guides/notification-center/introduction
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, or microsoftTeams.<br/>
+          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.<br/>
           <br/>
-            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams<br/>
+            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -15645,9 +15645,9 @@ PresetSpec defines the desired state of Preset.
         <td><b>connectorType</b></td>
         <td>enum</td>
         <td>
-          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, or microsoftTeams.<br/>
+          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.<br/>
           <br/>
-            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams<br/>
+            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge<br/>
         </td>
         <td>true</td>
       </tr><tr>

--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -42,6 +42,7 @@ var pagerDutyIntegrationId = os.Getenv("PD_INTEGRATION_ID")
 var msTeamsIntegrationId = os.Getenv("MS_TEAMS_INTEGRATION_ID")
 var msTeamsTeamId = os.Getenv("MS_TEAMS_TEAM_ID")
 var msTeamsChannelId = os.Getenv("MS_TEAMS_CHANNEL_ID")
+var eventbridgeIntegrationId = os.Getenv("EVENTBRIDGE_INTEGRATION_ID")
 
 var _ = Describe("Connector", Ordered, func() {
 	var (
@@ -362,6 +363,55 @@ var _ = Describe("Connector MicrosoftTeams", Ordered, func() {
 	})
 })
 
+var _ = Describe("Connector EventBridge", Ordered, func() {
+	var (
+		crClient            client.Client
+		notificationsClient *cxsdk.NotificationsClient
+		connectorID         string
+		connector           *coralogixv1alpha1.Connector
+		connectorName       string
+	)
+
+	BeforeAll(func() {
+		if eventbridgeIntegrationId == "" {
+			Skip("set EVENTBRIDGE_INTEGRATION_ID to run this spec locally")
+		}
+		crClient = ClientsInstance.GetControllerRuntimeClient()
+		notificationsClient = ClientsInstance.GetCoralogixClientSet().Notifications()
+	})
+
+	It("Should be created successfully", func(ctx context.Context) {
+		connectorName = fmt.Sprintf("eventbridge-connector-%d", time.Now().Unix())
+		connector = getSampleEventBridgeConnector(connectorName, testNamespace)
+		Expect(crClient.Create(ctx, connector)).To(Succeed())
+
+		Eventually(func(g Gomega) error {
+			fetched := &coralogixv1alpha1.Connector{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: connectorName, Namespace: testNamespace}, fetched)).To(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(fetched.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
+			g.Expect(fetched.Status.PrintableStatus).To(Equal("RemoteSynced"))
+			if fetched.Status.Id != nil {
+				connectorID = *fetched.Status.Id
+				return nil
+			}
+			return fmt.Errorf("connector ID is not set")
+		}, time.Minute, time.Second).Should(Succeed())
+
+		Eventually(func() error {
+			_, err := notificationsClient.GetConnector(ctx, &cxsdk.GetConnectorRequest{Id: connectorID})
+			return err
+		}, time.Minute, time.Second).Should(Succeed())
+	})
+
+	It("Should be deleted successfully", func(ctx context.Context) {
+		Expect(crClient.Delete(ctx, connector)).To(Succeed())
+		Eventually(func() codes.Code {
+			_, err := notificationsClient.GetConnector(ctx, &cxsdk.GetConnectorRequest{Id: connectorID})
+			return cxsdk.Code(err)
+		}, time.Minute, time.Second).Should(Equal(codes.NotFound))
+	})
+})
+
 // NC gap field: CASES config-override entity type.
 var _ = Describe("Connector with CASES config override", Ordered, func() {
 	var (
@@ -438,6 +488,22 @@ func getSampleMicrosoftTeamsConnector(name, namespace string) *coralogixv1alpha1
 					{FieldName: "integrationId", Value: ptr.To(msTeamsIntegrationId)},
 					{FieldName: "teamId", Value: ptr.To(msTeamsTeamId)},
 					{FieldName: "channelId", Value: ptr.To(msTeamsChannelId)},
+				},
+			},
+		},
+	}
+}
+
+func getSampleEventBridgeConnector(name, namespace string) *coralogixv1alpha1.Connector {
+	return &coralogixv1alpha1.Connector{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: coralogixv1alpha1.ConnectorSpec{
+			Name:        name,
+			Description: "EventBridge connector",
+			Type:        "eventBridge",
+			ConnectorConfig: coralogixv1alpha1.ConnectorConfig{
+				Fields: []coralogixv1alpha1.ConnectorConfigField{
+					{FieldName: "integrationId", Value: ptr.To(eventbridgeIntegrationId)},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- Add Notification Center `eventBridge` to Connector and Preset CRD enums/maps (`EVENTBRIDGE` in the SDK).
- This is the NC connector, **not** the legacy `OutboundWebhook.spec.awsEventBridge`.
- Connector config is the existing generic `{type, connectorConfig.fields[]}` shape. User-supplied field: `integrationId` only.
- Limited availability: staging and dedicated environments with the EventBridge IAM connector flag.

No SDK bump. No controller Go changes.

## Test plan
- [x] `make manifests && make helm-update-crds && make generate-api-docs && make helm-sync-check`
- [x] `go test ./api/coralogix/v1alpha1` (`TestConnectorExtractEventBridge`, `TestPresetExtractEventBridge`)
- [ ] `make lint` — skipped locally: golangci-lint was built with Go 1.25, repo targets Go 1.26.0
- [ ] `make unit-tests` — controller tests passed; `make unit-tests` then failed with `go: no such tool "covdata"` (toolchain)
- [ ] Live e2e `Describe("Connector EventBridge")` gated on `EVENTBRIDGE_INTEGRATION_ID`

[CX-54943](https://coralogix.atlassian.net/browse/CX-54943)

**Sibling PRs**
- Terraform provider: https://github.com/coralogix/terraform-provider-coralogix/pull/660
- VAC: https://github.com/coralogix/eng-svc-view-as-code/pull/109
- mgmt-mcp: https://github.com/coralogix/mgmt-mcp/pull/117

[CX-54943]: https://coralogix.atlassian.net/browse/CX-54943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ