### PR TITLE
feat: align QuotaAllocationRuleSet with TF quota allocation gaps

### DIFF
--- a/api/coralogix/v1alpha1/quotaallocationruleset_types.go
+++ b/api/coralogix/v1alpha1/quotaallocationruleset_types.go
@@ -24,8 +24,12 @@ import (
 
 // QuotaAllocationRuleSetSpec defines the desired state of Coralogix quota allocation rules.
 type QuotaAllocationRuleSetSpec struct {
-	// Coralogix quota allocation rules.
-	// +kubebuilder:validation:MinItems=1
+	// Complete set of customer-managed quota allocation rules.
+	// Because the backend stores a single account-level rule set, the controller
+	// replaces the full customer-managed set during reconcile.
+	// Set rules to an empty list to clear all customer-managed rules.
+	// Coralogix-managed (cx_managed) rules are never taken from this list; the
+	// controller preserves them from the backend.
 	// +listType=map
 	// +listMapKey=entityType
 	Rules []QuotaAllocationRule `json:"rules"`
@@ -33,23 +37,37 @@ type QuotaAllocationRuleSetSpec struct {
 
 // QuotaAllocationRule defines quota allocation for a single entity type.
 type QuotaAllocationRule struct {
-	// Entity type to allocate quota for.
+	// Entity type covered by the rule.
+	// Known values include logs, spans, metrics, cpuProfiles, memoryProfiles,
+	// browserLogs, browserLogs/v2, sessionRecordings, olly, auditEvents, alerts,
+	// quotaEvents, engineQueries, engineSchemaFields, labsLimitViolations, and
+	// notificationDeliveries. The list is additive; the API may accept more
+	// values over time.
 	// +kubebuilder:validation:MinLength=1
 	EntityType string `json:"entityType"`
 
-	// Allocation value. Percent allocations are 0-100; locked unit allocations are absolute units.
+	// Quota allocation value for this entity type.
+	// For percentage, this is a share of the pool left after lockedUnits (0-100).
+	// For lockedUnits, this is a fixed reservation from the team daily quota.
+	// The sum of enabled locked units plus any Coralogix bundle units must fit
+	// within the team daily quota.
 	// Fractional values must be supplied as quoted quantities, for example "12.5".
 	Allocation resource.Quantity `json:"allocation"`
 
-	// Interprets allocation as a percentage, locked units, or unspecified.
-	// Defaults to percentage when omitted.
+	// How the allocation value is interpreted.
+	// Valid values are percentage (default) and lockedUnits.
+	// unspecified is accepted as a compatible alias of percentage and is
+	// normalized to percentage before the API call.
+	// Locked units are reserved first from the team daily quota; percentage
+	// rules share the remaining pool and their enabled allocations must sum to
+	// at most 100.
 	// +optional
 	AllocationType *QuotaAllocationType `json:"allocationType,omitempty"`
 
 	// Whether this quota allocation rule is enabled.
 	Enabled bool `json:"enabled"`
 
-	// Whether this quota allocation rule can overflow.
+	// Whether this entity type can overflow beyond its allocation.
 	CanOverflow bool `json:"canOverflow"`
 }
 
@@ -66,7 +84,6 @@ const (
 var quotaAllocationTypeSchemaToOpenAPI = map[QuotaAllocationType]quotas.QuotaAllocationType{
 	QuotaAllocationTypePercentage:  quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_PERCENTAGE,
 	QuotaAllocationTypeLockedUnits: quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_LOCKED_UNITS,
-	QuotaAllocationTypeUnspecified: quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_UNSPECIFIED,
 }
 
 var maxQuotaAllocationPercentage = resource.MustParse("100")
@@ -109,6 +126,9 @@ func (r *QuotaAllocationRule) ExtractQuotaAllocationEntityTypeRule() quotas.Quot
 	allocationType := QuotaAllocationTypePercentage
 	if r.AllocationType != nil {
 		allocationType = *r.AllocationType
+	}
+	if allocationType == QuotaAllocationTypeUnspecified {
+		allocationType = QuotaAllocationTypePercentage
 	}
 	openAPIAllocationType := quotaAllocationTypeSchemaToOpenAPI[allocationType]
 
@@ -157,8 +177,10 @@ func (q *QuotaAllocationRuleSet) HasIDInStatus() bool {
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // QuotaAllocationRuleSet is the Schema for the QuotaAllocationRuleSet API.
 // NOTE: This account-level singleton resource replaces all user-managed backend
-// quota allocation rules. Coralogix-managed rules returned by the backend are
-// preserved by the controller.
+// quota allocation rules. An empty rules list clears customer-managed rules.
+// Delete clears customer-managed rules only. Coralogix-managed (cx_managed)
+// rules returned by the backend are preserved by the controller and are never
+// taken from the CR.
 //
 // **Added in v0.4.0**
 type QuotaAllocationRuleSet struct {

--- a/api/coralogix/v1alpha1/quotaallocationruleset_types_test.go
+++ b/api/coralogix/v1alpha1/quotaallocationruleset_types_test.go
@@ -40,6 +40,34 @@ func TestExtractQuotaAllocationRuleSetRequestDefaultsAllocationType(t *testing.T
 	require.Nil(t, ruleSet.Rules[0].CxManaged)
 }
 
+func TestExtractQuotaAllocationRuleSetRequestAllowsEmptyRules(t *testing.T) {
+	spec := &QuotaAllocationRuleSetSpec{
+		Rules: []QuotaAllocationRule{},
+	}
+
+	ruleSet, err := spec.ExtractQuotaAllocationRuleSetRequest()
+	require.NoError(t, err)
+	require.Empty(t, ruleSet.Rules)
+}
+
+func TestExtractQuotaAllocationRuleSetRequestNormalizesUnspecifiedToPercentage(t *testing.T) {
+	allocationType := QuotaAllocationTypeUnspecified
+	spec := &QuotaAllocationRuleSetSpec{
+		Rules: []QuotaAllocationRule{{
+			EntityType:     "logs",
+			Allocation:     resource.MustParse("60"),
+			AllocationType: &allocationType,
+			Enabled:        true,
+			CanOverflow:    true,
+		}},
+	}
+
+	ruleSet, err := spec.ExtractQuotaAllocationRuleSetRequest()
+	require.NoError(t, err)
+	require.Len(t, ruleSet.Rules, 1)
+	require.Equal(t, quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_PERCENTAGE, ruleSet.Rules[0].GetAllocationType())
+}
+
 func TestExtractQuotaAllocationRuleSetRequestMapsLockedUnits(t *testing.T) {
 	allocationType := QuotaAllocationTypeLockedUnits
 	spec := &QuotaAllocationRuleSetSpec{

--- a/charts/coralogix-operator/templates/crds/coralogix.com_quotaallocationrulesets.yaml
+++ b/charts/coralogix-operator/templates/crds/coralogix.com_quotaallocationrulesets.yaml
@@ -28,8 +28,10 @@ spec:
         description: |-
           QuotaAllocationRuleSet is the Schema for the QuotaAllocationRuleSet API.
           NOTE: This account-level singleton resource replaces all user-managed backend
-          quota allocation rules. Coralogix-managed rules returned by the backend are
-          preserved by the controller.
+          quota allocation rules. An empty rules list clears customer-managed rules.
+          Delete clears customer-managed rules only. Coralogix-managed (cx_managed)
+          rules returned by the backend are preserved by the controller and are never
+          taken from the CR.
 
           **Added in v0.4.0**
         properties:
@@ -55,7 +57,13 @@ spec:
               quota allocation rules.
             properties:
               rules:
-                description: Coralogix quota allocation rules.
+                description: |-
+                  Complete set of customer-managed quota allocation rules.
+                  Because the backend stores a single account-level rule set, the controller
+                  replaces the full customer-managed set during reconcile.
+                  Set rules to an empty list to clear all customer-managed rules.
+                  Coralogix-managed (cx_managed) rules are never taken from this list; the
+                  controller preserves them from the backend.
                 items:
                   description: QuotaAllocationRule defines quota allocation for a
                     single entity type.
@@ -65,27 +73,43 @@ spec:
                       - type: integer
                       - type: string
                       description: |-
-                        Allocation value. Percent allocations are 0-100; locked unit allocations are absolute units.
+                        Quota allocation value for this entity type.
+                        For percentage, this is a share of the pool left after lockedUnits (0-100).
+                        For lockedUnits, this is a fixed reservation from the team daily quota.
+                        The sum of enabled locked units plus any Coralogix bundle units must fit
+                        within the team daily quota.
                         Fractional values must be supplied as quoted quantities, for example "12.5".
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     allocationType:
                       description: |-
-                        Interprets allocation as a percentage, locked units, or unspecified.
-                        Defaults to percentage when omitted.
+                        How the allocation value is interpreted.
+                        Valid values are percentage (default) and lockedUnits.
+                        unspecified is accepted as a compatible alias of percentage and is
+                        normalized to percentage before the API call.
+                        Locked units are reserved first from the team daily quota; percentage
+                        rules share the remaining pool and their enabled allocations must sum to
+                        at most 100.
                       enum:
                       - percentage
                       - lockedUnits
                       - unspecified
                       type: string
                     canOverflow:
-                      description: Whether this quota allocation rule can overflow.
+                      description: Whether this entity type can overflow beyond its
+                        allocation.
                       type: boolean
                     enabled:
                       description: Whether this quota allocation rule is enabled.
                       type: boolean
                     entityType:
-                      description: Entity type to allocate quota for.
+                      description: |-
+                        Entity type covered by the rule.
+                        Known values include logs, spans, metrics, cpuProfiles, memoryProfiles,
+                        browserLogs, browserLogs/v2, sessionRecordings, olly, auditEvents, alerts,
+                        quotaEvents, engineQueries, engineSchemaFields, labsLimitViolations, and
+                        notificationDeliveries. The list is additive; the API may accept more
+                        values over time.
                       minLength: 1
                       type: string
                   required:
@@ -94,7 +118,6 @@ spec:
                   - enabled
                   - entityType
                   type: object
-                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - entityType

--- a/config/crd/bases/coralogix.com_quotaallocationrulesets.yaml
+++ b/config/crd/bases/coralogix.com_quotaallocationrulesets.yaml
@@ -27,8 +27,10 @@ spec:
         description: |-
           QuotaAllocationRuleSet is the Schema for the QuotaAllocationRuleSet API.
           NOTE: This account-level singleton resource replaces all user-managed backend
-          quota allocation rules. Coralogix-managed rules returned by the backend are
-          preserved by the controller.
+          quota allocation rules. An empty rules list clears customer-managed rules.
+          Delete clears customer-managed rules only. Coralogix-managed (cx_managed)
+          rules returned by the backend are preserved by the controller and are never
+          taken from the CR.
 
           **Added in v0.4.0**
         properties:
@@ -54,7 +56,13 @@ spec:
               quota allocation rules.
             properties:
               rules:
-                description: Coralogix quota allocation rules.
+                description: |-
+                  Complete set of customer-managed quota allocation rules.
+                  Because the backend stores a single account-level rule set, the controller
+                  replaces the full customer-managed set during reconcile.
+                  Set rules to an empty list to clear all customer-managed rules.
+                  Coralogix-managed (cx_managed) rules are never taken from this list; the
+                  controller preserves them from the backend.
                 items:
                   description: QuotaAllocationRule defines quota allocation for a
                     single entity type.
@@ -64,27 +72,43 @@ spec:
                       - type: integer
                       - type: string
                       description: |-
-                        Allocation value. Percent allocations are 0-100; locked unit allocations are absolute units.
+                        Quota allocation value for this entity type.
+                        For percentage, this is a share of the pool left after lockedUnits (0-100).
+                        For lockedUnits, this is a fixed reservation from the team daily quota.
+                        The sum of enabled locked units plus any Coralogix bundle units must fit
+                        within the team daily quota.
                         Fractional values must be supplied as quoted quantities, for example "12.5".
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     allocationType:
                       description: |-
-                        Interprets allocation as a percentage, locked units, or unspecified.
-                        Defaults to percentage when omitted.
+                        How the allocation value is interpreted.
+                        Valid values are percentage (default) and lockedUnits.
+                        unspecified is accepted as a compatible alias of percentage and is
+                        normalized to percentage before the API call.
+                        Locked units are reserved first from the team daily quota; percentage
+                        rules share the remaining pool and their enabled allocations must sum to
+                        at most 100.
                       enum:
                       - percentage
                       - lockedUnits
                       - unspecified
                       type: string
                     canOverflow:
-                      description: Whether this quota allocation rule can overflow.
+                      description: Whether this entity type can overflow beyond its
+                        allocation.
                       type: boolean
                     enabled:
                       description: Whether this quota allocation rule is enabled.
                       type: boolean
                     entityType:
-                      description: Entity type to allocate quota for.
+                      description: |-
+                        Entity type covered by the rule.
+                        Known values include logs, spans, metrics, cpuProfiles, memoryProfiles,
+                        browserLogs, browserLogs/v2, sessionRecordings, olly, auditEvents, alerts,
+                        quotaEvents, engineQueries, engineSchemaFields, labsLimitViolations, and
+                        notificationDeliveries. The list is additive; the API may accept more
+                        values over time.
                       minLength: 1
                       type: string
                   required:
@@ -93,7 +117,6 @@ spec:
                   - enabled
                   - entityType
                   type: object
-                minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
                 - entityType

--- a/config/samples/v1alpha1/quotaallocationruleset/example-quota-allocation-rule-set.yaml
+++ b/config/samples/v1alpha1/quotaallocationruleset/example-quota-allocation-rule-set.yaml
@@ -5,12 +5,22 @@ metadata:
 spec:
   rules:
     - entityType: logs
-      allocation: 60
+      allocation: 50
       allocationType: percentage
       enabled: true
       canOverflow: true
-    - entityType: metrics
-      allocation: 40
+    - entityType: spans
+      allocation: 1
+      allocationType: lockedUnits
+      enabled: true
+      canOverflow: false
+    - entityType: browserLogs
+      allocation: 10
+      allocationType: percentage
+      enabled: true
+      canOverflow: false
+    - entityType: browserLogs/v2
+      allocation: 10
       allocationType: percentage
       enabled: true
       canOverflow: false

--- a/docs/api.md
+++ b/docs/api.md
@@ -15999,8 +15999,10 @@ with respect to the current state of the instance.<br/>
 
 QuotaAllocationRuleSet is the Schema for the QuotaAllocationRuleSet API.
 NOTE: This account-level singleton resource replaces all user-managed backend
-quota allocation rules. Coralogix-managed rules returned by the backend are
-preserved by the controller.
+quota allocation rules. An empty rules list clears customer-managed rules.
+Delete clears customer-managed rules only. Coralogix-managed (cx_managed)
+rules returned by the backend are preserved by the controller and are never
+taken from the CR.
 
 **Added in v0.4.0**
 
@@ -16068,7 +16070,12 @@ QuotaAllocationRuleSetSpec defines the desired state of Coralogix quota allocati
         <td><b><a href="#quotaallocationrulesetspecrulesindex">rules</a></b></td>
         <td>[]object</td>
         <td>
-          Coralogix quota allocation rules.<br/>
+          Complete set of customer-managed quota allocation rules.
+Because the backend stores a single account-level rule set, the controller
+replaces the full customer-managed set during reconcile.
+Set rules to an empty list to clear all customer-managed rules.
+Coralogix-managed (cx_managed) rules are never taken from this list; the
+controller preserves them from the backend.<br/>
         </td>
         <td>true</td>
       </tr></tbody>
@@ -16095,7 +16102,11 @@ QuotaAllocationRule defines quota allocation for a single entity type.
         <td><b>allocation</b></td>
         <td>int or string</td>
         <td>
-          Allocation value. Percent allocations are 0-100; locked unit allocations are absolute units.
+          Quota allocation value for this entity type.
+For percentage, this is a share of the pool left after lockedUnits (0-100).
+For lockedUnits, this is a fixed reservation from the team daily quota.
+The sum of enabled locked units plus any Coralogix bundle units must fit
+within the team daily quota.
 Fractional values must be supplied as quoted quantities, for example "12.5".<br/>
         </td>
         <td>true</td>
@@ -16103,7 +16114,7 @@ Fractional values must be supplied as quoted quantities, for example "12.5".<br/
         <td><b>canOverflow</b></td>
         <td>boolean</td>
         <td>
-          Whether this quota allocation rule can overflow.<br/>
+          Whether this entity type can overflow beyond its allocation.<br/>
         </td>
         <td>true</td>
       </tr><tr>
@@ -16117,15 +16128,25 @@ Fractional values must be supplied as quoted quantities, for example "12.5".<br/
         <td><b>entityType</b></td>
         <td>string</td>
         <td>
-          Entity type to allocate quota for.<br/>
+          Entity type covered by the rule.
+Known values include logs, spans, metrics, cpuProfiles, memoryProfiles,
+browserLogs, browserLogs/v2, sessionRecordings, olly, auditEvents, alerts,
+quotaEvents, engineQueries, engineSchemaFields, labsLimitViolations, and
+notificationDeliveries. The list is additive; the API may accept more
+values over time.<br/>
         </td>
         <td>true</td>
       </tr><tr>
         <td><b>allocationType</b></td>
         <td>enum</td>
         <td>
-          Interprets allocation as a percentage, locked units, or unspecified.
-Defaults to percentage when omitted.<br/>
+          How the allocation value is interpreted.
+Valid values are percentage (default) and lockedUnits.
+unspecified is accepted as a compatible alias of percentage and is
+normalized to percentage before the API call.
+Locked units are reserved first from the team daily quota; percentage
+rules share the remaining pool and their enabled allocations must sum to
+at most 100.<br/>
           <br/>
             <i>Enum</i>: percentage, lockedUnits, unspecified<br/>
         </td>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coralogix/coralogix-operator/v2
 go 1.26.0
 
 require (
-	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161
+	github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260901135128-ebe5270f4da1
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161 h1:4KrRh0yXLKXl8dIovpoC7ACOI6Lbg7G35TzOxRpeNEo=
-github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260831113530-20693929d161/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260901135128-ebe5270f4da1 h1:yxtXRRkZ2Dmwv1nqErVvy/k4VN6dOBn6CqwOqKGLe0M=
+github.com/coralogix/coralogix-management-sdk v1.9.4-0.20260901135128-ebe5270f4da1/go.mod h1:ozYTXFgLfRR6Whmn89kYrgAlJgwxUDCqDDKb4HwfkrU=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c h1:aOfG9Pwe7Fp/m+tdybObODwgeK5st/+9df/QUw0dzBQ=
 github.com/coralogix/grpc-gateway/v2 v2.0.0-20251015134251-4d8694a21a7c/go.mod h1:bqGO/kNOHTFiDIfPmXLQcox10aWQs5Q3b9sXUFoaFFk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/tests/e2e/quota_allocation_rule_set_test.go
+++ b/tests/e2e/quota_allocation_rule_set_test.go
@@ -72,10 +72,17 @@ var _ = Describe("QuotaAllocationRuleSet", Ordered, func() {
 				Rules: []coralogixv1alpha1.QuotaAllocationRule{
 					{
 						EntityType:     "logs",
-						Allocation:     resource.MustParse("60"),
+						Allocation:     resource.MustParse("50"),
 						AllocationType: quotaAllocationTypePtr(coralogixv1alpha1.QuotaAllocationTypePercentage),
 						Enabled:        true,
 						CanOverflow:    true,
+					},
+					{
+						EntityType:     "spans",
+						Allocation:     resource.MustParse("1"),
+						AllocationType: quotaAllocationTypePtr(coralogixv1alpha1.QuotaAllocationTypeLockedUnits),
+						Enabled:        true,
+						CanOverflow:    false,
 					},
 					{
 						EntityType:     "metrics",
@@ -106,7 +113,7 @@ var _ = Describe("QuotaAllocationRuleSet", Ordered, func() {
 		}, time.Minute, time.Second).Should(BeTrue())
 	})
 
-	It("Should create and delete QuotaAllocationRuleSet successfully", func(ctx context.Context) {
+	It("Should create, clear with empty rules, and delete QuotaAllocationRuleSet successfully", func(ctx context.Context) {
 		By("Creating QuotaAllocationRuleSet")
 		Expect(crClient.Create(ctx, ruleSet)).To(Succeed())
 
@@ -123,13 +130,20 @@ var _ = Describe("QuotaAllocationRuleSet", Ordered, func() {
 			backendRuleSet, err := getQuotaAllocationRuleSet(ctx, quotasClient)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "logs")).ToNot(BeNil())
+			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "spans")).ToNot(BeNil())
 			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "metrics")).ToNot(BeNil())
 
 			logsRule := findUserQuotaAllocationRule(backendRuleSet.Rules, "logs")
-			g.Expect(logsRule.Allocation).To(Equal(float32(60)))
+			g.Expect(logsRule.Allocation).To(Equal(float32(50)))
 			g.Expect(logsRule.GetAllocationType()).To(Equal(quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_PERCENTAGE))
 			g.Expect(logsRule.Enabled).To(BeTrue())
 			g.Expect(logsRule.CanOverflow).To(BeTrue())
+
+			spansRule := findUserQuotaAllocationRule(backendRuleSet.Rules, "spans")
+			g.Expect(spansRule.Allocation).To(Equal(float32(1)))
+			g.Expect(spansRule.GetAllocationType()).To(Equal(quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_LOCKED_UNITS))
+			g.Expect(spansRule.Enabled).To(BeTrue())
+			g.Expect(spansRule.CanOverflow).To(BeFalse())
 
 			metricsRule := findUserQuotaAllocationRule(backendRuleSet.Rules, "metrics")
 			g.Expect(metricsRule.Allocation).To(Equal(float32(40)))
@@ -138,14 +152,42 @@ var _ = Describe("QuotaAllocationRuleSet", Ordered, func() {
 			g.Expect(metricsRule.CanOverflow).To(BeFalse())
 		}, time.Minute, time.Second).Should(Succeed())
 
-		By("Deleting the QuotaAllocationRuleSet")
-		Expect(crClient.Delete(ctx, ruleSet)).To(Succeed())
+		By("Updating QuotaAllocationRuleSet to clear customer-managed rules")
+		Eventually(func(g Gomega) {
+			fetched := &coralogixv1alpha1.QuotaAllocationRuleSet{}
+			g.Expect(crClient.Get(ctx, client.ObjectKey{Name: crName, Namespace: testNamespace}, fetched)).To(Succeed())
+			fetched.Spec.Rules = []coralogixv1alpha1.QuotaAllocationRule{}
+			g.Expect(crClient.Update(ctx, fetched)).To(Succeed())
+			*ruleSet = *fetched
+		}, time.Minute, time.Second).Should(Succeed())
 
-		By("Verifying user-managed quota allocation rules were deleted in Coralogix backend")
+		By("Verifying QuotaAllocationRuleSet stays synced with empty rules")
+		Eventually(func(g Gomega) {
+			fetched := &coralogixv1alpha1.QuotaAllocationRuleSet{}
+			g.Expect(crClient.Get(ctx, client.ObjectKey{Name: crName, Namespace: testNamespace}, fetched)).To(Succeed())
+			g.Expect(fetched.Spec.Rules).To(BeEmpty())
+			g.Expect(meta.IsStatusConditionTrue(fetched.Status.Conditions, utils.ConditionTypeRemoteSynced)).To(BeTrue())
+			g.Expect(fetched.Status.PrintableStatus).To(Equal("RemoteSynced"))
+		}, time.Minute, time.Second).Should(Succeed())
+
+		By("Verifying customer-managed quota allocation rules were cleared in Coralogix backend")
 		Eventually(func(g Gomega) {
 			backendRuleSet, err := getQuotaAllocationRuleSet(ctx, quotasClient)
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "logs")).To(BeNil())
+			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "spans")).To(BeNil())
+			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "metrics")).To(BeNil())
+		}, time.Minute, time.Second).Should(Succeed())
+
+		By("Deleting the QuotaAllocationRuleSet")
+		Expect(crClient.Delete(ctx, ruleSet)).To(Succeed())
+
+		By("Verifying user-managed quota allocation rules remain cleared in Coralogix backend")
+		Eventually(func(g Gomega) {
+			backendRuleSet, err := getQuotaAllocationRuleSet(ctx, quotasClient)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "logs")).To(BeNil())
+			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "spans")).To(BeNil())
 			g.Expect(findUserQuotaAllocationRule(backendRuleSet.Rules, "metrics")).To(BeNil())
 		}, time.Minute, time.Second).Should(Succeed())
 	})


### PR DESCRIPTION
## Summary
- Allow `spec.rules: []` to clear customer-managed quota allocation rules (TF parity with terraform-provider-coralogix#706 / CX-56436).
- Normalize `allocationType: unspecified` to `percentage` on extract; expand CRD docs for entity types, locked units, `cx_managed`, and delete semantics.
- Extend sample + unit/e2e coverage; bump `coralogix-management-sdk` to tip (`ebe5270f`).

## Test plan
- [x] `make lint` / `make unit-tests`
- [x] Focused e2e: `./scripts/run-e2e.sh QuotaAllocationRuleSet` (Kind + EU2)
- [x] Pre-commit gitleaks + manual scan for `cxup_` / API key patterns (public repo)


Made with [Cursor](https://cursor.com)