### PR TITLE
Add agent skill for proto-size vs CRD implementation budget

### DIFF
--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: proto-size-impl-budget
-description: "Use when reviewing or adding an operator CRD. Estimate types+controller size from pinned SDK fields and flag 3x overruns. Do NOT use for small field tweaks or dashboard JSON-blob edits."
+description: "Use when reviewing or adding an operator CRD. Estimate types+controller Go from pinned SDK fields and flag 3x overruns. Do NOT use for small field tweaks or dashboard JSON-blob edits."
 ---
 
 # SDK size vs CRD implementation budget
 
 **Trigger:** A new or large `*_types.go` plus controller for one management API.
 
-**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio. Compare implementation lines (CRD Spec/Status types + Extract/Handle/Reconcile; skip tests and generated deepcopy). Operator has no flatten; spec is the source of truth.
+**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
 
-- Expected: `2.7 × fields + 75`
-- Typical band: about `2×fields+65` to `4.5×fields+80`
+Count **all non-test, non-example `.go` lines** for that CRD: Spec/Status types, controller, helpers, and any generated client copied into this repo. Skip tests, examples, docs, and generated deepcopy. Compare:
 
-Flag only extremes: about **3× the midpoint** or more. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent, as with Dashboard). Alert is a deep-expand class (~5 lines/field); do not score other APIs against it.
+- Expected: `6.5 × fields`
+- Typical band: about `4×` to `10×`
 
-**Why:** The pinned SDK is the surface this operator can implement. Typical APIs are not linear enough for a linter. A large ratio still catches expanding a small API like a dashboard.
+Flag only extremes: about **3× the midpoint** or more. A copied OpenAPI/SDK client is included in the line count, so it shows up here. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent, as with Dashboard). Alert is a deep-expand class (~7 lines/field); do not score other APIs against it.
+
+**Why:** The pinned SDK is the surface this operator can implement. Typical APIs are not linear enough for a linter. Counting all Go, not only Extract/Handle, is what catches a dumped generated client.

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -7,7 +7,7 @@ description: "Use when reviewing or adding an operator CRD. Estimate types+contr
 
 **Trigger:** A new or large `*_types.go` plus controller for one management API.
 
-**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
+**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Count **this kind only**. If one gen package backs several kinds (for example `policies_service` for three TCO CRDs), do not use the whole package. Use this kind’s types (name prefixes, or models reachable from its create/get/replace requests). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
 
 Count **all non-test, non-example `.go` lines** for that CRD: Spec/Status types, controller, helpers, and any generated client copied into this repo. Skip tests, examples, docs, and generated deepcopy. Compare:
 

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -12,8 +12,8 @@ description: "Use when reviewing or adding an operator CRD. Estimate types+contr
 Count **all non-test, non-example `.go` lines** for that CRD: Spec/Status types, controller, helpers, and any generated client copied into this repo. Skip tests, examples, docs, and generated deepcopy. Compare:
 
 - Expected: `6.5 × fields`
-- Typical band: about `4×` to `10×`
+- Typical band: about `4×` to `9×`
 
-Flag only extremes: about **3× the midpoint** or more. A copied OpenAPI/SDK client is included in the line count, so it shows up here. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent, as with Dashboard). Alert is a deep-expand class (~7 lines/field); do not score other APIs against it.
+Flag only extremes: about **3× the midpoint** or more. A copied OpenAPI/SDK client is included in the line count, so it shows up here. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent, as with Dashboard). Alert sits in this band (~7×). Do not give it a separate formula.
 
 **Why:** The pinned SDK is the surface this operator can implement. Typical APIs are not linear enough for a linter. Counting all Go, not only Extract/Handle, is what catches a dumped generated client.

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: proto-size-impl-budget
-description: "Use when reviewing or adding an operator CRD. Estimate types+controller size from proto fields and flag 3x overruns. Do NOT use for small field tweaks or dashboard JSON-blob edits."
+description: "Use when reviewing or adding an operator CRD. Estimate types+controller size from pinned SDK fields and flag 3x overruns. Do NOT use for small field tweaks or dashboard JSON-blob edits."
 ---
 
-# Proto size vs CRD implementation budget
+# SDK size vs CRD implementation budget
 
 **Trigger:** A new or large `*_types.go` plus controller for one management API.
 
-**Fix:** Count numbered proto fields for that API in the public `coralogix/cx-management-apis` repo. If protos are missing, count fields on the generated SDK structs. If neither exists, skip the ratio. Compare implementation lines (CRD Spec/Status types + Extract/Handle/Reconcile; skip tests and generated deepcopy). Operator has no flatten; spec is the source of truth.
+**Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio. Compare implementation lines (CRD Spec/Status types + Extract/Handle/Reconcile; skip tests and generated deepcopy). Operator has no flatten; spec is the source of truth.
 
-- Expected: `2.4 × fields + 75`
-- Typical band: about `1.5×fields+50` to `4×fields+90`
+- Expected: `2.7 × fields + 75`
+- Typical band: about `2×fields+65` to `4.5×fields+80`
 
-Flag only extremes: about **3× the midpoint** or more. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent, as with Dashboard). Alert is a deep-expand class (~4 lines/field); do not score other APIs against it. Use field count, not proto lines.
+Flag only extremes: about **3× the midpoint** or more. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent, as with Dashboard). Alert is a deep-expand class (~5 lines/field); do not score other APIs against it.
 
-**Why:** Typical APIs are not linear enough for a linter. A large ratio still catches expanding a small proto like a dashboard.
+**Why:** The pinned SDK is the surface this operator can implement. Typical APIs are not linear enough for a linter. A large ratio still catches expanding a small API like a dashboard.

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -9,7 +9,7 @@ description: "Use when reviewing or adding an operator CRD. Estimate types+contr
 
 **Fix:** Count exported JSON-tagged fields on generated model structs in the **pinned** `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Count **this kind only**. If one gen package backs several kinds (for example `policies_service` for three TCO CRDs), do not use the whole package. Use this kind’s types (name prefixes, or models reachable from its create/get/replace requests). Skip duplicated OpenAPI filter/error types. Do not use live proto HEAD. If the SDK has no types for that API, skip the ratio.
 
-Count **all non-test, non-example `.go` lines** for that CRD: Spec/Status types, controller, helpers, and any generated client copied into this repo. Skip tests, examples, docs, and generated deepcopy. Compare:
+Count **non-blank, non-comment** lines in non-test, non-example `.go` files for that CRD: Spec/Status types, controller, helpers, and any generated client copied into this repo. Do not use `wc -l` (physical lines). Skip tests, examples, docs, and generated deepcopy. Compare:
 
 - Expected: `6.5 × fields`
 - Typical band: about `4×` to `9×`

--- a/.claude/skills/proto-size-impl-budget/SKILL.md
+++ b/.claude/skills/proto-size-impl-budget/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: proto-size-impl-budget
+description: "Use when reviewing or adding an operator CRD. Estimate types+controller size from proto fields and flag 3x overruns. Do NOT use for small field tweaks or dashboard JSON-blob edits."
+---
+
+# Proto size vs CRD implementation budget
+
+**Trigger:** A new or large `*_types.go` plus controller for one management API.
+
+**Fix:** Count numbered proto fields for that API in the public `coralogix/cx-management-apis` repo. If protos are missing, count fields on the generated SDK structs. If neither exists, skip the ratio. Compare implementation lines (CRD Spec/Status types + Extract/Handle/Reconcile; skip tests and generated deepcopy). Operator has no flatten; spec is the source of truth.
+
+- Expected: `2.4 × fields + 75`
+- Typical band: about `1.5×fields+50` to `4×fields+90`
+
+Flag only extremes: about **3× the midpoint** or more. In-band is not a pass; still read the code. Below-band is often a JSON blob (valid if that was the intent, as with Dashboard). Alert is a deep-expand class (~4 lines/field); do not score other APIs against it. Use field count, not proto lines.
+
+**Why:** Typical APIs are not linear enough for a linter. A large ratio still catches expanding a small proto like a dashboard.

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ kubeconfig
 *.swp
 *.swo
 *~
+
+# Claude Code per-user settings (allow-lists, model overrides, etc.)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ Use this map to choose the smallest useful reading set before opening broad dire
 - `docs/api.md` is generated from CRDs. `docs/prometheus-integration.md` and `docs/metrics.md` are hand-written.
 - `tests/e2e/` contains Go/Ginkgo tests that hit real Coralogix APIs. `tests/integration/` contains KUTTL scenarios.
 - `tools/cxo-observer/` is a supporting observer tool.
+- `.claude/skills/<skill-name>/SKILL.md` stores short agent lessons. `.cursor/skills` is a symlink to that directory.
 
 Primary resource kinds:
 


### PR DESCRIPTION
## Summary

Adds one agent skill: `.claude/skills/proto-size-impl-budget/SKILL.md`.

This is not a linter and not CI. An agent loads it when adding or reviewing an operator CRD.

Companion Terraform PR: https://github.com/coralogix/terraform-provider-coralogix/pull/728

Also adds the skill discovery path this repo did not have yet:

- `.cursor/skills` symlink to `.claude/skills`
- `.gitignore` entry for `.claude/settings.local.json`
- One repo-map line in `AGENTS.md`

## Measurements (short)

**Denominator:** exported JSON-tagged fields on generated model structs in the pinned `coralogix-management-sdk` from `go.mod` (`go/openapi/gen/<service>`). Duplicated OpenAPI filter/error types were skipped. Live proto HEAD was not used.

**Numerator:** all non-test, non-example `.go` lines for that CRD (Spec/Status types, controller, helpers, and any generated client copied into this repo). Tests, examples, docs, and generated deepcopy were excluded.

Typical CRDs, **including dashboard and alert**:

- About **6.5 lines per SDK field**
- Common band: about `4×` to `9×`

Alert is about 7× and sits in this band. Dashboard is often a JSON blob (about 0.2×, below the band; valid if that was the intent). They do not get a separate formula.

A copied OpenAPI/SDK client is part of the Go count, so it lands in the ratio.

The skill flags only extremes: about **3× the midpoint**. In-band is not a pass. The code still needs a review.

## Test plan

- [x] Skill text has no secrets, customer data, or internal ticket IDs
- [ ] Open a new-CRD task in an agent and confirm it loads this skill