### PR TITLE
test: use percentage-only quota e2e fixture (CX-56436)

### DIFF
--- a/tests/e2e/quota_allocation_rule_set_test.go
+++ b/tests/e2e/quota_allocation_rule_set_test.go
@@ -69,6 +69,7 @@ var _ = Describe("QuotaAllocationRuleSet", Ordered, func() {
 				Namespace: testNamespace,
 			},
 			Spec: coralogixv1alpha1.QuotaAllocationRuleSetSpec{
+				// Percentage only. Locked units are bounded by the team daily quota, which can be below 1 in CI.
 				Rules: []coralogixv1alpha1.QuotaAllocationRule{
 					{
 						EntityType:     "logs",
@@ -79,8 +80,8 @@ var _ = Describe("QuotaAllocationRuleSet", Ordered, func() {
 					},
 					{
 						EntityType:     "spans",
-						Allocation:     resource.MustParse("1"),
-						AllocationType: quotaAllocationTypePtr(coralogixv1alpha1.QuotaAllocationTypeLockedUnits),
+						Allocation:     resource.MustParse("10"),
+						AllocationType: quotaAllocationTypePtr(coralogixv1alpha1.QuotaAllocationTypePercentage),
 						Enabled:        true,
 						CanOverflow:    false,
 					},
@@ -140,8 +141,8 @@ var _ = Describe("QuotaAllocationRuleSet", Ordered, func() {
 			g.Expect(logsRule.CanOverflow).To(BeTrue())
 
 			spansRule := findUserQuotaAllocationRule(backendRuleSet.Rules, "spans")
-			g.Expect(spansRule.Allocation).To(Equal(float32(1)))
-			g.Expect(spansRule.GetAllocationType()).To(Equal(quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_LOCKED_UNITS))
+			g.Expect(spansRule.Allocation).To(Equal(float32(10)))
+			g.Expect(spansRule.GetAllocationType()).To(Equal(quotas.QUOTAALLOCATIONTYPE_QUOTA_ALLOCATION_TYPE_PERCENTAGE))
 			g.Expect(spansRule.Enabled).To(BeTrue())
 			g.Expect(spansRule.CanOverflow).To(BeFalse())
 


### PR DESCRIPTION
## Summary
- Live `QuotaAllocationRuleSet` e2e now uses percentage rules only (`logs` 50, `spans` 10, `metrics` 40).
- Locked units are bounded by the team daily quota. CI can be below 1 unit, so `lockedUnits: 1` never reaches `RemoteSynced`.
- Unit tests and the sample YAML still cover `lockedUnits`. This change is the live fixture only. No secrets.

## Test plan
- [ ] Operator live e2e: `QuotaAllocationRuleSet` create/sync/clear/delete
- [ ] Confirm the spec no longer returns `locked units exceed quota`


Made with [Cursor](https://cursor.com)