### PR TITLE
chore: bump operator version to 2.7.0

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "2.6.0"
+const OperatorVersion = "2.7.0"
 
 var (
 	scheme   = k8sruntime.NewScheme()


### PR DESCRIPTION
Bumps `OperatorVersion` in `cmd/main.go` from 2.6.0 to 2.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)