### PR TITLE
ci: authenticate to JFrog via GitHub OIDC for helm chart upload

### DIFF
--- a/.github/workflows/helm-chart-deploy.yml
+++ b/.github/workflows/helm-chart-deploy.yml
@@ -8,16 +8,15 @@ on:
     paths:
       - charts/coralogix-operator/Chart.yaml
 
-# The chart is uploaded to Artifactory with credentials from secrets.*, so the workflow token
-# only ever needs to read the repo.
+# The chart is uploaded to Artifactory using a short-lived token obtained via GitHub OIDC
+# (id-token: write). contents: read is all the workflow token itself needs.
 permissions:
   contents: read
+  id-token: write # OIDC token for the JFrog exchange
 
 env:
   CHART_VERSION: $(yq eval '.version' charts/coralogix-operator/Chart.yaml)
   CHART_NAME: coralogix-operator
-  ARTIFACTORY_URL: https://cgx.jfrog.io/artifactory/
-  ARTIFACTORY_USERNAME: integrations-actions
 
 jobs:
   build:
@@ -25,15 +24,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0
+      - name: Set up JFrog CLI
+        # Exchanges this job's GitHub OIDC JWT for a short-lived Artifactory token,
+        # replacing the rotated JFROG_USER / JFROG_PASSWORD secret pair. The action
+        # calls core.setSecret() on its outputs, so the token stays masked in the log.
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://cgx.jfrog.io
+        with:
+          oidc-provider-name: github
+          oidc-audience: jfrog-github
       - name: Setup Helm Repo
         run: |
           cd charts/coralogix-operator
           helm package .
-      - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v2.1.0
-        with:
-          version: 2.12.1
       - name: use-jfrog-cli
         run: |
           cd charts/coralogix-operator
-          jfrog rt upload --user "${{ secrets.JFROG_USER }}" --password "${{ secrets.JFROG_PASSWORD }}" "${{ env.CHART_NAME }}-*.tgz" coralogix-charts --url ${{ env.ARTIFACTORY_URL }}
+          jf rt upload "${{ env.CHART_NAME }}-*.tgz" coralogix-charts


### PR DESCRIPTION
## Problem

The `helm-release` workflow ([run 34371399725](https://github.com/coralogix/coralogix-operator/actions/runs/34371399725/job/102533240946)) fails at the `use-jfrog-cli` step uploading the chart to Artifactory:

```
Server response: 401
Server response: 403 (x3)
Failed uploading 1 artifacts.
```

It authenticated as the `integrations-actions` user via `JFROG_USER` / `JFROG_PASSWORD`. Those credentials were rotated/revoked as part of the JFrog curation rollout (CX-57916), so user/password auth no longer works.

## Fix

Migrate to **GitHub OIDC**, matching what telemetry-shippers did in coralogix/telemetry-shippers#1016 (docker images) and coralogix/telemetry-shippers#1019 (helm charts). `jfrog/setup-jfrog-cli@v4` exchanges this job's OIDC JWT for a short-lived Artifactory token — **no static secret stored in the repo**.

- Add `id-token: write` permission (required for the OIDC exchange).
- Replace `setup-jfrog-cli@v2.1.0` + `jfrog rt upload --user/--password ... --url ...` with `setup-jfrog-cli@v4` (OIDC) + `jf rt upload` against the `JF_URL`-configured server.
- Drop the now-unused `ARTIFACTORY_URL` / `ARTIFACTORY_USERNAME` env.

Simpler than the telemetry-shippers charts because the operator chart has no dependencies — no authenticated `helm repo add` is needed, just `helm package .`.

## Prerequisite

The JFrog-side OIDC setup from CX-57916 uses an **org-wide identity mapping** `{"repository_owner": "coralogix"}`, so `coralogix-operator` should already be covered — no per-repo secret or JFrog change needed. Worth a sanity check with the platform team (#pluto-interface) that the mapping is org-wide and not an allow-list of specific repos.

## Notes

- `upgrade-test.yaml` only does an anonymous `helm repo add` against the public `coralogix-charts-virtual` repo to *pull* charts — no auth, unaffected.
- This is CI-only; nothing to run locally. The JFrog local-package-manager setup guide (identity tokens in Keychain) is explicitly out of scope for CI/CD publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)