### PR TITLE
test: keep e2e Slack fallbackChannel on the CI dump channel

### DIFF
--- a/tests/e2e/connector_test.go
+++ b/tests/e2e/connector_test.go
@@ -228,7 +228,7 @@ func getSampleSlackConnector(name string) *coralogixv1alpha1.Connector {
 				Fields: []coralogixv1alpha1.ConnectorConfigField{
 					{FieldName: "channel", Value: ptr.To(slackIntegrationChannel)},
 					{FieldName: "integrationId", Value: ptr.To(slackIntegrationId)},
-					{FieldName: "fallbackChannel", Value: ptr.To("fallback_general")},
+					{FieldName: "fallbackChannel", Value: ptr.To(slackIntegrationChannel)},
 				},
 			},
 			ConfigOverrides: []coralogixv1alpha1.EntityTypeConfigOverrides{


### PR DESCRIPTION
## Summary
- Live e2e Slack connectors used a hardcoded `fallbackChannel` of `fallback_general`. Connector create can post a confirmation into that channel.
- `channel` already comes from `SLACK_INTEGRATION_CHANNEL` (now `eco-ci-test`). `fallbackChannel` now uses the same env value so CI cannot target `#general`, `#random`, or `fallback_general`.

## Test plan
- [ ] Confirm operator e2e still creates a Slack connector
- [ ] Confirm connector-create confirmation lands in `#eco-ci-test`, not `#general` / `#random` / `fallback_general`


Made with [Cursor](https://cursor.com)