### PR TITLE
test: change RUM policy priority from high to medium in e2e test

### DIFF
--- a/config/samples/v1alpha1/tcorumpolicies/example-tco-rum-policies.yaml
+++ b/config/samples/v1alpha1/tcorumpolicies/example-tco-rum-policies.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   policies:
     - name: first policy
-      priority: high
+      priority: medium
       severities:
         - critical
         - error

--- a/tests/e2e/tco_rum_policies_test.go
+++ b/tests/e2e/tco_rum_policies_test.go
@@ -112,7 +112,7 @@ var _ = Describe("TCORumPolicies", Serial, func() {
 				Policies: []coralogixv1alpha1.TCORumPolicy{
 					{
 						Name:       "sample policy",
-						Priority:   "high",
+						Priority:   "medium",
 						Severities: []coralogixv1alpha1.TCOPolicySeverity{"critical", "error"},
 						Applications: &coralogixv1alpha1.TCOPolicyRule{
 							Names:    []string{"prod"},


### PR DESCRIPTION
## Summary
Changes the RUM policy priority from `high` to `medium` in two places:
- `tests/e2e/tco_rum_policies_test.go` — the `sample policy` fixture.
- `config/samples/v1alpha1/tcorumpolicies/example-tco-rum-policies.yaml` — the `first policy` sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)