### PR TITLE
ci: backport JFrog OIDC auth to release-2.9 (#592)

### DIFF
--- a/.github/workflows/helm-chart-deploy.yml
+++ b/.github/workflows/helm-chart-deploy.yml
@@ -8,16 +8,15 @@ on:
     paths:
       - charts/coralogix-operator/Chart.yaml
 
-# The chart is uploaded to Artifactory with credentials from secrets.*, so the workflow token
-# only ever needs to read the repo.
+# The chart is uploaded to Artifactory using a short-lived token obtained via GitHub OIDC
+# (id-token: write). contents: read is all the workflow token itself needs.
 permissions:
   contents: read
+  id-token: write # OIDC token for the JFrog exchange
 
 env:
   CHART_VERSION: $(yq eval '.version' charts/coralogix-operator/Chart.yaml)
   CHART_NAME: coralogix-operator
-  ARTIFACTORY_URL: https://cgx.jfrog.io/artifactory/
-  ARTIFACTORY_USERNAME: integrations-actions
 
 jobs:
   build:
@@ -25,15 +24,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.4.0
+      - name: Set up JFrog CLI
+        # Exchanges this job's GitHub OIDC JWT for a short-lived Artifactory token,
+        # replacing the rotated JFROG_USER / JFROG_PASSWORD secret pair. The action
+        # calls core.setSecret() on its outputs, so the token stays masked in the log.
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://cgx.jfrog.io
+        with:
+          oidc-provider-name: github
+          oidc-audience: jfrog-github
       - name: Setup Helm Repo
         run: |
           cd charts/coralogix-operator
           helm package .
-      - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v2.1.0
-        with:
-          version: 2.12.1
       - name: use-jfrog-cli
         run: |
           cd charts/coralogix-operator
-          jfrog rt upload --user "${{ secrets.JFROG_USER }}" --password "${{ secrets.JFROG_PASSWORD }}" "${{ env.CHART_NAME }}-*.tgz" coralogix-charts --url ${{ env.ARTIFACTORY_URL }}
+          jf rt upload "${{ env.CHART_NAME }}-*.tgz" coralogix-charts


### PR DESCRIPTION
## What

Cherry-pick of #592 (commit 975918c) onto `release-2.9`.

## Why

The `helm-release` workflow runs **only on `release-*` branches**, so the fix on `main` doesn't help the 2.9.0 chart release — re-running [the failed run](https://github.com/coralogix/coralogix-operator/actions/runs/34371399725) replays `release-2.9`'s old workflow, which still uses `JFROG_USER` / `JFROG_PASSWORD`. Those were rotated/revoked under CX-57916, so the upload returns 401/403.

This backport puts the GitHub OIDC auth (`jfrog/setup-jfrog-cli@v4` → short-lived token, `jf rt upload`) on `release-2.9` so the 2.9.0 chart can actually publish. No static secret; the org-wide identity mapping (`{"repository_owner": "coralogix"}`) covers this repo.

## After merge

The failed run won't auto-retrigger. Trigger `helm-release` manually against `release-2.9` via `workflow_dispatch` (no Chart.yaml bump needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)