### PR TITLE
ci: alert acceptance failures only on nightly runs

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -80,8 +80,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -89,8 +89,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -70,8 +70,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -104,8 +104,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - upgrade-test
     permissions:


### PR DESCRIPTION
## Summary

- Limit acceptance/E2E Slack failure notifications to scheduled nightly runs.
- Keep acceptance/E2E test execution on push and pull request events unchanged.

This is a CI-only change.