### PR TITLE
ci: share one live-CX concurrency group across e2e suites (CX-55418)

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -84,8 +84,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Scheduled (nightly) runs alert. Pull request and push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -21,10 +21,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  # Shared across e2e, helm-e2e, upgrade-test, and integration-tests so those
+  # live suites cannot overlap on the same Coralogix team (archive metrics,
+  # TCO, quota, IP access).
+  group: coralogix-operator-live-cx
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
   # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
-  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # remote resources leak and pollute the shared team. Let the old run finish and queue behind
   # it instead.
   cancel-in-progress: false
 
@@ -80,8 +83,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
-    if: ${{ always() && github.event_name == 'schedule' }}
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -53,6 +53,7 @@ jobs:
       SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
       SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
+      TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -20,10 +20,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  # Shared across e2e, helm-e2e, upgrade-test, and integration-tests so those
+  # live suites cannot overlap on the same Coralogix team (archive metrics,
+  # TCO, quota, IP access).
+  group: coralogix-operator-live-cx
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
   # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
-  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # remote resources leak and pollute the shared team. Let the old run finish and queue behind
   # it instead.
   cancel-in-progress: false
 
@@ -89,8 +92,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
-    if: ${{ always() && github.event_name == 'schedule' }}
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -45,6 +45,7 @@ jobs:
       SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
       SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
+      TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -93,8 +93,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Scheduled (nightly) runs alert. Pull request and push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -73,8 +73,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Scheduled (nightly) runs alert. Pull request and push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,10 +21,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  # Shared across e2e, helm-e2e, upgrade-test, and integration-tests so those
+  # live suites cannot overlap on the same Coralogix team (archive metrics,
+  # TCO, quota, IP access).
+  group: coralogix-operator-live-cx
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
   # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
-  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # remote resources leak and pollute the shared team. Let the old run finish and queue behind
   # it instead.
   cancel-in-progress: false
 
@@ -70,8 +73,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
-    if: ${{ always() && github.event_name == 'schedule' }}
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
     needs:
       - tests
     permissions:

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -49,6 +49,7 @@ jobs:
       SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
       SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
+      TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -108,8 +108,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
-    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
+    # Scheduled (nightly) runs alert. Pull request and push runs stay quiet.
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - upgrade-test
     permissions:

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -21,10 +21,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  # Shared across e2e, helm-e2e, upgrade-test, and integration-tests so those
+  # live suites cannot overlap on the same Coralogix team (archive metrics,
+  # TCO, quota, IP access).
+  group: coralogix-operator-live-cx
   # Not cancel-in-progress: these specs create real Coralogix resources, and cleanup happens in
   # the suite's own teardown. Cancelling kills the Kind cluster before finalizers run, so the
-  # remote resources leak and pollute the shared account. Let the old run finish and queue behind
+  # remote resources leak and pollute the shared team. Let the old run finish and queue behind
   # it instead.
   cancel-in-progress: false
 
@@ -104,8 +107,8 @@ jobs:
 
   notify-failure:
     name: Notify Slack on failure
-    # Only scheduled (nightly) runs alert. Pull request and main/release push runs stay quiet.
-    if: ${{ always() && github.event_name == 'schedule' }}
+    # Scheduled (nightly) and main/release push runs alert. Pull request runs stay quiet.
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'push') }}
     needs:
       - upgrade-test
     permissions:

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -36,6 +36,8 @@ jobs:
     name: Upgrade Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
+      max-parallel: 1
       matrix:
         operator_version: [ "0.5", "1.0" ]
     env:

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -8,6 +8,7 @@ cd "$REPO_ROOT"
 
 if [[ $# -lt 1 ]]; then
   echo "Usage: $0 <ginkgo-focus>" >&2
+  echo "Requires CORALOGIX_API_KEY and TEST_TEAM_ID (prompted if unset)." >&2
   exit 2
 fi
 
@@ -27,6 +28,16 @@ if [[ -z "$CORALOGIX_API_KEY" ]]; then
   echo "CORALOGIX_API_KEY cannot be empty" >&2
   exit 1
 fi
+
+if [[ -z "${TEST_TEAM_ID:-}" ]]; then
+  read -r -p "Coralogix team ID (TEST_TEAM_ID): " TEST_TEAM_ID
+fi
+
+if [[ -z "$TEST_TEAM_ID" ]]; then
+  echo "TEST_TEAM_ID cannot be empty" >&2
+  exit 1
+fi
+export TEST_TEAM_ID
 
 umask 077
 API_KEY_FILE=$(mktemp)

--- a/tests/e2e/api_key_test.go
+++ b/tests/e2e/api_key_test.go
@@ -17,6 +17,9 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,6 +38,15 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
+
+func teamIDFromEnv() uint32 {
+	raw := strings.TrimSpace(os.Getenv("TEST_TEAM_ID"))
+	Expect(raw).ToNot(BeEmpty(), "TEST_TEAM_ID is required so ApiKey e2e owns the key on this team's ID")
+	id, err := strconv.ParseUint(raw, 10, 32)
+	Expect(err).ToNot(HaveOccurred(), "TEST_TEAM_ID must be a uint32")
+	Expect(id).ToNot(BeZero(), "TEST_TEAM_ID must be a positive team id")
+	return uint32(id)
+}
 
 var _ = Describe("ApiKey", Ordered, func() {
 	var (
@@ -57,7 +69,7 @@ var _ = Describe("ApiKey", Ordered, func() {
 				Name:   apiKeyName,
 				Active: true,
 				Owner: coralogixv1alpha1.ApiKeyOwner{
-					TeamId: ptr.To(uint32(4013254)),
+					TeamId: ptr.To(teamIDFromEnv()),
 				},
 				Presets:     []string{"APM"},
 				Permissions: []string{"ALERTS-MAP:READ"},

--- a/tests/e2e/events2metrics_test.go
+++ b/tests/e2e/events2metrics_test.go
@@ -72,7 +72,6 @@ var _ = Describe("Events2Metric", Ordered, func() {
 			Spec: coralogixv1alpha1.Events2MetricSpec{
 				Name:              e2mName,
 				Description:       ptr.To("e2m from k8s operator"),
-				DataSource:        ptr.To("default/logs"),
 				PermutationsLimit: ptr.To(int32(100)),
 				MetricLabels: []coralogixv1alpha1.MetricLabel{
 					{
@@ -123,8 +122,12 @@ var _ = Describe("Events2Metric", Ordered, func() {
 			g.Expect(getE2mRes.E2m).ToNot(BeNil())
 			g.Expect(getE2mRes.E2m.Description).ToNot(BeNil())
 			g.Expect(*getE2mRes.E2m.Description).To(Equal("e2m from k8s operator"))
-			g.Expect(getE2mRes.E2m.DataSource).ToNot(BeNil())
-			g.Expect(*getE2mRes.E2m.DataSource).To(Equal("default/logs"))
+			// Named "default/logs" is rejected on accounts that have not
+			// provisioned that catalog entry. Omit the field so the backend
+			// uses the implicit logs stream.
+			if getE2mRes.E2m.DataSource != nil {
+				g.Expect(*getE2mRes.E2m.DataSource).To(BeEmpty())
+			}
 			g.Expect(getE2mRes.E2m.Permutations).ToNot(BeNil())
 			g.Expect(getE2mRes.E2m.Permutations.Limit).To(Equal(int32(100)))
 			g.Expect(getE2mRes.E2m.LogsQuery).ToNot(BeNil())


### PR DESCRIPTION
## Summary
- Replace per-PR concurrency with one shared `coralogix-operator-live-cx` group on e2e, helm-e2e, upgrade-test, and integration-tests (`cancel-in-progress: false`).
- This is what allowed nightly e2e/upgrade/helm/integration to overlap on `ArchiveMetricsTarget` and TCO.
- **ApiKey e2e:** read `TEST_TEAM_ID` instead of a hardcoded foreign team id, so live CI on the isolated operator team can create the key secret. The GitHub secret is already set. Workflows pass `TEST_TEAM_ID` on e2e, helm-e2e, and upgrade-test.
- **Events2Metric e2e:** stop setting `spec.dataSource: default/logs` on create. Falkor (FLK-148): omit the field so the backend uses the implicit logs stream. Named `default/logs` 400s on teams that have not provisioned that catalog entry; `""` also 400s. Unit conversion tests that still map the named string are unchanged.

## Test plan
- [ ] Confirm those four workflows cannot run at the same time
- [ ] Confirm cancelling is off so Kind teardown still cleans remote fixtures
- [x] e2e ApiKey create/update/delete on the isolated team
- [x] Focused Events2Metric e2e (logs CRUD + spans) with `dataSource` omitted — 5 passed on the local docker-desktop operator

Made with [Cursor](https://cursor.com)