### PR TITLE
feat: add equals and notEquals logs and metric threshold operators (CX-54815)

### DIFF
--- a/api/coralogix/v1beta1/alert_types.go
+++ b/api/coralogix/v1beta1/alert_types.go
@@ -127,8 +127,10 @@ var (
 		LogsTimeWindow36Hours:   alerts.LOGSTIMEWINDOWVALUE_LOGS_TIME_WINDOW_VALUE_HOURS_36,
 	}
 	LogsThresholdConditionTypeToOpenAPI = map[LogsThresholdConditionType]alerts.LogsThresholdConditionType{
-		LogsThresholdConditionTypeMoreThan: alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED,
-		LogsThresholdConditionTypeLessThan: alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_LESS_THAN,
+		LogsThresholdConditionTypeMoreThan:  alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_UNSPECIFIED,
+		LogsThresholdConditionTypeLessThan:  alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_LESS_THAN,
+		LogsThresholdConditionTypeEquals:    alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_EQUALS,
+		LogsThresholdConditionTypeNotEquals: alerts.LOGSTHRESHOLDCONDITIONTYPE_LOGS_THRESHOLD_CONDITION_TYPE_NOT_EQUALS,
 	}
 	LogsRatioTimeWindowToOpenAPI = map[LogsRatioTimeWindowValue]alerts.LogsRatioTimeWindowValue{
 		LogsRatioTimeWindowMinutes5:  alerts.LOGSRATIOTIMEWINDOWVALUE_LOGS_RATIO_TIME_WINDOW_VALUE_MINUTES_5_OR_UNSPECIFIED,
@@ -169,6 +171,8 @@ var (
 		MetricThresholdConditionTypeLessThan:         alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_LESS_THAN,
 		MetricThresholdConditionTypeMoreThanOrEquals: alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_MORE_THAN_OR_EQUALS,
 		MetricThresholdConditionTypeLessThanOrEquals: alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_LESS_THAN_OR_EQUALS,
+		MetricThresholdConditionTypeEquals:           alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_EQUALS,
+		MetricThresholdConditionTypeNotEquals:        alerts.METRICTHRESHOLDCONDITIONTYPE_METRIC_THRESHOLD_CONDITION_TYPE_NOT_EQUALS,
 	}
 	MetricTimeWindowToOpenAPI = map[MetricTimeWindowSpecificValue]alerts.MetricTimeWindowValue{
 		MetricTimeWindowValue1Minute:   alerts.METRICTIMEWINDOWVALUE_METRIC_TIME_WINDOW_VALUE_MINUTES_1_OR_UNSPECIFIED,
@@ -776,14 +780,16 @@ const (
 	LogsTimeWindow36Hours   LogsTimeWindowValue = "36h"
 )
 
-// +kubebuilder:validation:Enum=moreThan;lessThan
+// +kubebuilder:validation:Enum=moreThan;lessThan;equals;notEquals
 // ConditionType type.
 type LogsThresholdConditionType string
 
 // Condition type values.
 const (
-	LogsThresholdConditionTypeMoreThan LogsThresholdConditionType = "moreThan"
-	LogsThresholdConditionTypeLessThan LogsThresholdConditionType = "lessThan"
+	LogsThresholdConditionTypeMoreThan  LogsThresholdConditionType = "moreThan"
+	LogsThresholdConditionTypeLessThan  LogsThresholdConditionType = "lessThan"
+	LogsThresholdConditionTypeEquals    LogsThresholdConditionType = "equals"
+	LogsThresholdConditionTypeNotEquals LogsThresholdConditionType = "notEquals"
 )
 
 // Override alert properties
@@ -1045,7 +1051,7 @@ const (
 	MetricTimeWindowValue36Hours   MetricTimeWindowSpecificValue = "36h"
 )
 
-// +kubebuilder:validation:Enum=moreThan;lessThan;moreThanOrEquals;lessThanOrEquals
+// +kubebuilder:validation:Enum=moreThan;lessThan;moreThanOrEquals;lessThanOrEquals;equals;notEquals
 // ConditionType type.
 type MetricThresholdConditionType string
 
@@ -1055,6 +1061,8 @@ const (
 	MetricThresholdConditionTypeLessThan         MetricThresholdConditionType = "lessThan"
 	MetricThresholdConditionTypeMoreThanOrEquals MetricThresholdConditionType = "moreThanOrEquals"
 	MetricThresholdConditionTypeLessThanOrEquals MetricThresholdConditionType = "lessThanOrEquals"
+	MetricThresholdConditionTypeEquals           MetricThresholdConditionType = "equals"
+	MetricThresholdConditionTypeNotEquals        MetricThresholdConditionType = "notEquals"
 )
 
 // Missing values strategies.

--- a/charts/coralogix-operator/templates/crds/coralogix.com_alerts.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_alerts.yaml
@@ -921,6 +921,8 @@ spec:
                                   enum:
                                   - moreThan
                                   - lessThan
+                                  - equals
+                                  - notEquals
                                   type: string
                                 threshold:
                                   anyOf:
@@ -1479,6 +1481,8 @@ spec:
                                   - lessThan
                                   - moreThanOrEquals
                                   - lessThanOrEquals
+                                  - equals
+                                  - notEquals
                                   type: string
                                 forOverPct:
                                   format: int32

--- a/charts/coralogix-operator/templates/crds/coralogix.com_alertsets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_alertsets.yaml
@@ -952,6 +952,8 @@ spec:
                                             enum:
                                             - moreThan
                                             - lessThan
+                                            - equals
+                                            - notEquals
                                             type: string
                                           threshold:
                                             anyOf:
@@ -1516,6 +1518,8 @@ spec:
                                             - lessThan
                                             - moreThanOrEquals
                                             - lessThanOrEquals
+                                            - equals
+                                            - notEquals
                                             type: string
                                           forOverPct:
                                             format: int32

--- a/config/crd/bases/coralogix.com_alerts.yaml
+++ b/config/crd/bases/coralogix.com_alerts.yaml
@@ -920,6 +920,8 @@ spec:
                                   enum:
                                   - moreThan
                                   - lessThan
+                                  - equals
+                                  - notEquals
                                   type: string
                                 threshold:
                                   anyOf:
@@ -1478,6 +1480,8 @@ spec:
                                   - lessThan
                                   - moreThanOrEquals
                                   - lessThanOrEquals
+                                  - equals
+                                  - notEquals
                                   type: string
                                 forOverPct:
                                   format: int32

--- a/config/crd/bases/coralogix.com_alertsets.yaml
+++ b/config/crd/bases/coralogix.com_alertsets.yaml
@@ -951,6 +951,8 @@ spec:
                                             enum:
                                             - moreThan
                                             - lessThan
+                                            - equals
+                                            - notEquals
                                             type: string
                                           threshold:
                                             anyOf:
@@ -1515,6 +1517,8 @@ spec:
                                             - lessThan
                                             - moreThanOrEquals
                                             - lessThanOrEquals
+                                            - equals
+                                            - notEquals
                                             type: string
                                           forOverPct:
                                             format: int32

--- a/config/samples/v1beta1/alerts/logs_threshold_equals.yaml
+++ b/config/samples/v1beta1/alerts/logs_threshold_equals.yaml
@@ -1,0 +1,26 @@
+apiVersion: coralogix.com/v1beta1
+kind: Alert
+metadata:
+  labels:
+    app.kubernetes.io/name: alert
+    app.kubernetes.io/instance: alert-sample
+    app.kubernetes.io/part-of: coralogix-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: coralogix-operator
+  name: logs-threshold-equals
+spec:
+  name: logs-threshold equals example
+  description: alert from k8s operator
+  alertType:
+    logsThreshold:
+      logsFilter:
+        simpleFilter:
+          luceneQuery: level:ERROR
+      rules:
+        - condition:
+            timeWindow:
+              specificValue: 10m
+            threshold: "100"
+            logsThresholdConditionType: equals
+          override:
+            priority: p2

--- a/config/samples/v1beta1/alerts/metric_threshold_not_equals.yaml
+++ b/config/samples/v1beta1/alerts/metric_threshold_not_equals.yaml
@@ -1,0 +1,28 @@
+apiVersion: coralogix.com/v1beta1
+kind: Alert
+metadata:
+  labels:
+    app.kubernetes.io/name: alert
+    app.kubernetes.io/instance: alert-sample
+    app.kubernetes.io/part-of: coralogix-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: coralogix-operator
+  name: metric-threshold-not-equals
+spec:
+  name: metric-threshold not-equals example
+  description: alert from k8s operator
+  alertType:
+    metricThreshold:
+      metricFilter:
+        promql: sum(rate(http_requests_total[5m]))
+      missingValues:
+        replaceWithZero: true
+      rules:
+        - condition:
+            threshold: "0"
+            forOverPct: 100
+            ofTheLast:
+              specificValue: 5m
+            conditionType: notEquals
+          override:
+            priority: p3

--- a/docs/api.md
+++ b/docs/api.md
@@ -4139,7 +4139,7 @@ Condition to match
         <td>
           Condition type.<br/>
           <br/>
-            <i>Enum</i>: moreThan, lessThan<br/>
+            <i>Enum</i>: moreThan, lessThan, equals, notEquals<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -5601,7 +5601,7 @@ Conditions to match for the rule.
         <td>
           ConditionType type.<br/>
           <br/>
-            <i>Enum</i>: moreThan, lessThan, moreThanOrEquals, lessThanOrEquals<br/>
+            <i>Enum</i>: moreThan, lessThan, moreThanOrEquals, lessThanOrEquals, equals, notEquals<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -22655,7 +22655,7 @@ Condition to match
         <td>
           Condition type.<br/>
           <br/>
-            <i>Enum</i>: moreThan, lessThan<br/>
+            <i>Enum</i>: moreThan, lessThan, equals, notEquals<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -24117,7 +24117,7 @@ Conditions to match for the rule.
         <td>
           ConditionType type.<br/>
           <br/>
-            <i>Enum</i>: moreThan, lessThan, moreThanOrEquals, lessThanOrEquals<br/>
+            <i>Enum</i>: moreThan, lessThan, moreThanOrEquals, lessThanOrEquals, equals, notEquals<br/>
         </td>
         <td>true</td>
       </tr><tr>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.26.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824133534-79f38d837aea
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c h1:zWTINNZMXUGkdO5rB3Ld0y6uwz0usyFCMoCfx/860Eg=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260812151205-db157a36375c/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824133534-79f38d837aea h1:IcFo3jw0pgsdKzXdLsPssFgZMF3FDepPUeqVgsHtx30=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260824133534-79f38d837aea/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=


### PR DESCRIPTION
## Summary
- Extend `Alert` v1beta1 logs and metric threshold condition-type enums with `equals` and `notEquals`, map them to the OpenAPI constants, and regenerate CRDs / Helm CRDs / API docs.
- Add samples `logs_threshold_equals.yaml` and `metric_threshold_not_equals.yaml`.
- Pin `coralogix-management-sdk` `79f38d837aea` for [CX-54815](https://coralogix.atlassian.net/browse/CX-54815).

AlertSet embeds `v1beta1.AlertSpec`, so the new values apply there as well. `undetectedValuesManagement` CEL still requires `lessThan`; that is unchanged.

## Test plan
- [x] `make generate` / `make manifests` / `make helm-sync-check`
- [x] v1beta1 envtest via `make unit-tests` (package passed; some other packages hit a local `covdata` toolchain issue)
- [x] EU2: applied the two new samples against a local operator image; both reached `RemoteSynced=True` (`RemoteSyncedSuccessfully`), then deleted
- [ ] Stock `tests/e2e/alert_test.go` needs Slack NC (`SLACK_INTEGRATION_CHANNEL`); not run to completion on this account

Merge after the SDK PR. VAC and MCP pin this commit (`f7d334f704f3`).


Made with [Cursor](https://cursor.com)

[CX-54815]: https://coralogix.atlassian.net/browse/CX-54815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ