### PR TITLE
test: own e2e team-scoped API keys via TEST_TEAM_ID

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -50,6 +50,7 @@ jobs:
       SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
       SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
+      TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/helm-e2e-tests.yaml
+++ b/.github/workflows/helm-e2e-tests.yaml
@@ -42,6 +42,7 @@ jobs:
       SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
       SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
+      TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -46,6 +46,7 @@ jobs:
       SLACK_INTEGRATION_ID: ${{ secrets.SLACK_INTEGRATION_ID }}
       SLACK_INTEGRATION_CHANNEL: ${{ secrets.SLACK_INTEGRATION_CHANNEL }}
       PD_INTEGRATION_ID: ${{ secrets.PD_INTEGRATION_ID }}
+      TEST_TEAM_ID: ${{ secrets.TEST_TEAM_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/e2e/api_key_test.go
+++ b/tests/e2e/api_key_test.go
@@ -17,6 +17,9 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,6 +38,15 @@ import (
 	coralogixv1alpha1 "github.com/coralogix/coralogix-operator/v2/api/coralogix/v1alpha1"
 	"github.com/coralogix/coralogix-operator/v2/internal/utils"
 )
+
+func teamIDFromEnv() uint32 {
+	raw := strings.TrimSpace(os.Getenv("TEST_TEAM_ID"))
+	Expect(raw).ToNot(BeEmpty(), "TEST_TEAM_ID is required so ApiKey e2e owns the key on this team's ID")
+	id, err := strconv.ParseUint(raw, 10, 32)
+	Expect(err).ToNot(HaveOccurred(), "TEST_TEAM_ID must be a uint32")
+	Expect(id).ToNot(BeZero(), "TEST_TEAM_ID must be a positive team id")
+	return uint32(id)
+}
 
 var _ = Describe("ApiKey", Ordered, func() {
 	var (
@@ -57,7 +69,7 @@ var _ = Describe("ApiKey", Ordered, func() {
 				Name:   apiKeyName,
 				Active: true,
 				Owner: coralogixv1alpha1.ApiKeyOwner{
-					TeamId: ptr.To(uint32(4013254)),
+					TeamId: ptr.To(teamIDFromEnv()),
 				},
 				Presets:     []string{"APM"},
 				Permissions: []string{"ALERTS-MAP:READ"},

--- a/tests/e2e/events2metrics_test.go
+++ b/tests/e2e/events2metrics_test.go
@@ -72,7 +72,6 @@ var _ = Describe("Events2Metric", Ordered, func() {
 			Spec: coralogixv1alpha1.Events2MetricSpec{
 				Name:              e2mName,
 				Description:       ptr.To("e2m from k8s operator"),
-				DataSource:        ptr.To("default/logs"),
 				PermutationsLimit: ptr.To(int32(100)),
 				MetricLabels: []coralogixv1alpha1.MetricLabel{
 					{
@@ -123,8 +122,12 @@ var _ = Describe("Events2Metric", Ordered, func() {
 			g.Expect(getE2mRes.E2m).ToNot(BeNil())
 			g.Expect(getE2mRes.E2m.Description).ToNot(BeNil())
 			g.Expect(*getE2mRes.E2m.Description).To(Equal("e2m from k8s operator"))
-			g.Expect(getE2mRes.E2m.DataSource).ToNot(BeNil())
-			g.Expect(*getE2mRes.E2m.DataSource).To(Equal("default/logs"))
+			// Named "default/logs" is rejected on accounts that have not
+			// provisioned that catalog entry. Omit the field so the backend
+			// uses the implicit logs stream.
+			if getE2mRes.E2m.DataSource != nil {
+				g.Expect(*getE2mRes.E2m.DataSource).To(BeEmpty())
+			}
 			g.Expect(getE2mRes.E2m.Permutations).ToNot(BeNil())
 			g.Expect(getE2mRes.E2m.Permutations.Limit).To(Equal(int32(100)))
 			g.Expect(getE2mRes.E2m.LogsQuery).ToNot(BeNil())


### PR DESCRIPTION
## Summary
- ApiKey e2e hardcoded a foreign team id, so live CI on the isolated operator team never created the key secret.
- Read `TEST_TEAM_ID` instead (same pattern as the Terraform provider). The GitHub secret is already set on this repo.
- **Events2Metric e2e:** stop setting `spec.dataSource: default/logs` on create. Falkor (FLK-148): omit the field so the backend uses the implicit logs stream. Named `default/logs` 400s on teams that have not provisioned that catalog entry; `""` also 400s. Unit conversion tests that still map the named string are unchanged.

## Test plan
- [x] e2e ApiKey create/update/delete on the isolated team
- [ ] Confirm `TEST_TEAM_ID` is present on e2e, helm-e2e, and upgrade-test workflows
- [x] Focused Events2Metric e2e (logs CRUD + spans) with `dataSource` omitted — 5 passed on the local docker-desktop operator

Made with [Cursor](https://cursor.com)