### PR TITLE
chore: bump operator version to 2.8.0

### DIFF
--- a/charts/coralogix-operator/Chart.yaml
+++ b/charts/coralogix-operator/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
 name: coralogix-operator
 sources:
   - https://github.com/coralogix/coralogix-operator
-version: 2.1.0
-appVersion: 2.1.0
+version: 2.8.0
+appVersion: 2.8.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/coralogix/coralogix-operator
 keywords:

--- a/charts/coralogix-operator/README.md
+++ b/charts/coralogix-operator/README.md
@@ -1,6 +1,6 @@
 # coralogix-operator
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Coralogix Operator Helm Chart
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-const OperatorVersion = "2.7.0"
+const OperatorVersion = "2.8.0"
 
 var (
 	scheme   = k8sruntime.NewScheme()


### PR DESCRIPTION
Bumps `OperatorVersion` in `cmd/main.go` from 2.7.0 to 2.8.0.

Also brings the chart version bump from the release branch to main, so `charts/coralogix-operator` no longer sits at 2.1.0:
- `Chart.yaml`: `version` and `appVersion` 2.1.0 -> 2.8.0
- chart `README.md`: version badges regenerated

These are the same changes as #582 on `release-2.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)