### PR TITLE
feat: add incidentIo Notification Center connector type (CX-55144)

### DIFF
--- a/api/coralogix/v1alpha1/connector_types.go
+++ b/api/coralogix/v1alpha1/connector_types.go
@@ -36,7 +36,7 @@ type ConnectorSpec struct {
 	// Description is the description of the connector.
 	Description string `json:"description"`
 
-	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.
+	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo.
 	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;serviceNow;microsoftTeams;eventBridge;incidentIo
 	Type string `json:"type"`
 

--- a/api/coralogix/v1alpha1/connector_types.go
+++ b/api/coralogix/v1alpha1/connector_types.go
@@ -36,8 +36,8 @@ type ConnectorSpec struct {
 	// Description is the description of the connector.
 	Description string `json:"description"`
 
-	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.
-	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;serviceNow;microsoftTeams;eventBridge
+	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo.
+	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;serviceNow;microsoftTeams;eventBridge;incidentIo
 	Type string `json:"type"`
 
 	// ConnectorConfig is the configuration of the connector.
@@ -128,6 +128,7 @@ var (
 		"serviceNow":         connectors.NOTIFICATIONCENTERCONNECTORTYPE_SERVICE_NOW,
 		"microsoftTeams":     connectors.NOTIFICATIONCENTERCONNECTORTYPE_MICROSOFT_TEAMS,
 		"eventBridge":        connectors.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE,
+		"incidentIo":         connectors.NotificationCenterConnectorType("INCIDENT_IO"),
 	}
 	schemaToOpenApiEntityType = map[string]connectors.NotificationCenterEntityType{
 		"alerts": connectors.NOTIFICATIONCENTERENTITYTYPE_ALERTS,

--- a/api/coralogix/v1alpha1/connector_types.go
+++ b/api/coralogix/v1alpha1/connector_types.go
@@ -36,7 +36,7 @@ type ConnectorSpec struct {
 	// Description is the description of the connector.
 	Description string `json:"description"`
 
-	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo.
+	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.
 	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;serviceNow;microsoftTeams;eventBridge;incidentIo
 	Type string `json:"type"`
 

--- a/api/coralogix/v1alpha1/connector_types.go
+++ b/api/coralogix/v1alpha1/connector_types.go
@@ -36,7 +36,7 @@ type ConnectorSpec struct {
 	// Description is the description of the connector.
 	Description string `json:"description"`
 
-	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo.
+	// Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo (preview).
 	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;serviceNow;microsoftTeams;eventBridge;incidentIo
 	Type string `json:"type"`
 

--- a/api/coralogix/v1alpha1/connector_types.go
+++ b/api/coralogix/v1alpha1/connector_types.go
@@ -128,7 +128,7 @@ var (
 		"serviceNow":         connectors.NOTIFICATIONCENTERCONNECTORTYPE_SERVICE_NOW,
 		"microsoftTeams":     connectors.NOTIFICATIONCENTERCONNECTORTYPE_MICROSOFT_TEAMS,
 		"eventBridge":        connectors.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE,
-		"incidentIo":         connectors.NotificationCenterConnectorType("INCIDENT_IO"),
+		"incidentIo":         connectors.NOTIFICATIONCENTERCONNECTORTYPE_INCIDENT_IO,
 	}
 	schemaToOpenApiEntityType = map[string]connectors.NotificationCenterEntityType{
 		"alerts": connectors.NOTIFICATIONCENTERENTITYTYPE_ALERTS,

--- a/api/coralogix/v1alpha1/notification_center_gaps_test.go
+++ b/api/coralogix/v1alpha1/notification_center_gaps_test.go
@@ -207,6 +207,56 @@ func TestPresetExtractEventBridge(t *testing.T) {
 	}
 }
 
+func TestConnectorExtractIncidentIO(t *testing.T) {
+	apiKey := "api-key"
+	alertEventsURL := "https://api.incident.io/v2/alert_events/http/source-id"
+	alertSourceToken := "alert-source-token"
+	connector := &Connector{
+		Spec: ConnectorSpec{
+			Name:        "c",
+			Description: "d",
+			Type:        "incidentIo",
+			ConnectorConfig: ConnectorConfig{
+				Fields: []ConnectorConfigField{
+					{FieldName: "apiKey", Value: &apiKey},
+					{FieldName: "alertEventsUrl", Value: &alertEventsURL},
+					{FieldName: "alertSourceToken", Value: &alertSourceToken},
+				},
+			},
+		},
+	}
+
+	got, err := connector.ExtractConnector(context.Background())
+	if err != nil {
+		t.Fatalf("ExtractConnector returned error: %v", err)
+	}
+	if got.Type == nil || *got.Type != connectors.NotificationCenterConnectorType("INCIDENT_IO") {
+		t.Fatalf("Type = %v, want INCIDENT_IO", got.Type)
+	}
+}
+
+func TestPresetExtractIncidentIO(t *testing.T) {
+	preset := &Preset{
+		Spec: PresetSpec{
+			Name:          "p",
+			Description:   "d",
+			ConnectorType: "incidentIo",
+			EntityType:    "cases",
+		},
+	}
+
+	got, err := preset.ExtractPreset()
+	if err != nil {
+		t.Fatalf("ExtractPreset returned error: %v", err)
+	}
+	if got.ConnectorType == nil || *got.ConnectorType != presets.NotificationCenterConnectorType("INCIDENT_IO") {
+		t.Fatalf("ConnectorType = %v, want INCIDENT_IO", got.ConnectorType)
+	}
+	if got.EntityType == nil || *got.EntityType != presets.NOTIFICATIONCENTERENTITYTYPE_CASES {
+		t.Fatalf("EntityType = %v, want CASES", got.EntityType)
+	}
+}
+
 // GlobalRouter supports disabled, fallbackTargets, and CASES routing-rule entity type.
 func TestGlobalRouterExtractDisabledFallbackTargetsAndCases(t *testing.T) {
 	disabled := true

--- a/api/coralogix/v1alpha1/notification_center_gaps_test.go
+++ b/api/coralogix/v1alpha1/notification_center_gaps_test.go
@@ -230,7 +230,7 @@ func TestConnectorExtractIncidentIO(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractConnector returned error: %v", err)
 	}
-	if got.Type == nil || *got.Type != connectors.NotificationCenterConnectorType("INCIDENT_IO") {
+	if got.Type == nil || *got.Type != connectors.NOTIFICATIONCENTERCONNECTORTYPE_INCIDENT_IO {
 		t.Fatalf("Type = %v, want INCIDENT_IO", got.Type)
 	}
 }
@@ -249,7 +249,7 @@ func TestPresetExtractIncidentIO(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractPreset returned error: %v", err)
 	}
-	if got.ConnectorType == nil || *got.ConnectorType != presets.NotificationCenterConnectorType("INCIDENT_IO") {
+	if got.ConnectorType == nil || *got.ConnectorType != presets.NOTIFICATIONCENTERCONNECTORTYPE_INCIDENT_IO {
 		t.Fatalf("ConnectorType = %v, want INCIDENT_IO", got.ConnectorType)
 	}
 	if got.EntityType == nil || *got.EntityType != presets.NOTIFICATIONCENTERENTITYTYPE_CASES {

--- a/api/coralogix/v1alpha1/preset_types.go
+++ b/api/coralogix/v1alpha1/preset_types.go
@@ -36,7 +36,7 @@ type PresetSpec struct {
 	// +optional
 	ParentId *string `json:"parentId,omitempty"`
 
-	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.
+	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, or incidentIo (preview).
 	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;microsoftTeams;eventBridge;incidentIo
 	ConnectorType string `json:"connectorType"`
 

--- a/api/coralogix/v1alpha1/preset_types.go
+++ b/api/coralogix/v1alpha1/preset_types.go
@@ -36,8 +36,8 @@ type PresetSpec struct {
 	// +optional
 	ParentId *string `json:"parentId,omitempty"`
 
-	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.
-	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;microsoftTeams;eventBridge
+	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, or incidentIo.
+	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;microsoftTeams;eventBridge;incidentIo
 	ConnectorType string `json:"connectorType"`
 
 	// EntityType is the entity type for the preset. Can be one of alerts or cases.
@@ -138,6 +138,7 @@ var (
 		"email":              presets.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
 		"microsoftTeams":     presets.NOTIFICATIONCENTERCONNECTORTYPE_MICROSOFT_TEAMS,
 		"eventBridge":        presets.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE,
+		"incidentIo":         presets.NotificationCenterConnectorType("INCIDENT_IO"),
 	}
 	schemaToOpenApiPresetsEntityType = map[string]presets.NotificationCenterEntityType{
 		"alerts": presets.NOTIFICATIONCENTERENTITYTYPE_ALERTS,

--- a/api/coralogix/v1alpha1/preset_types.go
+++ b/api/coralogix/v1alpha1/preset_types.go
@@ -138,7 +138,7 @@ var (
 		"email":              presets.NOTIFICATIONCENTERCONNECTORTYPE_EMAIL,
 		"microsoftTeams":     presets.NOTIFICATIONCENTERCONNECTORTYPE_MICROSOFT_TEAMS,
 		"eventBridge":        presets.NOTIFICATIONCENTERCONNECTORTYPE_EVENTBRIDGE,
-		"incidentIo":         presets.NotificationCenterConnectorType("INCIDENT_IO"),
+		"incidentIo":         presets.NOTIFICATIONCENTERCONNECTORTYPE_INCIDENT_IO,
 	}
 	schemaToOpenApiPresetsEntityType = map[string]presets.NotificationCenterEntityType{
 		"alerts": presets.NOTIFICATIONCENTERENTITYTYPE_ALERTS,

--- a/api/coralogix/v1alpha1/preset_types.go
+++ b/api/coralogix/v1alpha1/preset_types.go
@@ -36,7 +36,7 @@ type PresetSpec struct {
 	// +optional
 	ParentId *string `json:"parentId,omitempty"`
 
-	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, or incidentIo.
+	// ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.
 	// +kubebuilder:validation:Enum=slack;genericHttps;pagerDuty;pagerDutyIncidents;email;microsoftTeams;eventBridge;incidentIo
 	ConnectorType string `json:"connectorType"`
 

--- a/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
@@ -150,7 +150,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  microsoftTeams, or eventBridge.
+                  microsoftTeams, eventBridge, or incidentIo (preview).
                 enum:
                 - slack
                 - genericHttps

--- a/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
@@ -150,7 +150,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  microsoftTeams, or eventBridge.
+                  microsoftTeams, eventBridge, or incidentIo.
                 enum:
                 - slack
                 - genericHttps
@@ -160,6 +160,7 @@ spec:
                 - serviceNow
                 - microsoftTeams
                 - eventBridge
+                - incidentIo
                 type: string
             required:
             - connectorConfig

--- a/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_connectors.yaml
@@ -150,7 +150,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  microsoftTeams, eventBridge, or incidentIo.
+                  microsoftTeams, or eventBridge.
                 enum:
                 - slack
                 - genericHttps

--- a/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
@@ -124,7 +124,7 @@ spec:
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
                   of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
-                  or eventBridge.
+                  eventBridge, or incidentIo (preview).
                 enum:
                 - slack
                 - genericHttps

--- a/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
@@ -124,7 +124,7 @@ spec:
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
                   of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
-                  or eventBridge.
+                  eventBridge, or incidentIo.
                 enum:
                 - slack
                 - genericHttps
@@ -133,6 +133,7 @@ spec:
                 - email
                 - microsoftTeams
                 - eventBridge
+                - incidentIo
                 type: string
               description:
                 description: Description is the description of the preset.

--- a/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_presets.yaml
@@ -124,7 +124,7 @@ spec:
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
                   of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
-                  eventBridge, or incidentIo.
+                  or eventBridge.
                 enum:
                 - slack
                 - genericHttps

--- a/config/crd/bases/coralogix.com_connectors.yaml
+++ b/config/crd/bases/coralogix.com_connectors.yaml
@@ -149,7 +149,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  microsoftTeams, eventBridge, or incidentIo.
+                  microsoftTeams, or eventBridge.
                 enum:
                 - slack
                 - genericHttps

--- a/config/crd/bases/coralogix.com_connectors.yaml
+++ b/config/crd/bases/coralogix.com_connectors.yaml
@@ -149,7 +149,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  microsoftTeams, or eventBridge.
+                  microsoftTeams, eventBridge, or incidentIo (preview).
                 enum:
                 - slack
                 - genericHttps

--- a/config/crd/bases/coralogix.com_connectors.yaml
+++ b/config/crd/bases/coralogix.com_connectors.yaml
@@ -149,7 +149,7 @@ spec:
               type:
                 description: Type is the type of the connector. Can be one of slack,
                   genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow,
-                  microsoftTeams, or eventBridge.
+                  microsoftTeams, eventBridge, or incidentIo.
                 enum:
                 - slack
                 - genericHttps
@@ -159,6 +159,7 @@ spec:
                 - serviceNow
                 - microsoftTeams
                 - eventBridge
+                - incidentIo
                 type: string
             required:
             - connectorConfig

--- a/config/crd/bases/coralogix.com_presets.yaml
+++ b/config/crd/bases/coralogix.com_presets.yaml
@@ -123,7 +123,7 @@ spec:
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
                   of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
-                  or eventBridge.
+                  eventBridge, or incidentIo (preview).
                 enum:
                 - slack
                 - genericHttps

--- a/config/crd/bases/coralogix.com_presets.yaml
+++ b/config/crd/bases/coralogix.com_presets.yaml
@@ -123,7 +123,7 @@ spec:
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
                   of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
-                  or eventBridge.
+                  eventBridge, or incidentIo.
                 enum:
                 - slack
                 - genericHttps
@@ -132,6 +132,7 @@ spec:
                 - email
                 - microsoftTeams
                 - eventBridge
+                - incidentIo
                 type: string
               description:
                 description: Description is the description of the preset.

--- a/config/crd/bases/coralogix.com_presets.yaml
+++ b/config/crd/bases/coralogix.com_presets.yaml
@@ -123,7 +123,7 @@ spec:
               connectorType:
                 description: ConnectorType is the type of the connector. Can be one
                   of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams,
-                  eventBridge, or incidentIo.
+                  or eventBridge.
                 enum:
                 - slack
                 - genericHttps

--- a/config/samples/v1alpha1/connectors/incident-io.yaml
+++ b/config/samples/v1alpha1/connectors/incident-io.yaml
@@ -1,0 +1,22 @@
+apiVersion: coralogix.com/v1alpha1
+kind: Connector
+metadata:
+  labels:
+    app.kubernetes.io/name: coralogix-operator
+    app.kubernetes.io/instance: connector-sample
+    app.kubernetes.io/part-of: coralogix-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: coralogix-operator
+  name: incident-io-sample
+spec:
+  name: incident-io-sample
+  description: This is a sample incident.io connector
+  type: incidentIo
+  connectorConfig:
+    fields:
+      - fieldName: apiKey
+        value: some-api-key
+      - fieldName: alertEventsUrl
+        value: https://api.incident.io/v2/alert_events/http/source-id
+      - fieldName: alertSourceToken
+        value: some-alert-source-token

--- a/config/samples/v1alpha1/presets/incident-io.yaml
+++ b/config/samples/v1alpha1/presets/incident-io.yaml
@@ -1,0 +1,29 @@
+apiVersion: coralogix.com/v1alpha1
+kind: Preset
+metadata:
+  labels:
+    app.kubernetes.io/name: coralogix-operator
+    app.kubernetes.io/instance: preset-sample
+    app.kubernetes.io/part-of: coralogix-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: coralogix-operator
+  name: incident-io-sample
+spec:
+  name: incident-io-sample
+  description: This is a sample incident.io preset
+  connectorType: incidentIo
+  entityType: cases
+  parentId: preset_system_incident_io_cases_basic
+  configOverrides:
+    - conditionType:
+        matchEntityType: {}
+      messageConfig:
+        fields:
+          - fieldName: incidentKey
+            template: "{{case.id}}"
+          - fieldName: title
+            template: "{{case.title}}"
+          - fieldName: severity
+            template: "{{case.severity}}"
+          - fieldName: status
+            template: "{{case.status}}"

--- a/config/samples/v1alpha1/presets/incident-io.yaml
+++ b/config/samples/v1alpha1/presets/incident-io.yaml
@@ -20,10 +20,20 @@ spec:
       messageConfig:
         fields:
           - fieldName: incidentKey
-            template: "{{case.id}}"
+            template: "{{ case.id }}"
           - fieldName: title
-            template: "{{case.title}}"
+            template: "{{ case.title }}"
           - fieldName: severity
-            template: "{{case.severity}}"
+            template: "{% if case.priority == 'P1' %}Critical{% elif case.priority == 'P2' %}Major{% else %}Minor{% endif %}"
+          - fieldName: summary
+            template: |
+              {{ case.url }}
+              {{ case.description | default(value='') }}
           - fieldName: status
-            template: "{{case.status}}"
+            template: "{% if case.status == 'RESOLVED' or case.status == 'CLOSED' %}resolved{% else %}active{% endif %}"
+          - fieldName: assigneeEmail
+            template: "{% if case.assignee.coralogixUser.userEmail %}{{ case.assignee.coralogixUser.userEmail }}{% endif %}"
+          - fieldName: caseUrl
+            template: "{{ case.url }}"
+          - fieldName: alertMetadata
+            template: '{"priority": "{{ case.priority }}"}'

--- a/docs/api.md
+++ b/docs/api.md
@@ -10173,7 +10173,7 @@ See also https://coralogix.com/docs/user-guides/notification-center/introduction
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.<br/>
+          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo (preview).<br/>
           <br/>
             <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, incidentIo<br/>
         </td>
@@ -15652,7 +15652,7 @@ PresetSpec defines the desired state of Preset.
         <td><b>connectorType</b></td>
         <td>enum</td>
         <td>
-          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.<br/>
+          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, or incidentIo (preview).<br/>
           <br/>
             <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, incidentIo<br/>
         </td>

--- a/docs/api.md
+++ b/docs/api.md
@@ -10173,7 +10173,7 @@ See also https://coralogix.com/docs/user-guides/notification-center/introduction
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo.<br/>
+          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.<br/>
           <br/>
             <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, incidentIo<br/>
         </td>
@@ -15652,7 +15652,7 @@ PresetSpec defines the desired state of Preset.
         <td><b>connectorType</b></td>
         <td>enum</td>
         <td>
-          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, or incidentIo.<br/>
+          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.<br/>
           <br/>
             <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, incidentIo<br/>
         </td>

--- a/docs/api.md
+++ b/docs/api.md
@@ -10173,9 +10173,9 @@ See also https://coralogix.com/docs/user-guides/notification-center/introduction
         <td><b>type</b></td>
         <td>enum</td>
         <td>
-          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, or eventBridge.<br/>
+          Type is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, or incidentIo.<br/>
           <br/>
-            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge<br/>
+            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, serviceNow, microsoftTeams, eventBridge, incidentIo<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -15652,9 +15652,9 @@ PresetSpec defines the desired state of Preset.
         <td><b>connectorType</b></td>
         <td>enum</td>
         <td>
-          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, or eventBridge.<br/>
+          ConnectorType is the type of the connector. Can be one of slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, or incidentIo.<br/>
           <br/>
-            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge<br/>
+            <i>Enum</i>: slack, genericHttps, pagerDuty, pagerDutyIncidents, email, microsoftTeams, eventBridge, incidentIo<br/>
         </td>
         <td>true</td>
       </tr><tr>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.26.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824121651-e73b4c3a2028
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.26.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824121651-e73b4c3a2028
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260825080729-41b28d6c6e4f
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c h1:zWTINNZMXUGkdO5rB3Ld0y6uwz0usyFCMoCfx/860Eg=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824121651-e73b4c3a2028 h1:ukv0wQiuo6YjbCA6hBeqwonvKHxo2FdDtWBKsIJhbRM=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824121651-e73b4c3a2028/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824121651-e73b4c3a2028 h1:ukv0wQiuo6YjbCA6hBeqwonvKHxo2FdDtWBKsIJhbRM=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824121651-e73b4c3a2028/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260825080729-41b28d6c6e4f h1:XA3uRQeE0xae05TEbw1sJFHam8KyEU+0amJFeLqPlmw=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260825080729-41b28d6c6e4f/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -433,7 +433,7 @@ var _ = Describe("Connector IncidentIO", Ordered, func() {
 	})
 
 	It("Should be created successfully", func(ctx context.Context) {
-		connectorName = fmt.Sprintf("incidentio-connector-%d", time.Now().Unix())
+		connectorName = uniqueName("incidentio-connector")
 		connector = getSampleIncidentIOConnector(connectorName, testNamespace)
 		Expect(crClient.Create(ctx, connector)).To(Succeed())
 

--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -43,6 +43,9 @@ var msTeamsIntegrationId = os.Getenv("MS_TEAMS_INTEGRATION_ID")
 var msTeamsTeamId = os.Getenv("MS_TEAMS_TEAM_ID")
 var msTeamsChannelId = os.Getenv("MS_TEAMS_CHANNEL_ID")
 var eventbridgeIntegrationId = os.Getenv("EVENTBRIDGE_INTEGRATION_ID")
+var incidentIOAPIKey = os.Getenv("INCIDENT_IO_API_KEY")
+var incidentIOAlertEventsURL = os.Getenv("INCIDENT_IO_ALERT_EVENTS_URL")
+var incidentIOAlertSourceToken = os.Getenv("INCIDENT_IO_ALERT_SOURCE_TOKEN")
 
 var _ = Describe("Connector", Ordered, func() {
 	var (
@@ -412,6 +415,55 @@ var _ = Describe("Connector EventBridge", Ordered, func() {
 	})
 })
 
+var _ = Describe("Connector IncidentIO", Ordered, func() {
+	var (
+		crClient            client.Client
+		notificationsClient *cxsdk.NotificationsClient
+		connectorID         string
+		connector           *coralogixv1alpha1.Connector
+		connectorName       string
+	)
+
+	BeforeAll(func() {
+		if incidentIOAPIKey == "" || incidentIOAlertEventsURL == "" || incidentIOAlertSourceToken == "" {
+			Skip("set INCIDENT_IO_API_KEY, INCIDENT_IO_ALERT_EVENTS_URL, and INCIDENT_IO_ALERT_SOURCE_TOKEN to run this spec locally")
+		}
+		crClient = ClientsInstance.GetControllerRuntimeClient()
+		notificationsClient = ClientsInstance.GetCoralogixClientSet().Notifications()
+	})
+
+	It("Should be created successfully", func(ctx context.Context) {
+		connectorName = fmt.Sprintf("incidentio-connector-%d", time.Now().Unix())
+		connector = getSampleIncidentIOConnector(connectorName, testNamespace)
+		Expect(crClient.Create(ctx, connector)).To(Succeed())
+
+		Eventually(func(g Gomega) error {
+			fetched := &coralogixv1alpha1.Connector{}
+			g.Expect(crClient.Get(ctx, types.NamespacedName{Name: connectorName, Namespace: testNamespace}, fetched)).To(Succeed())
+			g.Expect(meta.IsStatusConditionTrue(fetched.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
+			g.Expect(fetched.Status.PrintableStatus).To(Equal("RemoteSynced"))
+			if fetched.Status.Id != nil {
+				connectorID = *fetched.Status.Id
+				return nil
+			}
+			return fmt.Errorf("connector ID is not set")
+		}, time.Minute, time.Second).Should(Succeed())
+
+		Eventually(func() error {
+			_, err := notificationsClient.GetConnector(ctx, &cxsdk.GetConnectorRequest{Id: connectorID})
+			return err
+		}, time.Minute, time.Second).Should(Succeed())
+	})
+
+	It("Should be deleted successfully", func(ctx context.Context) {
+		Expect(crClient.Delete(ctx, connector)).To(Succeed())
+		Eventually(func() codes.Code {
+			_, err := notificationsClient.GetConnector(ctx, &cxsdk.GetConnectorRequest{Id: connectorID})
+			return cxsdk.Code(err)
+		}, time.Minute, time.Second).Should(Equal(codes.NotFound))
+	})
+})
+
 // NC gap field: CASES config-override entity type.
 var _ = Describe("Connector with CASES config override", Ordered, func() {
 	var (
@@ -504,6 +556,24 @@ func getSampleEventBridgeConnector(name, namespace string) *coralogixv1alpha1.Co
 			ConnectorConfig: coralogixv1alpha1.ConnectorConfig{
 				Fields: []coralogixv1alpha1.ConnectorConfigField{
 					{FieldName: "integrationId", Value: ptr.To(eventbridgeIntegrationId)},
+				},
+			},
+		},
+	}
+}
+
+func getSampleIncidentIOConnector(name, namespace string) *coralogixv1alpha1.Connector {
+	return &coralogixv1alpha1.Connector{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: coralogixv1alpha1.ConnectorSpec{
+			Name:        name,
+			Description: "incident.io connector",
+			Type:        "incidentIo",
+			ConnectorConfig: coralogixv1alpha1.ConnectorConfig{
+				Fields: []coralogixv1alpha1.ConnectorConfigField{
+					{FieldName: "apiKey", Value: ptr.To(incidentIOAPIKey)},
+					{FieldName: "alertEventsUrl", Value: ptr.To(incidentIOAlertEventsURL)},
+					{FieldName: "alertSourceToken", Value: ptr.To(incidentIOAlertSourceToken)},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- Add Notification Center `incidentIo` to Connector and Preset CRD enums/maps (`INCIDENT_IO` in the API).
- This is the NC connector, **not** the generic-HTTPS incident.io workaround.
- Connector config is the existing generic `{type, connectorConfig.fields[]}` shape. User-supplied fields: `apiKey`, `alertEventsUrl`, `alertSourceToken`.
- Preset parent: `preset_system_incident_io_cases_basic`. Entity type: cases.
- Samples: `config/samples/v1alpha1/connectors/incident-io.yaml` and `.../presets/incident-io.yaml`.

The pinned `coralogix-management-sdk` does not yet name `INCIDENT_IO`. Maps use a string cast. Staging OpenAPI accepted the type and created/deleted a probe connector. SDK `UnmarshalJSON` still rejects `INCIDENT_IO` on read, so live operator reconcile will need an SDK bump before it works end-to-end.

No controller Go changes beyond the type maps.

## Test plan
- [x] `make manifests && make helm-update-crds && make generate-api-docs && make helm-sync-check`
- [x] `go test ./api/coralogix/v1alpha1`
- [ ] `make lint` / `make unit-tests` — not rerun as a full target in this pass
- [ ] Live e2e `Describe("Connector IncidentIO")` gated on `INCIDENT_IO_API_KEY`, `INCIDENT_IO_ALERT_EVENTS_URL`, `INCIDENT_IO_ALERT_SOURCE_TOKEN`

[CX-55144](https://coralogix.atlassian.net/browse/CX-55144)

**Sibling PRs**
- Terraform provider: https://github.com/coralogix/terraform-provider-coralogix/pull/663
- VAC: https://github.com/coralogix/eng-svc-view-as-code/pull/109
- mgmt-mcp: https://github.com/coralogix/mgmt-mcp/pull/117

[CX-55144]: https://coralogix.atlassian.net/browse/CX-55144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ